### PR TITLE
fix(zoho): allow null values for optional contact fields

### DIFF
--- a/zoho/config.json
+++ b/zoho/config.json
@@ -194,15 +194,15 @@
                                 "description": "Full name of the contact"
                             },
                             "Email": {
-                                "type": "string",
+                                "type": ["string", "null"],
                                 "description": "Email address"
                             },
                             "Phone": {
-                                "type": "string",
+                                "type": ["string", "null"],
                                 "description": "Phone number"
                             },
                             "Mobile": {
-                                "type": "string",
+                                "type": ["string", "null"],
                                 "description": "Mobile number"
                             },
                             "Account_Name": {
@@ -488,11 +488,11 @@
                                     "description": "Full name"
                                 },
                                 "Email": {
-                                    "type": "string",
+                                    "type": ["string", "null"],
                                     "description": "Email address"
                                 },
                                 "Phone": {
-                                    "type": "string",
+                                    "type": ["string", "null"],
                                     "description": "Phone number"
                                 },
                                 "Account_Name": {
@@ -656,11 +656,11 @@
                                     "description": "First name"
                                 },
                                 "Email": {
-                                    "type": "string",
+                                    "type": ["string", "null"],
                                     "description": "Email address"
                                 },
                                 "Phone": {
-                                    "type": "string",
+                                    "type": ["string", "null"],
                                     "description": "Phone number"
                                 }
                             }
@@ -904,11 +904,11 @@
                                 "description": "Annual revenue"
                             },
                             "Phone": {
-                                "type": "string",
+                                "type": ["string", "null"],
                                 "description": "Phone number"
                             },
                             "Website": {
-                                "type": "string",
+                                "type": ["string", "null"],
                                 "description": "Website URL"
                             },
                             "Owner": {


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Fix nullable contact field validation in Zoho integration by allowing null values for optional contact fields
- **Approach**: Updated the JSON schema configuration to accept both string and null types for Email, Phone, Mobile, and Website fields across all relevant contact schemas

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**
:point_right: Updated Email, Phone, Mobile, and Website fields to accept `["string", "null"]` types in contact schemas
:point_right: Applied changes across multiple schema sections including contacts, leads, and accounts
:point_right: Fixed validation errors when these optional fields contain null values from Zoho API responses

### Screenshots :camera:
{Image here of before and after - if applicable}

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
- Test contact creation/update operations with null values in Email, Phone, Mobile, and Website fields
- Verify that existing contacts with populated values continue to work correctly
- Test API responses from Zoho that include null values for these optional fields
- Confirm schema validation passes for both string and null values

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)