### PR TITLE
fix(google-ads): fix campaign and keyword metrics validation errors and ROAS calculations

### DIFF
--- a/google-ads/google_ads.py
+++ b/google-ads/google_ads.py
@@ -231,7 +231,7 @@ def fetch_campaign_data(client, customer_id, date_ranges_input, campaign_type=No
             budget = row_dict.get('campaign_budget', {})
 
             conversions_value = metrics.get('conversions_value', 0.0)
-            cost_micros = metrics.get('cost_micros', 1)
+            cost_micros = metrics.get('cost_micros', 0)
             cost = micros_to_currency(cost_micros)
             
             roas = 0
@@ -444,7 +444,7 @@ class RetrieveCampaignMetricsAction(ActionHandler):
         try:
             results = fetch_campaign_data(client, customer_id, date_ranges_input, campaign_type)
             logger.info("Successfully retrieved campaign data.")
-            return ActionResult(data=results, cost_usd=0.00)
+            return ActionResult(data={"results": results}, cost_usd=0.00)
         except Exception as e:
             logger.exception(f"Exception during campaign data retrieval: {str(e)}")
             raise
@@ -472,7 +472,7 @@ class RetrieveKeywordMetricsAction(ActionHandler):
         try:
             results = fetch_keyword_data(client, customer_id, date_ranges_input, campaign_ids, ad_group_ids)
             logger.info("Successfully retrieved keyword data.")
-            return ActionResult(data=results, cost_usd=0.00)
+            return ActionResult(data={"results": results}, cost_usd=0.00)
         except Exception as e:
             logger.exception(f"Exception during keyword data retrieval: {str(e)}")
             raise


### PR DESCRIPTION
### Description

- **Purpose**: Fix data format validation errors and incorrect ROAS calculations in Google Ads campaign and keyword metrics retrieval.
- **Approach**: Wrap API responses in the expected schema format and correct the default value for missing cost data to prevent calculation errors.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**

👉 Wrapped `retrieve_campaign_metrics` and `retrieve_keyword_metrics` responses in `{"results": ...}` object to match expected output schema and fix production ValidationError
👉 Changed default `cost_micros` value from 1 to 0 when missing to prevent incorrect Return On Ad Spend (ROAS) calculations
👉 Applied consistent response format across both campaign and keyword metrics endpoints

### Screenshots

N/A

### Test plan

1. Test `retrieve_campaign_metrics` action with valid customer ID and verify response format matches `{"results": [...]}` schema
2. Test `retrieve_keyword_metrics` action with valid parameters and verify response format is correct
3. Verify ROAS calculations are accurate when cost_micros is missing (should be 0, not inflated by default value of 1)
4. Confirm no ValidationErrors occur in production when these actions are executed

### Author(s) to check

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)