### PR TITLE
docs: add contributing guide with CI/CD documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,6 @@ my-integration/
     └── test_my_integration.py
 ```
 
-See the [tooling repo's INTEGRATION_CHECKLIST.md](https://github.com/autohive-ai/autohive-integrations-tooling/blob/master/INTEGRATION_CHECKLIST.md) for the full checklist with examples.
-
 ## Pull Request Process
 
 1. **Create a branch** following conventional naming (`feat/my-integration`)


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` for integration authors covering:

- **CI/CD checks** — documents the two automated workflows (validate-integration and PR title validation)
- **PR comment results** — explains the ✅/⚠️/❌ summary posted on PRs
- **Local validation** — how to set up the tooling repo side-by-side and run checks locally (Python env setup is tool-agnostic, uv shown as example)
- **Integration structure** — both basic and modular (with `actions/` directory) folder layouts
- **PR process** — branch naming, conventional commits, one integration per PR