### PR TITLE
 chore: rebrand Microsoft 365 to Microsoft Copilot 365

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Supports basic HTTP authentication and Bearer token authentication via the SDK.
 
 [google-business-profile](google-business-profile): Connects to Google My Business API for comprehensive business profile and review management. Supports listing business accounts and locations, reading customer reviews with ratings and comments, replying to customer reviews professionally, and managing review interactions. Features secure OAuth2 authentication with Google Maps Reviews provider and comprehensive error handling for reputation management workflows.
 
-### Microsoft 365
+### Microsoft Copilot 365
 
-[microsoft365](microsoft365): Comprehensive integration with Microsoft 365 services including Outlook, OneDrive, Calendar, and SharePoint through Microsoft Graph API. Supports email management (send, draft, reply, forward, search with attachments), calendar operations (create, update, list events with date filtering), OneDrive file operations (search, read with PDF conversion), SharePoint site and document library access (search sites, list libraries, search documents across all drives, read files), and contact management. Features multi-drive SharePoint support, automatic PDF conversion for Office documents, timezone-aware calendar queries, null-safe field handling, and OAuth2 authentication with enterprise-grade permissions including Sites.Read.All for organizational knowledge base access.
+[Microsoft Copilot 365](microsoft365): Comprehensive integration with Microsoft Copilot 365 services including Outlook, OneDrive, Calendar, and SharePoint through Microsoft Graph API. Supports email management (send, draft, reply, forward, search with attachments), calendar operations (create, update, list events with date filtering), OneDrive file operations (search, read with PDF conversion), SharePoint site and document library access (search sites, list libraries, search documents across all drives, read files), and contact management. Features multi-drive SharePoint support, automatic PDF conversion for Office documents, timezone-aware calendar queries, null-safe field handling, and OAuth2 authentication with enterprise-grade permissions including Sites.Read.All for organizational knowledge base access.
 
 ### Microsoft Planner
 

--- a/microsoft365/README.md
+++ b/microsoft365/README.md
@@ -1,10 +1,10 @@
-# Microsoft 365 Integration for Autohive
+# Microsoft Copilot 365 Integration for Autohive
 
-Connects Autohive to Microsoft 365 services including Outlook, OneDrive, Calendar, and SharePoint through the Microsoft Graph API.
+Connects Autohive to Microsoft Copilot 365 services including Outlook, OneDrive, Calendar, and SharePoint through the Microsoft Graph API.
 
 ## Description
 
-This integration provides comprehensive access to Microsoft 365 services, enabling users to manage emails, calendar events, contacts, files, and SharePoint sites through a unified interface. It interacts with the Microsoft Graph API to deliver seamless integration with Outlook email, OneDrive file storage, Calendar management, and SharePoint collaboration.
+This integration provides comprehensive access to Microsoft Copilot 365 services, enabling users to manage emails, calendar events, contacts, files, and SharePoint sites through a unified interface. It interacts with the Microsoft Graph API to deliver seamless integration with Outlook email, OneDrive file storage, Calendar management, and SharePoint collaboration.
 
 Key capabilities include sending and managing emails, creating and updating calendar events, uploading and accessing files, reading contact information, and accessing SharePoint sites and document libraries. The integration supports advanced features like HTML email content, file attachments, timezone-aware operations, folder management, PDF conversion for Office documents, and multi-drive SharePoint document access.
 
@@ -24,7 +24,7 @@ Required Microsoft Graph API permissions:
 
 **Authentication Fields:**
 
-The integration uses platform-level OAuth2 authentication, so no manual configuration of authentication fields is required. Users simply need to authorize their Microsoft 365 account through the Autohive platform.
+The integration uses platform-level OAuth2 authentication, so no manual configuration of authentication fields is required. Users simply need to authorize their Microsoft Copilot 365 account through the Autohive platform.
 
 ## Actions
 
@@ -419,7 +419,7 @@ The integration uses platform-level OAuth2 authentication, so no manual configur
 {
   "to": "recipient@example.com",
   "subject": "Hello from Autohive",
-  "body": "This is a test email sent via Microsoft 365 integration",
+  "body": "This is a test email sent via Microsoft Copilot 365 integration",
   "body_type": "Text"
 }
 ```
@@ -567,4 +567,4 @@ To run the tests:
 2.  Install dependencies: `pip install -r requirements.txt -t dependencies`
 3.  Run the tests: `python tests/test_microsoft365_integration.py`
 
-Note: Testing requires proper Microsoft 365 authentication credentials and may require mock data for certain test scenarios.
+Note: Testing requires proper Microsoft Copilot 365 authentication credentials and may require mock data for certain test scenarios.

--- a/microsoft365/__init__.py
+++ b/microsoft365/__init__.py
@@ -1,1 +1,1 @@
-# Microsoft 365 Integration for Autohive
+# Microsoft Copilot 365 Integration for Autohive

--- a/microsoft365/config.json
+++ b/microsoft365/config.json
@@ -1,7 +1,7 @@
 {
-    "name": "Microsoft 365",
+    "name": "Microsoft Copilot 365",
     "version": "1.0.0",
-    "description": "Microsoft 365 integration for Outlook, OneDrive, and Calendar",
+    "description": "Microsoft Copilot 365 integration for Outlook, OneDrive, and Calendar",
     "entry_point": "microsoft365.py",
     "auth": {
         "type": "platform",

--- a/microsoft365/tests/__init__.py
+++ b/microsoft365/tests/__init__.py
@@ -1,1 +1,1 @@
-# Tests for Microsoft 365 integration
+# Tests for Microsoft Copilot 365 integration


### PR DESCRIPTION
 This commit updates integration display name and documentation to reflect Microsoft's new branding while maintaining technical compatibility.