### PR TITLE
Add CRUD operations for Notion integration

### DIFF
--- a/notion/config.json
+++ b/notion/config.json
@@ -622,6 +622,423 @@
                     }
                 }
             }
+        },
+        "update_notion_block": {
+            "display_name": "Update Block",
+            "description": "Update the content of an existing block",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "block_id": {
+                        "type": "string",
+                        "description": "The unique identifier of the block to update"
+                    },
+                    "paragraph": {
+                        "type": "object",
+                        "description": "Paragraph block content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "heading_1": {
+                        "type": "object",
+                        "description": "Heading 1 block content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "is_toggleable": {
+                                "type": "boolean",
+                                "description": "Whether heading can be toggled"
+                            }
+                        }
+                    },
+                    "heading_2": {
+                        "type": "object",
+                        "description": "Heading 2 block content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "is_toggleable": {
+                                "type": "boolean",
+                                "description": "Whether heading can be toggled"
+                            }
+                        }
+                    },
+                    "heading_3": {
+                        "type": "object",
+                        "description": "Heading 3 block content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "is_toggleable": {
+                                "type": "boolean",
+                                "description": "Whether heading can be toggled"
+                            }
+                        }
+                    },
+                    "bulleted_list_item": {
+                        "type": "object",
+                        "description": "Bulleted list item content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "numbered_list_item": {
+                        "type": "object",
+                        "description": "Numbered list item content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "to_do": {
+                        "type": "object",
+                        "description": "To-do item content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "checked": {
+                                "type": "boolean",
+                                "description": "Whether the to-do item is checked"
+                            }
+                        }
+                    },
+                    "code": {
+                        "type": "object",
+                        "description": "Code block content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "language": {
+                                "type": "string",
+                                "description": "Programming language for syntax highlighting"
+                            }
+                        }
+                    },
+                    "quote": {
+                        "type": "object",
+                        "description": "Quote block content",
+                        "properties": {
+                            "rich_text": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["text"]
+                                        },
+                                        "text": {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "required": ["block_id"]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "object": {
+                        "type": "string",
+                        "description": "Type of object (always 'block')"
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the updated block"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Type of the block"
+                    },
+                    "last_edited_time": {
+                        "type": "string",
+                        "description": "ISO 8601 timestamp when the block was last edited"
+                    }
+                }
+            }
+        },
+        "delete_notion_block": {
+            "display_name": "Delete Block",
+            "description": "Delete (archive) a block by moving it to trash",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "block_id": {
+                        "type": "string",
+                        "description": "The unique identifier of the block to delete"
+                    }
+                },
+                "required": ["block_id"]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "object": {
+                        "type": "string",
+                        "description": "Type of object (always 'block')"
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the deleted block"
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Whether the block is archived (always true after deletion)"
+                    },
+                    "last_edited_time": {
+                        "type": "string",
+                        "description": "ISO 8601 timestamp when the block was deleted"
+                    }
+                }
+            }
+        },
+        "update_notion_page": {
+            "display_name": "Update Page Properties",
+            "description": "Update properties of a page (for database pages)",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "page_id": {
+                        "type": "string",
+                        "description": "The unique identifier of the page to update"
+                    },
+                    "properties": {
+                        "type": "object",
+                        "description": "Page properties to update",
+                        "additionalProperties": true
+                    },
+                    "icon": {
+                        "type": "object",
+                        "description": "Page icon (emoji or external URL)",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["emoji", "external"]
+                            },
+                            "emoji": {
+                                "type": "string",
+                                "description": "Emoji character (if type is emoji)"
+                            },
+                            "external": {
+                                "type": "object",
+                                "description": "External icon URL (if type is external)",
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "URL of the external icon"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "cover": {
+                        "type": "object",
+                        "description": "Page cover image",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["external"]
+                            },
+                            "external": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "URL of the cover image"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Whether to archive/restore the page"
+                    }
+                },
+                "required": ["page_id"]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "object": {
+                        "type": "string",
+                        "description": "Type of object (always 'page')"
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the updated page"
+                    },
+                    "last_edited_time": {
+                        "type": "string",
+                        "description": "ISO 8601 timestamp when the page was last edited"
+                    },
+                    "properties": {
+                        "type": "object",
+                        "description": "Updated page properties"
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Whether the page is archived"
+                    }
+                }
+            }
         }
     }
 }

--- a/notion/notion.py
+++ b/notion/notion.py
@@ -453,9 +453,9 @@ class NotionUpdateBlockHandler(ActionHandler):
             "table_row", "table", "column", "synced_block", "template"
         }
         
-        # Prepare the update request body (only include valid block type fields)
+        # Prepare the update request body (only include valid block type fields, exclude internal fields)
         update_body = {key: value for key, value in inputs.items() 
-                      if key in valid_block_types and value is not None}
+                      if key in valid_block_types and value is not None and not key.startswith("NOTION_")}
         
         # Prepare headers for Notion API
         headers = {
@@ -531,8 +531,14 @@ class NotionUpdatePageHandler(ActionHandler):
         """
         page_id = inputs["page_id"]
         
-        # Prepare the update request body (exclude page_id from the body)
-        update_body = {key: value for key, value in inputs.items() if key != "page_id"}
+        # Valid page update fields
+        valid_page_fields = {
+            "properties", "icon", "cover", "archived"
+        }
+        
+        # Prepare the update request body (only include valid page fields, exclude internal fields)
+        update_body = {key: value for key, value in inputs.items() 
+                      if key in valid_page_fields and value is not None and not key.startswith("NOTION_")}
         
         # Prepare headers for Notion API
         headers = {

--- a/notion/notion.py
+++ b/notion/notion.py
@@ -424,5 +424,132 @@ class NotionGetPagePropertyHandler(ActionHandler):
             raise Exception(f"Failed to get property {property_id} from page {page_id}: {str(e)}")
 
 
+# ---- New Update/Delete Handlers ----
+
+@notion.action("update_notion_block")
+class NotionUpdateBlockHandler(ActionHandler):
+    """Handler for updating existing blocks"""
+    
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> Dict[str, Any]:
+        """
+        Update the content of an existing block
+        
+        Args:
+            inputs: Dictionary containing 'block_id' and block content (paragraph, heading_1, etc.)
+            context: Execution context with auth and network capabilities
+            
+        Returns:
+            Dictionary containing updated block from Notion API
+        """
+        block_id = inputs["block_id"]
+        
+        # Valid block types that can be updated
+        valid_block_types = {
+            "paragraph", "heading_1", "heading_2", "heading_3",
+            "bulleted_list_item", "numbered_list_item", "to_do", 
+            "code", "quote", "callout", "toggle", "embed", "bookmark",
+            "image", "video", "pdf", "file", "audio", "equation",
+            "divider", "breadcrumb", "table_of_contents", "link_to_page",
+            "table_row", "table", "column", "synced_block", "template"
+        }
+        
+        # Prepare the update request body (only include valid block type fields)
+        update_body = {key: value for key, value in inputs.items() 
+                      if key in valid_block_types and value is not None}
+        
+        # Prepare headers for Notion API
+        headers = {
+            "Notion-Version": "2022-06-28",
+            "Content-Type": "application/json"
+        }
+        
+        # Make the update block request to Notion API
+        try:
+            response = await context.fetch(
+                url=f"https://api.notion.com/v1/blocks/{block_id}",
+                method="PATCH",
+                headers=headers,
+                json=update_body
+            )
+            
+            return response
+            
+        except Exception as e:
+            raise Exception(f"Failed to update block {block_id}: {str(e)}")
 
 
+@notion.action("delete_notion_block")
+class NotionDeleteBlockHandler(ActionHandler):
+    """Handler for deleting (archiving) blocks"""
+    
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> Dict[str, Any]:
+        """
+        Delete (archive) a block by moving it to trash
+        
+        Args:
+            inputs: Dictionary containing 'block_id'
+            context: Execution context with auth and network capabilities
+            
+        Returns:
+            Dictionary containing deleted block from Notion API
+        """
+        block_id = inputs["block_id"]
+        
+        # Prepare headers for Notion API
+        headers = {
+            "Notion-Version": "2022-06-28"
+        }
+        
+        # Make the delete block request to Notion API
+        try:
+            response = await context.fetch(
+                url=f"https://api.notion.com/v1/blocks/{block_id}",
+                method="DELETE",
+                headers=headers
+            )
+            
+            return response
+            
+        except Exception as e:
+            raise Exception(f"Failed to delete block {block_id}: {str(e)}")
+
+
+@notion.action("update_notion_page")
+class NotionUpdatePageHandler(ActionHandler):
+    """Handler for updating page properties"""
+    
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> Dict[str, Any]:
+        """
+        Update properties of a page (for database pages)
+        
+        Args:
+            inputs: Dictionary containing 'page_id' and optional 'properties', 'icon', 'cover', 'archived'
+            context: Execution context with auth and network capabilities
+            
+        Returns:
+            Dictionary containing updated page from Notion API
+        """
+        page_id = inputs["page_id"]
+        
+        # Prepare the update request body (exclude page_id from the body)
+        update_body = {key: value for key, value in inputs.items() if key != "page_id"}
+        
+        # Prepare headers for Notion API
+        headers = {
+            "Notion-Version": "2022-06-28",
+            "Content-Type": "application/json"
+        }
+        
+        # Make the update page request to Notion API
+        try:
+            response = await context.fetch(
+                url=f"https://api.notion.com/v1/pages/{page_id}",
+                method="PATCH",
+                headers=headers,
+                json=update_body
+            )
+            
+            return response
+            
+        except Exception as e:
+            raise Exception(f"Failed to update page {page_id}: {str(e)}")

--- a/notion/test_integration.py
+++ b/notion/test_integration.py
@@ -1,0 +1,87 @@
+import asyncio
+import json
+from typing import Dict, Any
+from notion import notion
+
+async def test_integration_config():
+    """Test that the integration configuration is valid"""
+    
+    # Test that all actions defined in config.json have corresponding handlers
+    with open("config.json", "r") as f:
+        config = json.load(f)
+    
+    defined_actions = set(config.get("actions", {}).keys())
+    
+    # Get all registered action handlers from the integration
+    registered_actions = set(notion._actions.keys()) if hasattr(notion, '_actions') else set()
+    
+    print(f"Actions defined in config.json: {defined_actions}")
+    print(f"Actions registered in handlers: {registered_actions}")
+    
+    missing_handlers = defined_actions - registered_actions
+    extra_handlers = registered_actions - defined_actions
+    
+    if missing_handlers:
+        print(f"❌ Missing handlers for actions: {missing_handlers}")
+    
+    if extra_handlers:
+        print(f"⚠️  Extra handlers without config: {extra_handlers}")
+    
+    if not missing_handlers and not extra_handlers:
+        print("✅ All actions have matching handlers!")
+        return True
+    
+    return False
+
+async def test_new_actions():
+    """Test that the new update/delete actions are properly configured"""
+    
+    new_actions = ["update_notion_block", "delete_notion_block", "update_notion_page"]
+    
+    with open("config.json", "r") as f:
+        config = json.load(f)
+    
+    actions = config.get("actions", {})
+    
+    for action in new_actions:
+        if action in actions:
+            print(f"✅ {action} is defined in config.json")
+            
+            # Check required fields
+            action_config = actions[action]
+            if "display_name" in action_config and "description" in action_config:
+                print(f"   - Has display_name: {action_config['display_name']}")
+                print(f"   - Has description: {action_config['description']}")
+            else:
+                print(f"   ❌ Missing display_name or description")
+                
+            if "input_schema" in action_config and "output_schema" in action_config:
+                print(f"   - Has input and output schemas")
+            else:
+                print(f"   ❌ Missing input or output schema")
+        else:
+            print(f"❌ {action} is NOT defined in config.json")
+
+async def main():
+    """Run all tests"""
+    print("=== Testing Notion Integration Enhancement ===\n")
+    
+    print("1. Testing integration configuration...")
+    config_valid = await test_integration_config()
+    print()
+    
+    print("2. Testing new action configurations...")
+    await test_new_actions()
+    print()
+    
+    if config_valid:
+        print("🎉 Integration enhancement completed successfully!")
+        print("\nNew capabilities added:")
+        print("- update_notion_block: Update content of existing blocks")
+        print("- delete_notion_block: Delete (archive) blocks")
+        print("- update_notion_page: Update page properties, icon, cover, etc.")
+    else:
+        print("❌ Integration has configuration issues that need to be fixed.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/notion/validate_config.py
+++ b/notion/validate_config.py
@@ -1,0 +1,106 @@
+import json
+import re
+import sys
+
+# Set UTF-8 encoding for Windows console
+if sys.platform == "win32":
+    import codecs
+    sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
+
+def validate_config():
+    """Validate the integration configuration"""
+    
+    print("=== Validating Notion Integration Enhancement ===\n")
+    
+    # Load config
+    try:
+        with open("config.json", "r") as f:
+            config = json.load(f)
+        print("✅ config.json loaded successfully")
+    except Exception as e:
+        print(f"❌ Failed to load config.json: {e}")
+        return False
+    
+    # Check required fields
+    required_fields = ["name", "version", "description", "entry_point", "auth", "actions"]
+    for field in required_fields:
+        if field in config:
+            print(f"✅ Has required field: {field}")
+        else:
+            print(f"❌ Missing required field: {field}")
+            return False
+    
+    # Check new actions
+    new_actions = ["update_notion_block", "delete_notion_block", "update_notion_page"]
+    actions = config.get("actions", {})
+    
+    print(f"\n=== Checking New Actions ===")
+    for action in new_actions:
+        if action in actions:
+            print(f"✅ {action} is defined")
+            
+            action_config = actions[action]
+            
+            # Check required action fields
+            if "display_name" in action_config:
+                print(f"   ✅ Has display_name: '{action_config['display_name']}'")
+            else:
+                print(f"   ❌ Missing display_name")
+            
+            if "description" in action_config:
+                print(f"   ✅ Has description: '{action_config['description']}'")
+            else:
+                print(f"   ❌ Missing description")
+            
+            if "input_schema" in action_config and "output_schema" in action_config:
+                print(f"   ✅ Has input and output schemas")
+                
+                # Check input schema has required fields
+                input_schema = action_config["input_schema"]
+                if "properties" in input_schema and "required" in input_schema:
+                    required_props = input_schema["required"]
+                    if action in ["update_notion_block", "delete_notion_block", "update_notion_page"]:
+                        expected_id_field = "page_id" if action == "update_notion_page" else "block_id"
+                        if expected_id_field in required_props:
+                            print(f"   ✅ Has required {expected_id_field} field")
+                        else:
+                            print(f"   ❌ Missing required {expected_id_field} field")
+            else:
+                print(f"   ❌ Missing input or output schema")
+        else:
+            print(f"❌ {action} is NOT defined in config.json")
+    
+    # Check Python file for handlers
+    print(f"\n=== Checking Python Handlers ===")
+    try:
+        with open("notion.py", "r") as f:
+            python_content = f.read()
+        
+        for action in new_actions:
+            # Look for the decorator pattern
+            decorator_pattern = f'@notion.action\\("{action}"\\)'
+            if re.search(decorator_pattern, python_content):
+                print(f"✅ Handler for {action} found in notion.py")
+            else:
+                print(f"❌ Handler for {action} NOT found in notion.py")
+                
+    except Exception as e:
+        print(f"❌ Failed to read notion.py: {e}")
+        return False
+    
+    print(f"\n=== Summary ===")
+    print("🎉 Notion integration enhancement completed!")
+    print("\nNew capabilities added:")
+    print("• update_notion_block - Update content of existing blocks (paragraphs, headings, etc.)")
+    print("• delete_notion_block - Delete (archive) blocks by moving to trash") 
+    print("• update_notion_page - Update page properties, icons, covers, and archive status")
+    print("\nYou can now:")
+    print("• Change 'hi' to 'bye' in any paragraph block")
+    print("• Update headings, list items, code blocks, etc.")
+    print("• Delete unwanted blocks")
+    print("• Update page properties and metadata")
+    
+    return True
+
+if __name__ == "__main__":
+    validate_config()


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Add CRUD operations for Notion integration to enable updating and deleting blocks and pages
- **Approach**: Extend the existing Notion integration with three new action handlers that provide comprehensive update and delete functionality for blocks and pages, including robust field validation to prevent API errors

**Type of change**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**
:point_right: Added update_notion_block handler with support for paragraphs, headings, lists, code blocks, quotes, and to-do items
:point_right: Added delete_notion_block handler to archive blocks by moving them to trash
:point_right: Added update_notion_page handler for updating page properties, icons, covers, and archive status

### Screenshots :camera:
{Image here of before and after - if applicable}

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
- Test updating various block types (paragraphs, headings, lists) with the update_notion_block action
- Test deleting blocks using the delete_notion_block action and verify they are archived
- Test updating page properties, icons, and covers with the update_notion_page action
- Verify that internal NOTION_ explanation fields are properly filtered from API requests
- Test error handling for invalid block IDs and malformed requests

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)