### PR TITLE
chore(config): add chat.memberships.readonly scope to Google Chat config

### DIFF
--- a/google-chat/config.json
+++ b/google-chat/config.json
@@ -10,7 +10,8 @@
         "scopes": [
             "https://www.googleapis.com/auth/chat.messages",
             "https://www.googleapis.com/auth/chat.spaces",
-            "https://www.googleapis.com/auth/chat.messages.reactions"
+            "https://www.googleapis.com/auth/chat.messages.reactions",
+            "https://www.googleapis.com/auth/chat.memberships.readonly"
         ]
     },
     "actions": {


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Add readonly access to Google Chat memberships to enable retrieving membership information for chat spaces
- **Approach**: Added the `https://www.googleapis.com/auth/chat.memberships.readonly` OAuth scope to the Google Chat integration configuration

**Type of change**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**
:point_right: Added `chat.memberships.readonly` OAuth scope to Google Chat config.json
:point_right: Enables read-only access to chat space membership information
:point_right: Maintains existing OAuth scopes while extending permissions

### Screenshots :camera:
{Image here of before and after - if applicable}

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
- Verify OAuth configuration accepts the new scope
- Test that existing Google Chat functionality remains unaffected
- Confirm membership data can be retrieved when scope is granted

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)