### PR TITLE
fix: include 'id' in update body for Google Tasks API

### DIFF
--- a/google-tasks/google_tasks.py
+++ b/google-tasks/google_tasks.py
@@ -179,7 +179,9 @@ class UpdateTaskAction(ActionHandler):
             task_id = inputs['task']
 
             # Build update body with only provided fields
-            body = {}
+            # NOTE: Google Tasks API requires 'id' in the body even though it's in the URL
+            body = {'id': task_id}
+
             if 'title' in inputs and inputs['title']:
                 body['title'] = inputs['title']
             if 'notes' in inputs and inputs['notes']:


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Fix Google Tasks API update functionality by including required 'id' field in request body
- **Approach**: Add the task ID to the update body as required by the Google Tasks API specification, even though it's already present in the URL

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**
:point_right: Added 'id' field to update body in Google Tasks API calls
:point_right: Included explanatory comment about API requirement
:point_right: Fixed task update functionality that was previously failing

### Screenshots :camera:
{Image here of before and after - if applicable}

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
- Test updating a Google Task with new title and/or notes
- Verify the API call succeeds and the task is properly updated
- Confirm no regression in other Google Tasks functionality

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)