### PR TITLE
ci: pin tooling action to release 1.0.0

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@ci/composite-action
+        uses: autohive-ai/autohive-integrations-tooling@1.0.0
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Updates the validate-integration workflow to use the tagged `1.0.0` release of `autohive-integrations-tooling` instead of the `ci/composite-action` branch.