### PR TITLE
Ad words: Fixed missing field

### DIFF
--- a/google-ads/config.json
+++ b/google-ads/config.json
@@ -164,6 +164,10 @@
                         "type": "string",
                         "enum": ["MANUAL_CPC", "TARGET_SPEND", "MAXIMIZE_CONVERSIONS", "MAXIMIZE_CLICKS"],
                         "description": "Bidding strategy for the campaign. Defaults to MANUAL_CPC."
+                    },
+                    "contains_eu_political_advertising": {
+                        "type": "boolean",
+                        "description": "Whether the campaign contains EU political advertising content. Required for compliance. Defaults to false."
                     }
                 },
                 "required": ["login_customer_id", "customer_id", "campaign_name", "budget_amount_micros"]

--- a/google-ads/google_ads.py
+++ b/google-ads/google_ads.py
@@ -515,7 +515,7 @@ class CreateCampaignAction(ActionHandler):
             campaign.network_settings.target_partner_search_network = False
 
             # EU political advertising compliance (required by Google Ads API)
-            campaign.contains_eu_political_advertising = False
+            campaign.contains_eu_political_advertising = inputs.get('contains_eu_political_advertising', False)
 
             campaign_response = campaign_service.mutate_campaigns(
                 customer_id=customer_id,


### PR DESCRIPTION
The Adwords integration can't automatically create campaigns because of a missing field that was recently added. 
This PR adds in the new field `contains_eu_political_advertising` to address this.