### PR TITLE
Remove unused contacts.write scope from Dropbox integration

### DIFF
--- a/dropbox/README.md
+++ b/dropbox/README.md
@@ -19,7 +19,7 @@ The integration uses OAuth 2.0 with the following scopes:
 - `files.metadata.read` - Read file and folder metadata
 - `files.content.read` - Read file content and download files
 - `files.content.write` - Upload, create, delete, move, and copy files/folders
-- `contacts.write` - Write access for sharing operations
+
 
 ### Setup Steps in Autohive
 
@@ -301,7 +301,7 @@ To test the integration:
 - **files.metadata.read**: Allows listing folders and reading file/folder metadata
 - **files.content.read**: Allows downloading file content and getting temporary links
 - **files.content.write**: Allows uploading files, creating folders, deleting, moving, and copying files/folders
-- **contacts.write**: Allows write access for sharing operations
+
 
 ## Version History
 

--- a/dropbox/config.json
+++ b/dropbox/config.json
@@ -11,8 +11,7 @@
             "account_info.read",
             "files.metadata.read",
             "files.content.read",
-            "files.content.write",
-            "contacts.write"
+            "files.content.write"
         ]
     },
     "actions": {


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Remove unused `contacts.write` scope from Dropbox integration OAuth configuration
- **Approach**: Clean up the OAuth scope configuration by removing the unnecessary `contacts.write` scope from both the config.json and documentation

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**
:point_right: Removed `contacts.write` scope from dropbox/config.json OAuth configuration
:point_right: Updated dropbox/README.md to remove references to contacts.write scope
:point_right: Cleaned up scope documentation to reflect actual required permissions

### Screenshots :camera:
{Image here of before and after - if applicable}

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
- Verify Dropbox integration still functions correctly with reduced scope permissions
- Test OAuth flow completes successfully without contacts.write scope
- Confirm all existing Dropbox actions (file operations) work as expected

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)