### PR TITLE
Fix Canva user information extraction

### DIFF
--- a/canva/canva.py
+++ b/canva/canva.py
@@ -28,9 +28,10 @@ class CanvaConnectedAccountHandler(ConnectedAccountHandler):
         )
 
         # Extract information from responses
-        display_name = profile_response.get("display_name")
-        user_id = user_response.get("user", {}).get("id")
-        team_id = user_response.get("user", {}).get("team_id")
+        display_name = profile_response.get("profile", {}).get("display_name")
+        team_user = user_response.get("team_user", {})
+        user_id = team_user.get("user_id")
+        team_id = team_user.get("team_id")
 
         # Split display name into first/last if possible
         first_name = None


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Fixes the extraction of user profile and team information for the Canva integration.
- **Approach**: Updates the key access paths in `get_account_info` to match the correct API response structure (accessing `profile.display_name` and `team_user` fields).
**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
**Updates**
:point_right: Updated `display_name` retrieval to access `profile` object
:point_right: Updated `user_id` and `team_id` retrieval to use `team_user` object
### Screenshots :camera:
{Image here of before and after - if applicable}
### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
{A test plan outlining scenarios to test}
### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)