### PR TITLE
ci: add validate-integration workflow using tooling composite action

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -1,0 +1,23 @@
+name: Validate Integration (Tooling)
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    name: Validate Integration
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate
+        uses: autohive-ai/autohive-integrations-tooling@ci/composite-action
+        with:
+          base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Adds a new `validate-integration.yml` workflow that uses the composite action from `autohive-integrations-tooling` to validate integration structure, code quality, and README updates on PRs.

```yaml
uses: autohive-ai/autohive-integrations-tooling@ci/composite-action
```

> **Note:** Currently pointing at the `ci/composite-action` branch for testing. Will be updated to a tagged release later.