### PR TITLE
Refactor Zoho integration to use region-specific API domains and standardize ActionResult

### DIFF
--- a/zoho/config.json
+++ b/zoho/config.json
@@ -496,7 +496,7 @@
                                     "description": "Phone number"
                                 },
                                 "Account_Name": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "description": "Associated account"
                                 },
                                 "Created_Time": {


### PR DESCRIPTION
## Refactor Zoho integration to use region-specific API domains and standardize ActionResult

### Description

**Purpose**: Refactors the Zoho CRM integration to support region-specific API domains and standardizes return types across all action handlers.

**Approach**: This PR introduces dynamic API domain resolution from credentials and updates all action handlers to consistently return ActionResult instances.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**

:point_right: Modified `get_zoho_api_url()` to accept ExecutionContext and dynamically construct API URLs using the `api_domain` credential (supporting US, EU, AU datacenters)

:point_right: Updated all ActionHandler classes to return `ActionResult` instances instead of plain dictionaries for consistency with SDK patterns

:point_right: Replaced unittest-based mock tests with integration-style async tests that demonstrate real API usage patterns with placeholder credentials

### Test plan

- Verify API calls correctly route to region-specific endpoints (com, eu, com.au) based on configured `api_domain` credential
- Test existing Zoho actions continue to function with the new ActionResult return format
- Run integration tests with valid Zoho credentials to validate end-to-end flows

### Author(s) to check

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)