### PR TITLE
chore: bump tooling action to 1.0.2

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@1.0.0
+        uses: autohive-ai/autohive-integrations-tooling@1.0.2
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
## Summary

Bumps the `autohive-integrations-tooling` action reference from `1.0.0` to `1.0.2`.

## Why

Version `1.0.0` of the tooling ran `ruff` without passing `--config ruff.toml`, which meant the `ruff.toml` settings (including the 120 character line length) were silently ignored in CI. Ruff would fall back to its default 88 character line length and flag correctly formatted code as a formatting failure.

This fix landed in `1.0.2` — bumping to that version ensures CI uses the correct ruff configuration consistently.

## Change

- `.github/workflows/validate-integration.yml`: `autohive-ai/autohive-integrations-tooling@1.0.0` -> `autohive-ai/autohive-integrations-tooling@1.0.2`

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Confirm existing integration PRs no longer see spurious ruff formatting failures