### PR TITLE
Fix API URL to adhere to multiple company instances

### DIFF
--- a/gong/gong.py
+++ b/gong/gong.py
@@ -14,7 +14,7 @@ class GongAPIClient:
     
     def __init__(self, context: ExecutionContext):
         self.context = context
-        self.base_url = context.auth.get("credentials", {}).get("api_base_url")
+        self.base_url = context.metadata.get("api_base_url")
         if not self.base_url:
             raise ValueError("api_base_url is required in auth context. This should be provided by Gong's OAuth flow as 'api_base_url_for_customer'.")
     


### PR DESCRIPTION
## Fix API URL to adhere to multiple company instances
 
### Description :memo:
- **Purpose**: Fix Gong API client to use company-specific base URLs instead of hardcoded URL, enabling support for multiple Gong company instances
- **Approach**: Replace hardcoded base URL with dynamic retrieval from auth credentials and add validation to ensure the URL is provided

This work goes hand in hand with the platform changes - https://github.com/Autohive-AI/Autohive/pull/2245

**Type of change**
Bug fix (non-breaking change which fixes an issue)

**Updates**
:point_right: Replace hardcoded `https://us-10552.api.gong.io/v2` with dynamic `api_base_url` from auth credentials
:point_right: Add validation to ensure `api_base_url` is present in auth context during client initialization
:point_right: Provide clear error message referencing Gong's OAuth `api_base_url_for_customer` field

### Screenshots :camera:
N/A

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
- Test Gong integration with valid `api_base_url` in auth credentials to ensure API calls work correctly
- Test initialization without `api_base_url` to verify proper error handling and message
- Verify that different Gong company instances can now be supported with their respective base URLs
- Confirm existing Gong integrations continue to work after the platform provides the base URL

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)
