### PR TITLE
Google Ads: Fix retrieve_campaign_metrics failing on non-VIDEO campaigns

### DIFF
--- a/google-ads/config.json
+++ b/google-ads/config.json
@@ -58,6 +58,11 @@
                             "type": "string"
                         },
                         "description": "List of date ranges. Supported formats: 'YYYY-MM-DD_YYYY-MM-DD', 'last 7 days', or single dates 'DD/MM/YYYY'."
+                    },
+                    "campaign_type": {
+                        "type": "string",
+                        "enum": ["SEARCH", "VIDEO", "DISPLAY", "PERFORMANCE_MAX", "ALL"],
+                        "description": "Filter by campaign type. VIDEO includes video-specific metrics (average_cpv). SEARCH, DISPLAY, PERFORMANCE_MAX filter to that type. ALL (default) uses universal metrics safe for mixed campaign types."
                     }
                 },
                 "required": ["login_customer_id", "customer_id"]


### PR DESCRIPTION
## Google Ads: Fix retrieve_campaign_metrics failing on non-VIDEO campaigns

### Description 📝

Fixes the `retrieve_campaign_metrics` action failing on Search, Display, and Performance Max campaigns due to the GAQL query including `metrics.average_cpv`, which is only valid for VIDEO campaigns. Adds a new `campaign_type` parameter to allow filtering by campaign type and include the appropriate metrics.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Updates

👉 Added `campaign_type` parameter to `retrieve_campaign_metrics` action with options: `SEARCH`, `VIDEO`, `DISPLAY`, `PERFORMANCE_MAX`, `ALL`
👉 Removed `metrics.average_cpv` from base GAQL query - now only included when `campaign_type=VIDEO`
👉 Updated `fetch_campaign_data()` to dynamically build query based on campaign type
👉 Added campaign type filtering to GAQL WHERE clause when specific type is requested
👉 `Avg. CPV` field now only included in response data for VIDEO campaign queries

### Author(s) to check 👓

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested (code review of changes)
- [x] Code is written to standards
- [x] Appropriate documentation written

### Reviewer(s) to check ✔️

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Code is written to standards
- [ ] Appropriate documentation written