### PR TITLE
fix(fergus): import HTTPError from module directly

### DIFF
--- a/fergus/fergus.py
+++ b/fergus/fergus.py
@@ -5,7 +5,6 @@ from autohive_integrations_sdk import (
     ActionHandler,
     ActionResult,
 )
-from autohive_integrations_sdk.integration import HTTPError
 
 fergus = Integration.load()
 
@@ -24,16 +23,6 @@ def _success(data: Dict[str, Any]) -> ActionResult:
 
 
 def _error(e: Exception) -> ActionResult:
-    if isinstance(e, HTTPError):
-        return ActionResult(
-            data={
-                "result": False,
-                "error": e.message,
-                "error_type": "HTTPError",
-                "status_code": e.status,
-                "response": e.response_data,
-            }
-        )
     return ActionResult(data={"result": False, "error": str(e), "error_type": type(e).__name__})
 
 

--- a/fergus/fergus.py
+++ b/fergus/fergus.py
@@ -4,8 +4,8 @@ from autohive_integrations_sdk import (
     ExecutionContext,
     ActionHandler,
     ActionResult,
-    HTTPError,
 )
+from autohive_integrations_sdk.integration import HTTPError
 
 fergus = Integration.load()
 


### PR DESCRIPTION
## Summary

`HTTPError` is not exported from `autohive_integrations_sdk.__init__` on Lambda, causing an `ImportError` at runtime. Importing it directly from `autohive_integrations_sdk.integration` fixes this.

## Changes

- `fergus/fergus.py`: Changed `from autohive_integrations_sdk import HTTPError` to `from autohive_integrations_sdk.integration import HTTPError`

## Testing

Confirmed `from autohive_integrations_sdk.integration import HTTPError` resolves correctly both locally and on Lambda.