### PR TITLE
chore: remove test-hello workflow

### DIFF
--- a/.github/workflows/test-hello.yml
+++ b/.github/workflows/test-hello.yml
@@ -1,6 +1,0 @@
-name: Test Hello
-on: [push]
-
-jobs:
-  call-hello:
-    uses: Autohive-AI/autohive-integrations-tooling/.github/workflows/hello-world.yml@master


### PR DESCRIPTION
Removes the `test-hello.yml` workflow which was a basic smoke test calling a reusable hello-world workflow from `autohive-integrations-tooling`. No longer needed.