### PR TITLE
ci: add conventional commit checks for PR titles

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,37 @@
+name: "Pull-Request Check"
+
+on:
+    pull_request:
+        types:
+            - opened
+            - edited
+            - synchronize
+
+jobs:
+    main:
+        name: Validate PR title
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v6
+              id: lint_pr_title
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - uses: marocchino/sticky-pull-request-comment@v2
+                # When the previous steps fails, the workflow would stop. By adding this
+                # condition you can continue the execution with the populated error message.
+              if: always() && (steps.lint_pr_title.outputs.error_message != null)
+              with:
+                  header: pr-title-lint-error
+                  message: |
+                      We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+                      Details:
+                      ```
+                      ${{ steps.lint_pr_title.outputs.error_message }}
+                      ```
+            # Delete a previous comment when the issue has been resolved
+            - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: pr-title-lint-error
+                  delete: true


### PR DESCRIPTION
Closes https://github.com/Autohive-AI/autohive-integrations/issues/25

Adds a GitHub Actions workflow that validates PR titles follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification, matching the setup used in `autohive-mobile-app`.

- Uses `amannn/action-semantic-pull-request@v6` to lint PR titles
- Posts a sticky comment explaining the error when validation fails
- Automatically removes the comment when the title is fixed