### PR TITLE
refactor(google-docs): enhance docs_insert_markdown_content to parse all heading levels and inline formatting

### DIFF
--- a/google-docs/README.md
+++ b/google-docs/README.md
@@ -9,7 +9,7 @@ This integration provides comprehensive access to Google Docs functionality thro
 - Create new Google Docs documents
 - Retrieve full document content and structure
 - Insert plain text paragraphs
-- Insert markdown-formatted content with automatic heading styling
+- Insert markdown-formatted content with automatic styling (headings, bold, italic)
 - Apply text formatting (bold, italic, font size, colors)
 - Parse document structure to identify headings and paragraphs
 - Execute complex batch update operations
@@ -71,18 +71,22 @@ This integration uses OAuth2 authentication via the Autohive platform. The requi
 
 ### Action: `docs_insert_markdown_content`
 
-*   **Description:** Insert markdown-formatted content with automatic heading detection and styling. Requires markdown format with headings (# for H1, ## for H2). For plain paragraphs, use `docs_insert_paragraphs` instead.
+*   **Description:** Insert markdown-formatted content with automatic styling. Detects ALL heading levels (# through ######) and inline formatting (**bold**, *italic*) in a single operation. Automatically applies Google Docs styles (HEADING_1-6, bold, italic) without showing markdown symbols. For plain paragraphs without any formatting, use `docs_insert_paragraphs` instead.
 *   **Inputs:**
     *   `document_id` (required): The ID of the document
-    *   `content` (required): Markdown text with headings (e.g., "# Overview\nParagraph text\n\n## Details\nMore text")
-    *   `heading_level` (optional): Which heading level to parse (default: 1 for #). Use 1 for #, 2 for ##, etc.
+    *   `content` (required): Markdown text with headings and inline formatting (e.g., "# Overview\n**Bold text** and *italic text*\n\n## Details\nMore text")
     *   `tab_id` (optional): Optional tab ID if working with a specific tab
     *   `append` (optional): If true, append to end of document (default: true)
 *   **Outputs:**
     *   `result`: Boolean indicating success
-    *   `sections_inserted`: Number of sections processed
-    *   `total_paragraphs`: Total paragraphs inserted
+    *   `headings_inserted`: Number of headings inserted
+    *   `paragraphs_inserted`: Number of paragraphs inserted
+    *   `total_elements`: Total elements inserted
     *   `error`: Error message if operation failed
+*   **Supported Markdown Features:**
+    *   Headings: `#` through `######` (H1 through H6)
+    *   Bold: `**text**`
+    *   Italic: `*text*`
 
 ### Action: `docs_batch_update`
 
@@ -151,17 +155,16 @@ This integration uses OAuth2 authentication via the Autohive platform. The requi
 **Example 2: Inserting structured content with markdown**
 
 ```json
-// Insert content with automatic heading styling
+// Insert content with automatic styling (all heading levels and inline formatting)
 {
   "action": "docs_insert_markdown_content",
   "inputs": {
     "document_id": "abc123...",
-    "content": "# Overview\n\nThis is the overview section with important details.\n\n# Historical Background\n\nThis section covers the historical context.\n\n# Conclusion\n\nFinal thoughts and summary.",
-    "heading_level": 1,
+    "content": "# Lead Analysis Report\n\n**Prepared for:** Autohive **Date:** October 23, 2025\n\n## 1. Executive Summary\n\nThis is a paragraph with **bold** and *italic* text.\n\n### Key Findings\n\n- Point one with **emphasis**\n- Point two with *italic style*\n\n## 2. Detailed Analysis\n\nFinal paragraph with mixed formatting.",
     "append": true
   }
 }
-// Response: { "result": true, "sections_inserted": 3, "total_paragraphs": 3 }
+// Response: { "result": true, "headings_inserted": 4, "paragraphs_inserted": 3, "total_elements": 7 }
 ```
 
 **Example 3: Applying text formatting with batch update**

--- a/google-docs/config.json
+++ b/google-docs/config.json
@@ -174,7 +174,7 @@
     },
     "docs_insert_markdown_content": {
       "display_name": "Insert Markdown Content",
-      "description": "Insert markdown-formatted content with automatic heading detection and styling. REQUIRES markdown format with headings (# for H1, ## for H2). For plain paragraphs without headings, use docs_insert_paragraphs instead. Automatically applies Google Docs heading styles in a single operation.",
+      "description": "Insert markdown-formatted content with automatic styling. Detects ALL heading levels (# through ######) and inline formatting (**bold**, *italic*) in a single operation. Automatically applies Google Docs styles (HEADING_1-6, bold, italic) without showing markdown symbols. For plain paragraphs without any formatting, use docs_insert_paragraphs instead.",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -184,11 +184,7 @@
           },
           "content": {
             "type": "string",
-            "description": "MARKDOWN text with headings (# for H1, ## for H2, etc.). Example: '# Overview\\nParagraph text\\n\\n## Details\\nMore text'."
-          },
-          "heading_level": {
-            "type": "integer",
-            "description": "Which heading level to parse (default: 1 for #). Use 1 for #, 2 for ##, etc."
+            "description": "MARKDOWN text with headings and inline formatting. Example: '# Overview\\n**Bold text** and *italic text*\\n\\n## Details\\nMore text'. All heading levels (# through ######), **bold**, and *italic* are automatically detected and styled."
           },
           "tab_id": {
             "type": "string",
@@ -205,8 +201,9 @@
         "type": "object",
         "properties": {
           "result": { "type": "boolean" },
-          "sections_inserted": { "type": "integer" },
-          "total_paragraphs": { "type": "integer" },
+          "headings_inserted": { "type": "integer", "description": "Number of headings inserted" },
+          "paragraphs_inserted": { "type": "integer", "description": "Number of paragraphs inserted" },
+          "total_elements": { "type": "integer", "description": "Total elements inserted" },
           "error": { "type": "string" }
         },
         "required": ["result"]

--- a/google-docs/google_docs.py
+++ b/google-docs/google_docs.py
@@ -343,36 +343,32 @@ class ParseStructure(ActionHandler):
 class InsertMarkdownContent(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         """
-        Insert markdown-formatted content with automatic heading detection and styling.
-
-        IMPORTANT: This action requires markdown format with headings (# for H1, ## for H2).
-        For plain paragraphs without headings, use docs_insert_paragraphs instead.
+        Insert markdown-formatted content with automatic styling.
 
         Features:
-        - Parses markdown headings (# H1, ## H2, ### H3, etc.)
-        - Automatically applies Google Docs heading styles (HEADING_1, HEADING_2, etc.)
+        - Parses ALL markdown headings (# H1, ## H2, ### H3, etc.) in a single call
+        - Parses inline formatting: **bold** and *italic*
+        - Automatically applies Google Docs styles (headings, bold, italic)
         - Inserts and styles in a single batch operation
         - No duplicate content
 
         Inputs:
         - document_id: The document ID
-        - content: Markdown text with headings (# Heading, ## Subheading, etc.)
-        - heading_level: Which heading level to parse (default: 1 for #)
+        - content: Markdown text with headings and inline formatting
         - tab_id: Optional tab ID if working with a specific tab
         - append: If true, append to end of document (default: True)
         """
         try:
             document_id = inputs['document_id']
             content = inputs['content']
-            heading_level = inputs.get('heading_level', 1)
             tab_id = inputs.get('tab_id')
             append = inputs.get('append', True)
 
-            # Step 1: Parse content into sections
-            sections = self._parse_sections(content, heading_level)
+            # Step 1: Parse content into structured elements
+            elements = self._parse_markdown(content)
 
-            if not sections:
-                return {'result': False, 'error': 'No sections found in content'}
+            if not elements:
+                return {'result': False, 'error': 'No content found to insert'}
 
             # Step 2: Get the insertion index
             insertion_index = await self._get_insertion_index(
@@ -380,8 +376,8 @@ class InsertMarkdownContent(ActionHandler):
             )
 
             # Step 3: Insert all content with styles in a single batch operation
-            result = await self._insert_and_style_sections(
-                context, document_id, tab_id, sections, insertion_index, heading_level
+            result = await self._insert_and_style_content(
+                context, document_id, tab_id, elements, insertion_index
             )
 
             return result
@@ -389,56 +385,131 @@ class InsertMarkdownContent(ActionHandler):
         except Exception as e:
             return handle_api_error(e, "Failed to insert markdown content")
 
-    def _parse_sections(self, content: str, heading_level: int) -> List[Dict[str, Any]]:
-        """Parse content into sections based on heading level."""
-        sections = []
-        heading_marker = '#' * heading_level + ' '
+    def _parse_markdown(self, content: str) -> List[Dict[str, Any]]:
+        """
+        Parse markdown content into structured elements with heading levels and inline formatting.
 
+        Returns a list of elements, each with:
+        - type: 'heading' or 'paragraph'
+        - text: plain text (without markdown symbols)
+        - level: heading level (1-6) if type is 'heading'
+        - formatting: list of {type, start, end} for inline formatting
+        """
+        import re
+
+        elements = []
         lines = content.split('\n')
-        current_heading = None
-        current_paragraphs = []
-        current_buffer = []
+        i = 0
 
-        for line in lines:
+        while i < len(lines):
+            line = lines[i]
             stripped = line.strip()
 
-            # Check if it's a heading at the target level
-            if stripped.startswith(heading_marker):
-                # Save previous section
-                if current_heading is not None:
-                    if current_buffer:
-                        # Join lines with space to preserve word boundaries
-                        current_paragraphs.append(' '.join(current_buffer).strip())
-                    sections.append({
-                        'heading': current_heading,
-                        'paragraphs': [p for p in current_paragraphs if p]
+            # Skip empty lines
+            if not stripped:
+                i += 1
+                continue
+
+            # Check for headings (# to ######)
+            heading_match = re.match(r'^(#{1,6})\s+(.+)$', stripped)
+            if heading_match:
+                level = len(heading_match.group(1))
+                heading_text = heading_match.group(2)
+
+                # Parse inline formatting in heading
+                plain_text, formatting = self._parse_inline_formatting(heading_text)
+
+                elements.append({
+                    'type': 'heading',
+                    'level': level,
+                    'text': plain_text,
+                    'formatting': formatting
+                })
+                i += 1
+                continue
+
+            # Otherwise, it's a paragraph - collect until empty line
+            para_lines = []
+            while i < len(lines) and lines[i].strip():
+                para_lines.append(lines[i].strip())
+                i += 1
+
+            if para_lines:
+                para_text = ' '.join(para_lines)
+                plain_text, formatting = self._parse_inline_formatting(para_text)
+
+                elements.append({
+                    'type': 'paragraph',
+                    'text': plain_text,
+                    'formatting': formatting
+                })
+
+        return elements
+
+    def _parse_inline_formatting(self, text: str) -> tuple:
+        """
+        Parse inline formatting (bold, italic) from markdown text.
+
+        Returns:
+        - plain_text: text without markdown symbols
+        - formatting: list of {type: 'bold'/'italic', start: int, end: int}
+        """
+        import re
+
+        formatting = []
+        plain_text = ""
+        offset = 0  # Track position in plain text
+
+        # Process text character by character to handle nested/overlapping formatting
+        i = 0
+        while i < len(text):
+            # Check for bold (**text**)
+            if i + 1 < len(text) and text[i:i+2] == '**':
+                # Find closing **
+                end = text.find('**', i + 2)
+                if end != -1:
+                    bold_text = text[i+2:end]
+                    start_pos = offset
+                    plain_text += bold_text
+                    end_pos = offset + len(bold_text)
+                    formatting.append({
+                        'type': 'bold',
+                        'start': start_pos,
+                        'end': end_pos
                     })
+                    offset += len(bold_text)
+                    i = end + 2
+                    continue
 
-                # Start new section
-                current_heading = stripped[len(heading_marker):].strip()
-                current_paragraphs = []
-                current_buffer = []
+            # Check for italic (*text*) - but not part of **
+            if text[i] == '*' and (i == 0 or text[i-1] != '*') and (i + 1 >= len(text) or text[i+1] != '*'):
+                # Find closing *
+                end = i + 1
+                while end < len(text):
+                    if text[end] == '*' and (end + 1 >= len(text) or text[end+1] != '*'):
+                        break
+                    end += 1
 
-            # Check for paragraph breaks (empty lines separate paragraphs)
-            elif not stripped:
-                if current_buffer:
-                    # Join lines with space to preserve word boundaries
-                    current_paragraphs.append(' '.join(current_buffer).strip())
-                    current_buffer = []
-            else:
-                current_buffer.append(line)
+                if end < len(text):
+                    italic_text = text[i+1:end]
+                    start_pos = offset
+                    plain_text += italic_text
+                    end_pos = offset + len(italic_text)
+                    formatting.append({
+                        'type': 'italic',
+                        'start': start_pos,
+                        'end': end_pos
+                    })
+                    offset += len(italic_text)
+                    i = end + 1
+                    continue
 
-        # Save last section
-        if current_heading is not None:
-            if current_buffer:
-                # Join lines with space to preserve word boundaries
-                current_paragraphs.append(' '.join(current_buffer).strip())
-            sections.append({
-                'heading': current_heading,
-                'paragraphs': [p for p in current_paragraphs if p]
-            })
+            # Regular character
+            plain_text += text[i]
+            offset += 1
+            i += 1
 
-        return sections
+        return plain_text, formatting
 
     async def _get_insertion_index(self, context: ExecutionContext,
                                    document_id: str, tab_id: Optional[str],
@@ -475,14 +546,12 @@ class InsertMarkdownContent(ActionHandler):
             content = body.get('content', [])
             return content[-1].get('endIndex', 1) - 1 if content else 1
 
-    async def _insert_and_style_sections(self, context: ExecutionContext,
-                                         document_id: str, tab_id: Optional[str],
-                                         sections: List[Dict[str, Any]],
-                                         start_index: int,
-                                         heading_level: int) -> Dict[str, Any]:
+    async def _insert_and_style_content(self, context: ExecutionContext,
+                                        document_id: str, tab_id: Optional[str],
+                                        elements: List[Dict[str, Any]],
+                                        start_index: int) -> Dict[str, Any]:
         """
-        Insert all sections with content and apply styles in a single batch operation.
-        This prevents duplicate content by doing everything in one go.
+        Insert all content and apply styles in a single batch operation.
         """
         try:
             batch_requests = []
@@ -497,58 +566,89 @@ class InsertMarkdownContent(ActionHandler):
                 5: 'HEADING_5',
                 6: 'HEADING_6'
             }
-            heading_style = heading_style_map.get(heading_level, 'HEADING_1')
+
+            heading_count = 0
+            paragraph_count = 0
 
             # Build all insertion and styling requests
-            for section in sections:
-                heading = section['heading']
-                paragraphs = section['paragraphs']
+            for element in elements:
+                element_type = element['type']
+                text = element['text']
+                formatting = element.get('formatting', [])
 
-                # Insert heading text
-                heading_text = heading + '\n'
-                heading_insert = {
+                # Add newline for proper spacing
+                if element_type == 'heading':
+                    full_text = text + '\n'
+                else:
+                    full_text = text + '\n\n'
+
+                # Insert text
+                insert_request = {
                     'insertText': {
-                        'text': heading_text,
+                        'text': full_text,
                         'location': {'index': current_index}
                     }
                 }
                 if tab_id:
-                    heading_insert['insertText']['location']['tabId'] = tab_id
-                batch_requests.append(heading_insert)
+                    insert_request['insertText']['location']['tabId'] = tab_id
+                batch_requests.append(insert_request)
 
-                # Apply heading style
-                heading_style_request = {
-                    'updateParagraphStyle': {
-                        'range': {
-                            'startIndex': current_index,
-                            'endIndex': current_index + len(heading_text)
-                        },
-                        'paragraphStyle': {
-                            'namedStyleType': heading_style
-                        },
-                        'fields': 'namedStyleType'
-                    }
-                }
-                if tab_id:
-                    heading_style_request['updateParagraphStyle']['range']['tabId'] = tab_id
-                batch_requests.append(heading_style_request)
+                # Apply paragraph-level style for headings
+                if element_type == 'heading':
+                    level = element['level']
+                    heading_style = heading_style_map.get(level, 'HEADING_1')
 
-                current_index += len(heading_text)
-
-                # Insert paragraphs
-                for paragraph in paragraphs:
-                    para_text = paragraph + '\n\n'
-                    para_insert = {
-                        'insertText': {
-                            'text': para_text,
-                            'location': {'index': current_index}
+                    style_request = {
+                        'updateParagraphStyle': {
+                            'range': {
+                                'startIndex': current_index,
+                                'endIndex': current_index + len(full_text)
+                            },
+                            'paragraphStyle': {
+                                'namedStyleType': heading_style
+                            },
+                            'fields': 'namedStyleType'
                         }
                     }
                     if tab_id:
-                        para_insert['insertText']['location']['tabId'] = tab_id
-                    batch_requests.append(para_insert)
+                        style_request['updateParagraphStyle']['range']['tabId'] = tab_id
+                    batch_requests.append(style_request)
+                    heading_count += 1
+                else:
+                    paragraph_count += 1
 
-                    current_index += len(para_text)
+                # Apply inline formatting (bold, italic)
+                for fmt in formatting:
+                    fmt_type = fmt['type']
+                    fmt_start = current_index + fmt['start']
+                    fmt_end = current_index + fmt['end']
+
+                    text_style = {}
+                    fields = []
+
+                    if fmt_type == 'bold':
+                        text_style['bold'] = True
+                        fields.append('bold')
+                    elif fmt_type == 'italic':
+                        text_style['italic'] = True
+                        fields.append('italic')
+
+                    if text_style:
+                        style_request = {
+                            'updateTextStyle': {
+                                'range': {
+                                    'startIndex': fmt_start,
+                                    'endIndex': fmt_end
+                                },
+                                'textStyle': text_style,
+                                'fields': ','.join(fields)
+                            }
+                        }
+                        if tab_id:
+                            style_request['updateTextStyle']['range']['tabId'] = tab_id
+                        batch_requests.append(style_request)
+
+                current_index += len(full_text)
 
             # Execute all insertions and styling in a single batch
             url = f"{DOCS_API_BASE}/documents/{document_id}:batchUpdate"
@@ -558,10 +658,11 @@ class InsertMarkdownContent(ActionHandler):
 
             return {
                 'result': True,
-                'sections_inserted': len(sections),
-                'total_paragraphs': sum(len(s['paragraphs']) for s in sections)
+                'headings_inserted': heading_count,
+                'paragraphs_inserted': paragraph_count,
+                'total_elements': len(elements)
             }
 
         except Exception as e:
-            return handle_api_error(e, "Failed to insert and style sections")
+            return handle_api_error(e, "Failed to insert and style content")
 

--- a/google-docs/tests/test_google-docs.py
+++ b/google-docs/tests/test_google-docs.py
@@ -71,17 +71,34 @@ async def test_insert_paragraphs():
 
 
 async def test_insert_markdown_content():
-    """Test inserting markdown content with automatic heading styling."""
+    """Test inserting markdown content with automatic styling (all heading levels and inline formatting)."""
     auth = {
         "credentials": {
             "access_token": "test_access_token"
         }
     }
 
+    # Test content with multiple heading levels and inline formatting
+    markdown_content = """# Main Heading
+
+This is a paragraph with **bold text** and *italic text*.
+
+## Subheading Level 2
+
+Another paragraph with **important** information.
+
+### Subheading Level 3
+
+- This has **bold** and *italic* inline formatting
+- Multiple formatting in one paragraph
+
+## Another Section
+
+Final paragraph with mixed **bold** and *italic* styles."""
+
     inputs = {
         "document_id": "test_document_id",
-        "content": "# Overview\n\nThis is the overview section.\n\n# Details\n\nThis section has more details.",
-        "heading_level": 1,
+        "content": markdown_content,
         "append": True
     }
 
@@ -89,6 +106,9 @@ async def test_insert_markdown_content():
         try:
             result = await google_docs.execute_action("docs_insert_markdown_content", inputs, context)
             print(f"Insert Markdown Content Result: {result}")
+            print(f"  - Headings inserted: {result.get('headings_inserted', 0)}")
+            print(f"  - Paragraphs inserted: {result.get('paragraphs_inserted', 0)}")
+            print(f"  - Total elements: {result.get('total_elements', 0)}")
         except Exception as e:
             print(f"Error testing docs_insert_markdown_content: {e}")
 


### PR DESCRIPTION
This commit implements update to docs_insert_markdown_content action to automatically detect and style all heading levels (# through ######) and inline formatting (**bold**, *italic*) in a single operation.