### PR TITLE
fix(coda,fergus,jira): fix ruff lint and format issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Supports basic HTTP authentication and Bearer token authentication via the SDK.
 
 ### Coda
 
-[coda](coda): Comprehensive Coda integration for managing documents, pages, tables, and rows. Supports full CRUD operations for docs (list, get, create, update, delete) and pages (list, get, create with HTML/Markdown content, update metadata, delete). Includes table and column discovery (list tables/columns, get table/column details) and complete row management (list with filtering/sorting, get, upsert with keyColumns, update, delete single/multiple). Features Bearer token authentication, pagination support, async processing (HTTP 202 responses), multiple value formats (simple/rich), and comprehensive error handling. Ideal for document automation, content management, and data synchronization workflows.
+[coda](coda): Coda integration for managing documents, pages, tables, and rows. Supports full CRUD operations for docs (list, get, create, update, delete) and pages (list, get, create with HTML/Markdown content, update metadata, delete). Includes table and column discovery (list tables/columns, get table/column details) and complete row management (list with filtering/sorting, get, upsert with keyColumns, update, delete single/multiple). Features Bearer token authentication, pagination support, async processing (HTTP 202 responses), multiple value formats (simple/rich), and comprehensive error handling. Ideal for document automation, content management, and data synchronization workflows.
 
 ### ElevenLabs
 

--- a/coda/coda.py
+++ b/coda/coda.py
@@ -1,6 +1,4 @@
-from autohive_integrations_sdk import (
-    Integration, ExecutionContext, ActionHandler
-)
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
 from typing import Dict, Any, List, Optional
 
 # Create the integration using the config.json
@@ -11,6 +9,7 @@ CODA_API_BASE_URL = "https://coda.io/apis/v1"
 
 
 # ---- Helper Functions ----
+
 
 def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     """
@@ -25,13 +24,11 @@ def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     credentials = context.auth.get("credentials", {})
     api_token = credentials.get("api_token", "")
 
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Content-Type": "application/json"
-    }
+    return {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
 
 
 # ---- Action Handlers ----
+
 
 @coda.action("list_docs")
 class ListDocsAction(ActionHandler):
@@ -68,27 +65,15 @@ class ListDocsAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers,
-                params=params
-            )
+            response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract docs from response
             docs = response.get("items", [])
 
-            return {
-                "docs": docs,
-                "result": True
-            }
+            return {"docs": docs, "result": True}
 
         except Exception as e:
-            return {
-                "docs": [],
-                "result": False,
-                "error": str(e)
-            }
+            return {"docs": [], "result": False, "error": str(e)}
 
 
 @coda.action("get_doc")
@@ -107,23 +92,12 @@ class GetDocAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers
-            )
+            response = await context.fetch(url, method="GET", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("create_doc")
@@ -137,9 +111,7 @@ class CreateDocAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             # Build request body
-            body = {
-                "title": inputs["title"]
-            }
+            body = {"title": inputs["title"]}
 
             # Add optional fields if provided
             if "source_doc" in inputs and inputs["source_doc"]:
@@ -156,24 +128,12 @@ class CreateDocAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs"
-            response = await context.fetch(
-                url,
-                method="POST",
-                headers=headers,
-                json=body
-            )
+            response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("update_doc")
@@ -202,24 +162,12 @@ class UpdateDocAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
-            response = await context.fetch(
-                url,
-                method="PATCH",
-                headers=headers,
-                json=body
-            )
+            response = await context.fetch(url, method="PATCH", headers=headers, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("delete_doc")
@@ -240,23 +188,12 @@ class DeleteDocAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
-            response = await context.fetch(
-                url,
-                method="DELETE",
-                headers=headers
-            )
+            response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("list_pages")
@@ -285,21 +222,13 @@ class ListPagesAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers,
-                params=params
-            )
+            response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract pages from response
             pages = response.get("items", [])
             next_page_token = response.get("nextPageToken")
 
-            result = {
-                "pages": pages,
-                "result": True
-            }
+            result = {"pages": pages, "result": True}
 
             if next_page_token:
                 result["next_page_token"] = next_page_token
@@ -307,11 +236,7 @@ class ListPagesAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {
-                "pages": [],
-                "result": False,
-                "error": str(e)
-            }
+            return {"pages": [], "result": False, "error": str(e)}
 
 
 @coda.action("get_page")
@@ -331,23 +256,12 @@ class GetPageAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers
-            )
+            response = await context.fetch(url, method="GET", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("create_page")
@@ -365,9 +279,7 @@ class CreatePageAction(ActionHandler):
             name = inputs["name"]
 
             # Build request body
-            body = {
-                "name": name
-            }
+            body = {"name": name}
 
             # Add optional fields
             if "subtitle" in inputs and inputs["subtitle"]:
@@ -387,10 +299,7 @@ class CreatePageAction(ActionHandler):
                 content_format = inputs.get("content_format", "html")
                 body["pageContent"] = {
                     "type": "canvas",
-                    "canvasContent": {
-                        "format": content_format,
-                        "content": inputs["content"]
-                    }
+                    "canvasContent": {"format": content_format, "content": inputs["content"]},
                 }
 
             # Get auth headers
@@ -398,24 +307,12 @@ class CreatePageAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages"
-            response = await context.fetch(
-                url,
-                method="POST",
-                headers=headers,
-                json=body
-            )
+            response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("update_page")
@@ -453,24 +350,12 @@ class UpdatePageAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="PUT",
-                headers=headers,
-                json=body
-            )
+            response = await context.fetch(url, method="PUT", headers=headers, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("delete_page")
@@ -492,23 +377,12 @@ class DeletePageAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="DELETE",
-                headers=headers
-            )
+            response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("list_tables")
@@ -543,21 +417,13 @@ class ListTablesAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers,
-                params=params
-            )
+            response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract tables from response
             tables = response.get("items", [])
             next_page_token = response.get("nextPageToken")
 
-            result = {
-                "tables": tables,
-                "result": True
-            }
+            result = {"tables": tables, "result": True}
 
             if next_page_token:
                 result["next_page_token"] = next_page_token
@@ -565,11 +431,7 @@ class ListTablesAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {
-                "tables": [],
-                "result": False,
-                "error": str(e)
-            }
+            return {"tables": [], "result": False, "error": str(e)}
 
 
 @coda.action("get_table")
@@ -589,23 +451,12 @@ class GetTableAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers
-            )
+            response = await context.fetch(url, method="GET", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("list_columns")
@@ -638,21 +489,13 @@ class ListColumnsAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/columns"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers,
-                params=params
-            )
+            response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract columns from response
             columns = response.get("items", [])
             next_page_token = response.get("nextPageToken")
 
-            result = {
-                "columns": columns,
-                "result": True
-            }
+            result = {"columns": columns, "result": True}
 
             if next_page_token:
                 result["next_page_token"] = next_page_token
@@ -660,11 +503,7 @@ class ListColumnsAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {
-                "columns": [],
-                "result": False,
-                "error": str(e)
-            }
+            return {"columns": [], "result": False, "error": str(e)}
 
 
 @coda.action("get_column")
@@ -685,23 +524,12 @@ class GetColumnAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/columns/{column_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers
-            )
+            response = await context.fetch(url, method="GET", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("list_rows")
@@ -746,21 +574,13 @@ class ListRowsAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers,
-                params=params
-            )
+            response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract rows from response
             rows = response.get("items", [])
             next_page_token = response.get("nextPageToken")
 
-            result = {
-                "rows": rows,
-                "result": True
-            }
+            result = {"rows": rows, "result": True}
 
             if next_page_token:
                 result["next_page_token"] = next_page_token
@@ -768,11 +588,7 @@ class ListRowsAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {
-                "rows": [],
-                "result": False,
-                "error": str(e)
-            }
+            return {"rows": [], "result": False, "error": str(e)}
 
 
 @coda.action("get_row")
@@ -802,24 +618,12 @@ class GetRowAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="GET",
-                headers=headers,
-                params=params
-            )
+            response = await context.fetch(url, method="GET", headers=headers, params=params)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("upsert_rows")
@@ -838,9 +642,7 @@ class UpsertRowsAction(ActionHandler):
             rows = inputs["rows"]
 
             # Build request body
-            body = {
-                "rows": rows
-            }
+            body = {"rows": rows}
 
             # Add optional keyColumns for upsert behavior
             if "key_columns" in inputs and inputs["key_columns"]:
@@ -856,25 +658,12 @@ class UpsertRowsAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
-            response = await context.fetch(
-                url,
-                method="POST",
-                headers=headers,
-                params=params,
-                json=body
-            )
+            response = await context.fetch(url, method="POST", headers=headers, params=params, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("update_row")
@@ -894,11 +683,7 @@ class UpdateRowAction(ActionHandler):
             cells = inputs["cells"]
 
             # Build request body
-            body = {
-                "row": {
-                    "cells": cells
-                }
-            }
+            body = {"row": {"cells": cells}}
 
             # Build query parameters
             params = {}
@@ -910,25 +695,12 @@ class UpdateRowAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="PUT",
-                headers=headers,
-                params=params,
-                json=body
-            )
+            response = await context.fetch(url, method="PUT", headers=headers, params=params, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("delete_row")
@@ -950,23 +722,12 @@ class DeleteRowAction(ActionHandler):
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
-            response = await context.fetch(
-                url,
-                method="DELETE",
-                headers=headers
-            )
+            response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}
 
 
 @coda.action("delete_rows")
@@ -984,30 +745,16 @@ class DeleteRowsAction(ActionHandler):
             row_ids = inputs["row_ids"]
 
             # Build request body
-            body = {
-                "rowIds": row_ids
-            }
+            body = {"rowIds": row_ids}
 
             # Get auth headers
             headers = get_auth_headers(context)
 
             # Make API request
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
-            response = await context.fetch(
-                url,
-                method="DELETE",
-                headers=headers,
-                json=body
-            )
+            response = await context.fetch(url, method="DELETE", headers=headers, json=body)
 
-            return {
-                "data": response,
-                "result": True
-            }
+            return {"data": response, "result": True}
 
         except Exception as e:
-            return {
-                "data": {},
-                "result": False,
-                "error": str(e)
-            }
+            return {"data": {}, "result": False, "error": str(e)}

--- a/coda/coda.py
+++ b/coda/coda.py
@@ -1,5 +1,5 @@
 from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any
 
 # Create the integration using the config.json
 coda = Integration.load()

--- a/coda/config.json
+++ b/coda/config.json
@@ -75,7 +75,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["docs", "result"]
+                "required": [
+                    "docs",
+                    "result"
+                ]
             }
         },
         "get_doc": {
@@ -89,7 +92,9 @@
                         "description": "ID of the doc (e.g., 'AbCDeFGH')"
                     }
                 },
-                "required": ["doc_id"]
+                "required": [
+                    "doc_id"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -107,7 +112,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "create_doc": {
@@ -133,7 +141,9 @@
                         "description": "Optional: Folder ID where the doc should be created"
                     }
                 },
-                "required": ["title"]
+                "required": [
+                    "title"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -151,7 +161,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "update_doc": {
@@ -173,7 +186,9 @@
                         "description": "Optional: New icon name (e.g., 'rocket', 'star', 'heart')"
                     }
                 },
-                "required": ["doc_id"]
+                "required": [
+                    "doc_id"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -191,7 +206,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "delete_doc": {
@@ -205,7 +223,9 @@
                         "description": "ID of the doc to delete (e.g., 'AbCDeFGH')"
                     }
                 },
-                "required": ["doc_id"]
+                "required": [
+                    "doc_id"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -223,7 +243,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "list_pages": {
@@ -248,7 +271,9 @@
                         "description": "Token for fetching the next page of results"
                     }
                 },
-                "required": ["doc_id"]
+                "required": [
+                    "doc_id"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -273,7 +298,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["pages", "result"]
+                "required": [
+                    "pages",
+                    "result"
+                ]
             }
         },
         "get_page": {
@@ -291,7 +319,10 @@
                         "description": "Page ID or name (e.g., 'canvas-abc123')"
                     }
                 },
-                "required": ["doc_id", "page_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "page_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -309,7 +340,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "create_page": {
@@ -344,7 +378,10 @@
                     },
                     "content_format": {
                         "type": "string",
-                        "enum": ["html", "markdown"],
+                        "enum": [
+                            "html",
+                            "markdown"
+                        ],
                         "description": "Optional: Format of page content (html or markdown)",
                         "default": "html"
                     },
@@ -353,7 +390,10 @@
                         "description": "Optional: Page content in HTML or Markdown format"
                     }
                 },
-                "required": ["doc_id", "name"]
+                "required": [
+                    "doc_id",
+                    "name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -371,7 +411,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "update_page": {
@@ -405,7 +448,10 @@
                         "description": "Optional: New cover image URL"
                     }
                 },
-                "required": ["doc_id", "page_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "page_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -423,7 +469,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "delete_page": {
@@ -441,7 +490,10 @@
                         "description": "Page ID or name to delete. Names are discouraged as they can be changed by users. If multiple pages have the same name, an arbitrary one will be selected."
                     }
                 },
-                "required": ["doc_id", "page_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "page_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -459,7 +511,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "list_tables": {
@@ -493,7 +548,9 @@
                         "default": "table,view"
                     }
                 },
-                "required": ["doc_id"]
+                "required": [
+                    "doc_id"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -518,7 +575,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["tables", "result"]
+                "required": [
+                    "tables",
+                    "result"
+                ]
             }
         },
         "get_table": {
@@ -536,7 +596,10 @@
                         "description": "Table ID or name. IDs recommended over names (e.g., 'grid-xyz123')"
                     }
                 },
-                "required": ["doc_id", "table_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -554,7 +617,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "list_columns": {
@@ -588,7 +654,10 @@
                         "default": false
                     }
                 },
-                "required": ["doc_id", "table_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -613,7 +682,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["columns", "result"]
+                "required": [
+                    "columns",
+                    "result"
+                ]
             }
         },
         "get_column": {
@@ -635,7 +707,11 @@
                         "description": "Column ID or name. IDs recommended (e.g., 'c-column123')"
                     }
                 },
-                "required": ["doc_id", "table_id_or_name", "column_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name",
+                    "column_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -653,7 +729,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "list_rows": {
@@ -696,7 +775,11 @@
                     },
                     "value_format": {
                         "type": "string",
-                        "enum": ["simple", "simpleWithArrays", "rich"],
+                        "enum": [
+                            "simple",
+                            "simpleWithArrays",
+                            "rich"
+                        ],
                         "description": "Format for cell values (simple, simpleWithArrays, or rich)",
                         "default": "simple"
                     },
@@ -706,7 +789,10 @@
                         "default": false
                     }
                 },
-                "required": ["doc_id", "table_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -731,7 +817,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["rows", "result"]
+                "required": [
+                    "rows",
+                    "result"
+                ]
             }
         },
         "get_row": {
@@ -759,12 +848,20 @@
                     },
                     "value_format": {
                         "type": "string",
-                        "enum": ["simple", "simpleWithArrays", "rich"],
+                        "enum": [
+                            "simple",
+                            "simpleWithArrays",
+                            "rich"
+                        ],
                         "description": "Format for cell values",
                         "default": "simple"
                     }
                 },
-                "required": ["doc_id", "table_id_or_name", "row_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name",
+                    "row_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -782,7 +879,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "upsert_rows": {
@@ -819,11 +919,16 @@
                                                 "description": "Cell value (type depends on column)"
                                             }
                                         },
-                                        "required": ["column", "value"]
+                                        "required": [
+                                            "column",
+                                            "value"
+                                        ]
                                     }
                                 }
                             },
-                            "required": ["cells"]
+                            "required": [
+                                "cells"
+                            ]
                         }
                     },
                     "key_columns": {
@@ -839,7 +944,11 @@
                         "default": false
                     }
                 },
-                "required": ["doc_id", "table_id_or_name", "rows"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name",
+                    "rows"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -857,7 +966,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "update_row": {
@@ -892,7 +1004,10 @@
                                     "description": "New cell value (type depends on column)"
                                 }
                             },
-                            "required": ["column", "value"]
+                            "required": [
+                                "column",
+                                "value"
+                            ]
                         }
                     },
                     "disable_parsing": {
@@ -901,7 +1016,12 @@
                         "default": false
                     }
                 },
-                "required": ["doc_id", "table_id_or_name", "row_id_or_name", "cells"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name",
+                    "row_id_or_name",
+                    "cells"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -919,7 +1039,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "delete_row": {
@@ -941,7 +1064,11 @@
                         "description": "Row ID or name to delete. IDs recommended (e.g., 'i-rowId123')"
                     }
                 },
-                "required": ["doc_id", "table_id_or_name", "row_id_or_name"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name",
+                    "row_id_or_name"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -959,7 +1086,10 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         },
         "delete_rows": {
@@ -984,7 +1114,11 @@
                         }
                     }
                 },
-                "required": ["doc_id", "table_id_or_name", "row_ids"]
+                "required": [
+                    "doc_id",
+                    "table_id_or_name",
+                    "row_ids"
+                ]
             },
             "output_schema": {
                 "type": "object",
@@ -1002,8 +1136,12 @@
                         "description": "Error message if operation failed"
                     }
                 },
-                "required": ["data", "result"]
+                "required": [
+                    "data",
+                    "result"
+                ]
             }
         }
-    }
+    },
+    "display_name": "coda"
 }

--- a/coda/requirements.txt
+++ b/coda/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk
+autohive-integrations-sdk~=1.0.2

--- a/coda/tests/context.py
+++ b/coda/tests/context.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))
 
 from coda import coda

--- a/coda/tests/test_coda.py
+++ b/coda/tests/test_coda.py
@@ -3,13 +3,10 @@ import asyncio
 from context import coda
 from autohive_integrations_sdk import ExecutionContext
 
+
 async def test_list_docs():
     """Test listing all accessible Coda docs"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     inputs = {}
 
@@ -34,18 +31,12 @@ async def test_list_docs():
             print(f"Error testing list_docs: {e}")
             return None
 
+
 async def test_list_docs_with_filters():
     """Test listing docs with filters"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
-    inputs = {
-        "is_owner": True,
-        "limit": 5
-    }
+    inputs = {"is_owner": True, "limit": 5}
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -65,18 +56,12 @@ async def test_list_docs_with_filters():
             print(f"Error testing list_docs_with_filters: {e}")
             return None
 
+
 async def test_list_docs_with_query():
     """Test searching docs by query"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
-    inputs = {
-        "query": "test",
-        "limit": 10
-    }
+    inputs = {"query": "test", "limit": 10}
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -95,13 +80,10 @@ async def test_list_docs_with_query():
             print(f"Error testing list_docs_with_query: {e}")
             return None
 
+
 async def test_get_doc():
     """Test getting a specific doc by ID"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID from list_docs
     list_inputs = {"limit": 1}
@@ -137,17 +119,12 @@ async def test_get_doc():
             print(f"Error testing get_doc: {e}")
             return None
 
+
 async def test_create_doc():
     """Test creating a new Coda doc"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
-    inputs = {
-        "title": "Test Doc - Created by Integration"
-    }
+    inputs = {"title": "Test Doc - Created by Integration"}
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -169,13 +146,10 @@ async def test_create_doc():
             print(f"Error testing create_doc: {e}")
             return None
 
+
 async def test_create_doc_from_source():
     """Test creating a doc from a source doc (template)"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID to use as source
     list_inputs = {"limit": 1}
@@ -192,10 +166,7 @@ async def test_create_doc_from_source():
             print("\nTest 6: Create Doc from Source Template")
             print("=" * 60)
 
-            inputs = {
-                "title": "Test Doc - From Template",
-                "source_doc": source_doc_id
-            }
+            inputs = {"title": "Test Doc - From Template", "source_doc": source_doc_id}
             result = await coda.execute_action("create_doc", inputs, context)
 
             if not result.get("result"):
@@ -212,17 +183,12 @@ async def test_create_doc_from_source():
             print(f"Error testing create_doc_from_source: {e}")
             return None
 
+
 async def test_list_published_docs():
     """Test listing only published docs"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
-    inputs = {
-        "is_published": True
-    }
+    inputs = {"is_published": True}
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -241,17 +207,12 @@ async def test_list_published_docs():
             print(f"Error testing list_published_docs: {e}")
             return None
 
+
 async def test_list_starred_docs():
     """Test listing only starred docs"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
-    inputs = {
-        "is_starred": True
-    }
+    inputs = {"is_starred": True}
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -270,13 +231,10 @@ async def test_list_starred_docs():
             print(f"Error testing list_starred_docs: {e}")
             return None
 
+
 async def test_update_doc():
     """Test updating a doc's metadata"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID from list_docs
     list_inputs = {"limit": 1}
@@ -293,11 +251,7 @@ async def test_update_doc():
             print("\nTest 9: Update Doc")
             print("=" * 60)
 
-            inputs = {
-                "doc_id": doc_id,
-                "title": "Updated Doc Title via API",
-                "icon_name": "star"
-            }
+            inputs = {"doc_id": doc_id, "title": "Updated Doc Title via API", "icon_name": "star"}
             result = await coda.execute_action("update_doc", inputs, context)
 
             if not result.get("result"):
@@ -312,21 +266,16 @@ async def test_update_doc():
             print(f"Error testing update_doc: {e}")
             return None
 
+
 async def test_delete_doc():
     """Test deleting a doc"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, create a doc to delete
     async with ExecutionContext(auth=auth) as context:
         try:
             # Create a test doc
-            create_result = await coda.execute_action("create_doc", {
-                "title": "Test Doc - To Be Deleted"
-            }, context)
+            create_result = await coda.execute_action("create_doc", {"title": "Test Doc - To Be Deleted"}, context)
 
             if not create_result.get("result"):
                 print("\nTest 10: Delete Doc (SKIPPED - Could not create test doc)")
@@ -334,6 +283,7 @@ async def test_delete_doc():
 
             # Wait for doc creation to process
             import asyncio
+
             await asyncio.sleep(3)
 
             # Get the created doc ID
@@ -360,13 +310,10 @@ async def test_delete_doc():
             print(f"Error testing delete_doc: {e}")
             return None
 
+
 async def test_list_pages():
     """Test listing pages in a doc"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID from list_docs
     list_inputs = {"limit": 1}
@@ -400,13 +347,10 @@ async def test_list_pages():
             print(f"Error testing list_pages: {e}")
             return None
 
+
 async def test_get_page():
     """Test getting a specific page"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID and page ID
     list_inputs = {"limit": 1}
@@ -450,13 +394,10 @@ async def test_get_page():
             print(f"Error testing get_page: {e}")
             return None
 
+
 async def test_create_page():
     """Test creating a new page in a doc"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID
     list_inputs = {"limit": 1}
@@ -477,7 +418,7 @@ async def test_create_page():
                 "doc_id": doc_id,
                 "name": "Test Page - Created by Integration",
                 "subtitle": "This is a test page",
-                "icon_name": "rocket"
+                "icon_name": "rocket",
             }
             result = await coda.execute_action("create_page", inputs, context)
 
@@ -494,13 +435,10 @@ async def test_create_page():
             print(f"Error testing create_page: {e}")
             return None
 
+
 async def test_create_page_with_content():
     """Test creating a page with HTML content"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID
     list_inputs = {"limit": 1}
@@ -521,7 +459,7 @@ async def test_create_page_with_content():
                 "doc_id": doc_id,
                 "name": "Test Page with Content",
                 "content_format": "html",
-                "content": "<h1>Test Content</h1><p>This is a test page with HTML content.</p>"
+                "content": "<h1>Test Content</h1><p>This is a test page with HTML content.</p>",
             }
             result = await coda.execute_action("create_page", inputs, context)
 
@@ -537,13 +475,10 @@ async def test_create_page_with_content():
             print(f"Error testing create_page_with_content: {e}")
             return None
 
+
 async def test_update_page():
     """Test updating a page's metadata"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID and page ID
     list_inputs = {"limit": 1}
@@ -573,7 +508,7 @@ async def test_update_page():
                 "doc_id": doc_id,
                 "page_id_or_name": page_id,
                 "name": "Updated Page Name",
-                "subtitle": "Updated subtitle"
+                "subtitle": "Updated subtitle",
             }
             result = await coda.execute_action("update_page", inputs, context)
 
@@ -590,13 +525,10 @@ async def test_update_page():
             print(f"Error testing update_page: {e}")
             return None
 
+
 async def test_delete_page():
     """Test deleting a page"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, create a test page to delete
     list_inputs = {"limit": 1}
@@ -611,10 +543,9 @@ async def test_delete_page():
             doc_id = list_result["docs"][0]["id"]
 
             # Create a page to delete
-            create_result = await coda.execute_action("create_page", {
-                "doc_id": doc_id,
-                "name": "Page to Delete"
-            }, context)
+            create_result = await coda.execute_action(
+                "create_page", {"doc_id": doc_id, "name": "Page to Delete"}, context
+            )
 
             if not create_result.get("result"):
                 print("\nTest 14: Delete Page (SKIPPED - Could not create test page)")
@@ -622,6 +553,7 @@ async def test_delete_page():
 
             # Wait a moment for page creation to process
             import asyncio
+
             await asyncio.sleep(2)
 
             # Get the created page ID from list
@@ -641,10 +573,7 @@ async def test_delete_page():
             print("\nTest 14: Delete Page")
             print("=" * 60)
 
-            inputs = {
-                "doc_id": doc_id,
-                "page_id_or_name": page_id
-            }
+            inputs = {"doc_id": doc_id, "page_id_or_name": page_id}
             result = await coda.execute_action("delete_page", inputs, context)
 
             if not result.get("result"):
@@ -660,13 +589,10 @@ async def test_delete_page():
             print(f"Error testing delete_page: {e}")
             return None
 
+
 async def test_list_tables():
     """Test listing tables in a doc"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID
     list_inputs = {"limit": 1}
@@ -702,13 +628,10 @@ async def test_list_tables():
             print(f"Error testing list_tables: {e}")
             return None
 
+
 async def test_get_table():
     """Test getting a specific table"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID and table ID
     list_inputs = {"limit": 1}
@@ -753,13 +676,10 @@ async def test_get_table():
             print(f"Error testing get_table: {e}")
             return None
 
+
 async def test_list_columns():
     """Test listing columns in a table"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID and table ID
     list_inputs = {"limit": 1}
@@ -804,13 +724,10 @@ async def test_list_columns():
             print(f"Error testing list_columns: {e}")
             return None
 
+
 async def test_get_column():
     """Test getting a specific column"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # First, get a doc ID, table ID, and column ID
     list_inputs = {"limit": 1}
@@ -834,11 +751,9 @@ async def test_get_column():
             table_id = tables_result["tables"][0]["id"]
 
             # Get columns
-            columns_result = await coda.execute_action("list_columns", {
-                "doc_id": doc_id,
-                "table_id_or_name": table_id,
-                "limit": 1
-            }, context)
+            columns_result = await coda.execute_action(
+                "list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context
+            )
 
             if not columns_result.get("result") or not columns_result.get("columns"):
                 print("\nTest 18: Get Column (SKIPPED - No columns available)")
@@ -849,11 +764,7 @@ async def test_get_column():
             print("\nTest 18: Get Column")
             print("=" * 60)
 
-            inputs = {
-                "doc_id": doc_id,
-                "table_id_or_name": table_id,
-                "column_id_or_name": column_id
-            }
+            inputs = {"doc_id": doc_id, "table_id_or_name": table_id, "column_id_or_name": column_id}
             result = await coda.execute_action("get_column", inputs, context)
 
             if not result.get("result"):
@@ -872,13 +783,10 @@ async def test_get_column():
             print(f"Error testing get_column: {e}")
             return None
 
+
 async def test_list_rows():
     """Test listing rows in a table"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     # Get doc and table IDs
     async with ExecutionContext(auth=auth) as context:
@@ -916,13 +824,10 @@ async def test_list_rows():
             print(f"Error testing list_rows: {e}")
             return None
 
+
 async def test_get_row():
     """Test getting a specific row"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -939,7 +844,9 @@ async def test_get_row():
                 return None
 
             table_id = tables_result["tables"][0]["id"]
-            rows_result = await coda.execute_action("list_rows", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context)
+            rows_result = await coda.execute_action(
+                "list_rows", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context
+            )
 
             if not rows_result.get("result") or not rows_result.get("rows"):
                 print("\nTest 20: Get Row (SKIPPED - No rows available)")
@@ -966,13 +873,10 @@ async def test_get_row():
             print(f"Error testing get_row: {e}")
             return None
 
+
 async def test_upsert_rows():
     """Test upserting rows into a table"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -982,14 +886,18 @@ async def test_upsert_rows():
                 return None
 
             doc_id = list_result["docs"][0]["id"]
-            tables_result = await coda.execute_action("list_tables", {"doc_id": doc_id, "table_types": "table", "limit": 1}, context)
+            tables_result = await coda.execute_action(
+                "list_tables", {"doc_id": doc_id, "table_types": "table", "limit": 1}, context
+            )
 
             if not tables_result.get("result") or not tables_result.get("tables"):
                 print("\nTest 21: Upsert Rows (SKIPPED - No base tables available)")
                 return None
 
             table_id = tables_result["tables"][0]["id"]
-            columns_result = await coda.execute_action("list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 2}, context)
+            columns_result = await coda.execute_action(
+                "list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 2}, context
+            )
 
             if not columns_result.get("result") or not columns_result.get("columns"):
                 print("\nTest 21: Upsert Rows (SKIPPED - No columns available)")
@@ -1004,9 +912,7 @@ async def test_upsert_rows():
             inputs = {
                 "doc_id": doc_id,
                 "table_id_or_name": table_id,
-                "rows": [
-                    {"cells": [{"column": column_id, "value": "Test Row from API"}]}
-                ]
+                "rows": [{"cells": [{"column": column_id, "value": "Test Row from API"}]}],
             }
             result = await coda.execute_action("upsert_rows", inputs, context)
 
@@ -1022,13 +928,10 @@ async def test_upsert_rows():
             print(f"Error testing upsert_rows: {e}")
             return None
 
+
 async def test_update_row():
     """Test updating a row"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -1045,14 +948,18 @@ async def test_update_row():
                 return None
 
             table_id = tables_result["tables"][0]["id"]
-            rows_result = await coda.execute_action("list_rows", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context)
+            rows_result = await coda.execute_action(
+                "list_rows", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context
+            )
 
             if not rows_result.get("result") or not rows_result.get("rows"):
                 print("\nTest 22: Update Row (SKIPPED - No rows available)")
                 return None
 
             row_id = rows_result["rows"][0]["id"]
-            columns_result = await coda.execute_action("list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context)
+            columns_result = await coda.execute_action(
+                "list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context
+            )
 
             if not columns_result.get("result") or not columns_result.get("columns"):
                 print("\nTest 22: Update Row (SKIPPED - No columns available)")
@@ -1067,7 +974,7 @@ async def test_update_row():
                 "doc_id": doc_id,
                 "table_id_or_name": table_id,
                 "row_id_or_name": row_id,
-                "cells": [{"column": column_id, "value": "Updated via API"}]
+                "cells": [{"column": column_id, "value": "Updated via API"}],
             }
             result = await coda.execute_action("update_row", inputs, context)
 
@@ -1081,13 +988,10 @@ async def test_update_row():
             print(f"Error testing update_row: {e}")
             return None
 
+
 async def test_delete_row():
     """Test deleting a single row"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -1097,7 +1001,9 @@ async def test_delete_row():
                 return None
 
             doc_id = list_result["docs"][0]["id"]
-            tables_result = await coda.execute_action("list_tables", {"doc_id": doc_id, "table_types": "table", "limit": 1}, context)
+            tables_result = await coda.execute_action(
+                "list_tables", {"doc_id": doc_id, "table_types": "table", "limit": 1}, context
+            )
 
             if not tables_result.get("result") or not tables_result.get("tables"):
                 print("\nTest 23: Delete Row (SKIPPED - No base tables available)")
@@ -1106,7 +1012,9 @@ async def test_delete_row():
             table_id = tables_result["tables"][0]["id"]
 
             # Create a test row to delete
-            columns_result = await coda.execute_action("list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context)
+            columns_result = await coda.execute_action(
+                "list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context
+            )
             if not columns_result.get("result") or not columns_result.get("columns"):
                 print("\nTest 23: Delete Row (SKIPPED - No columns available)")
                 return None
@@ -1114,11 +1022,15 @@ async def test_delete_row():
             column_id = columns_result["columns"][0]["id"]
 
             # Insert a test row
-            upsert_result = await coda.execute_action("upsert_rows", {
-                "doc_id": doc_id,
-                "table_id_or_name": table_id,
-                "rows": [{"cells": [{"column": column_id, "value": "Row to Delete"}]}]
-            }, context)
+            upsert_result = await coda.execute_action(
+                "upsert_rows",
+                {
+                    "doc_id": doc_id,
+                    "table_id_or_name": table_id,
+                    "rows": [{"cells": [{"column": column_id, "value": "Row to Delete"}]}],
+                },
+                context,
+            )
 
             if not upsert_result.get("result"):
                 print("\nTest 23: Delete Row (SKIPPED - Could not create test row)")
@@ -1126,10 +1038,13 @@ async def test_delete_row():
 
             # Wait for row creation
             import asyncio
+
             await asyncio.sleep(2)
 
             # Get the row ID
-            rows_result = await coda.execute_action("list_rows", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 10}, context)
+            rows_result = await coda.execute_action(
+                "list_rows", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 10}, context
+            )
             row_id = None
             for row in rows_result.get("rows", []):
                 values = row.get("values", {})
@@ -1144,11 +1059,7 @@ async def test_delete_row():
             print("\nTest 23: Delete Row")
             print("=" * 60)
 
-            inputs = {
-                "doc_id": doc_id,
-                "table_id_or_name": table_id,
-                "row_id_or_name": row_id
-            }
+            inputs = {"doc_id": doc_id, "table_id_or_name": table_id, "row_id_or_name": row_id}
             result = await coda.execute_action("delete_row", inputs, context)
 
             if not result.get("result"):
@@ -1161,13 +1072,10 @@ async def test_delete_row():
             print(f"Error testing delete_row: {e}")
             return None
 
+
 async def test_delete_rows():
     """Test deleting multiple rows"""
-    auth = {
-        "credentials": {
-            "api_token": "your_api_token_here"
-        }
-    }
+    auth = {"credentials": {"api_token": "your_api_token_here"}}  # nosec B105
 
     async with ExecutionContext(auth=auth) as context:
         try:
@@ -1177,7 +1085,9 @@ async def test_delete_rows():
                 return None
 
             doc_id = list_result["docs"][0]["id"]
-            tables_result = await coda.execute_action("list_tables", {"doc_id": doc_id, "table_types": "table", "limit": 1}, context)
+            tables_result = await coda.execute_action(
+                "list_tables", {"doc_id": doc_id, "table_types": "table", "limit": 1}, context
+            )
 
             if not tables_result.get("result") or not tables_result.get("tables"):
                 print("\nTest 24: Delete Rows (SKIPPED - No base tables available)")
@@ -1186,7 +1096,9 @@ async def test_delete_rows():
             table_id = tables_result["tables"][0]["id"]
 
             # Create test rows to delete
-            columns_result = await coda.execute_action("list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context)
+            columns_result = await coda.execute_action(
+                "list_columns", {"doc_id": doc_id, "table_id_or_name": table_id, "limit": 1}, context
+            )
             if not columns_result.get("result") or not columns_result.get("columns"):
                 print("\nTest 24: Delete Rows (SKIPPED - No columns available)")
                 return None
@@ -1194,14 +1106,18 @@ async def test_delete_rows():
             column_id = columns_result["columns"][0]["id"]
 
             # Insert test rows
-            upsert_result = await coda.execute_action("upsert_rows", {
-                "doc_id": doc_id,
-                "table_id_or_name": table_id,
-                "rows": [
-                    {"cells": [{"column": column_id, "value": "Bulk Delete 1"}]},
-                    {"cells": [{"column": column_id, "value": "Bulk Delete 2"}]}
-                ]
-            }, context)
+            upsert_result = await coda.execute_action(
+                "upsert_rows",
+                {
+                    "doc_id": doc_id,
+                    "table_id_or_name": table_id,
+                    "rows": [
+                        {"cells": [{"column": column_id, "value": "Bulk Delete 1"}]},
+                        {"cells": [{"column": column_id, "value": "Bulk Delete 2"}]},
+                    ],
+                },
+                context,
+            )
 
             if not upsert_result.get("result"):
                 print("\nTest 24: Delete Rows (SKIPPED - Could not create test rows)")
@@ -1209,10 +1125,13 @@ async def test_delete_rows():
 
             # Wait for row creation
             import asyncio
+
             await asyncio.sleep(2)
 
             # Get the row IDs
-            rows_result = await coda.execute_action("list_rows", {"doc_id": doc_id, "table_id_or_name": table_id}, context)
+            rows_result = await coda.execute_action(
+                "list_rows", {"doc_id": doc_id, "table_id_or_name": table_id}, context
+            )
             row_ids = []
             for row in rows_result.get("rows", []):
                 values = row.get("values", {})
@@ -1228,11 +1147,7 @@ async def test_delete_rows():
             print("\nTest 24: Delete Rows")
             print("=" * 60)
 
-            inputs = {
-                "doc_id": doc_id,
-                "table_id_or_name": table_id,
-                "row_ids": row_ids
-            }
+            inputs = {"doc_id": doc_id, "table_id_or_name": table_id, "row_ids": row_ids}
             result = await coda.execute_action("delete_rows", inputs, context)
 
             if not result.get("result"):
@@ -1244,6 +1159,7 @@ async def test_delete_rows():
         except Exception as e:
             print(f"Error testing delete_rows: {e}")
             return None
+
 
 async def main():
     """Run all tests"""
@@ -1291,6 +1207,7 @@ async def main():
     print("\n" + "=" * 60)
     print("ALL TESTS COMPLETED")
     print("=" * 60 + "\n")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/coda/tests/test_coda.py
+++ b/coda/tests/test_coda.py
@@ -107,7 +107,7 @@ async def test_get_doc():
                 print(f"ERROR: {result.get('error')}")
             else:
                 doc = result.get("data", {})
-                print(f"SUCCESS: Retrieved doc")
+                print("SUCCESS: Retrieved doc")
                 print(f"Name: {doc.get('name')}")
                 print(f"ID: {doc.get('id')}")
                 print(f"Owner: {doc.get('owner')}")
@@ -136,7 +136,7 @@ async def test_create_doc():
                 print(f"ERROR: {result.get('error')}")
             else:
                 doc = result.get("data", {})
-                print(f"SUCCESS: Doc created (HTTP 202 - Processing)")
+                print("SUCCESS: Doc created (HTTP 202 - Processing)")
                 print(f"Name: {doc.get('name')}")
                 print(f"ID: {doc.get('id')}")
                 print(f"Request ID: {doc.get('requestId', 'N/A')}")
@@ -173,7 +173,7 @@ async def test_create_doc_from_source():
                 print(f"ERROR: {result.get('error')}")
             else:
                 doc = result.get("data", {})
-                print(f"SUCCESS: Doc created from source (HTTP 202 - Processing)")
+                print("SUCCESS: Doc created from source (HTTP 202 - Processing)")
                 print(f"Name: {doc.get('name')}")
                 print(f"ID: {doc.get('id')}")
                 print(f"Source Doc: {source_doc_id}")
@@ -258,7 +258,7 @@ async def test_update_doc():
                 print(f"ERROR: {result.get('error')}")
             else:
                 doc = result.get("data", {})
-                print(f"SUCCESS: Doc updated")
+                print("SUCCESS: Doc updated")
                 print(f"ID: {doc.get('id', doc_id)}")
 
             return result
@@ -302,7 +302,7 @@ async def test_delete_doc():
             if not result.get("result"):
                 print(f"ERROR: {result.get('error')}")
             else:
-                print(f"SUCCESS: Doc deleted (HTTP 202 - Processing)")
+                print("SUCCESS: Doc deleted (HTTP 202 - Processing)")
                 print(f"Deleted doc ID: {doc_id}")
 
             return result
@@ -383,7 +383,7 @@ async def test_get_page():
                 print(f"ERROR: {result.get('error')}")
             else:
                 page = result.get("data", {})
-                print(f"SUCCESS: Retrieved page")
+                print("SUCCESS: Retrieved page")
                 print(f"Name: {page.get('name')}")
                 print(f"ID: {page.get('id')}")
                 print(f"Subtitle: {page.get('subtitle', 'None')}")
@@ -426,7 +426,7 @@ async def test_create_page():
                 print(f"ERROR: {result.get('error')}")
             else:
                 page = result.get("data", {})
-                print(f"SUCCESS: Page created (HTTP 202 - Processing)")
+                print("SUCCESS: Page created (HTTP 202 - Processing)")
                 print(f"ID: {page.get('id')}")
                 print(f"Request ID: {page.get('requestId', 'N/A')}")
 
@@ -467,7 +467,7 @@ async def test_create_page_with_content():
                 print(f"ERROR: {result.get('error')}")
             else:
                 page = result.get("data", {})
-                print(f"SUCCESS: Page with content created (HTTP 202 - Processing)")
+                print("SUCCESS: Page with content created (HTTP 202 - Processing)")
                 print(f"ID: {page.get('id')}")
 
             return result
@@ -516,7 +516,7 @@ async def test_update_page():
                 print(f"ERROR: {result.get('error')}")
             else:
                 page = result.get("data", {})
-                print(f"SUCCESS: Page updated (HTTP 202 - Processing)")
+                print("SUCCESS: Page updated (HTTP 202 - Processing)")
                 print(f"ID: {page.get('id')}")
                 print(f"Request ID: {page.get('requestId', 'N/A')}")
 
@@ -580,7 +580,7 @@ async def test_delete_page():
                 print(f"ERROR: {result.get('error')}")
             else:
                 page = result.get("data", {})
-                print(f"SUCCESS: Page deleted (HTTP 202 - Processing)")
+                print("SUCCESS: Page deleted (HTTP 202 - Processing)")
                 print(f"ID: {page.get('id')}")
                 print(f"Request ID: {page.get('requestId', 'N/A')}")
 
@@ -664,7 +664,7 @@ async def test_get_table():
                 print(f"ERROR: {result.get('error')}")
             else:
                 table = result.get("data", {})
-                print(f"SUCCESS: Retrieved table")
+                print("SUCCESS: Retrieved table")
                 print(f"Name: {table.get('name')}")
                 print(f"ID: {table.get('id')}")
                 print(f"Type: {table.get('type')}")
@@ -771,7 +771,7 @@ async def test_get_column():
                 print(f"ERROR: {result.get('error')}")
             else:
                 column = result.get("data", {})
-                print(f"SUCCESS: Retrieved column")
+                print("SUCCESS: Retrieved column")
                 print(f"Name: {column.get('name')}")
                 print(f"ID: {column.get('id')}")
                 print(f"Value Type: {column.get('valueType')}")
@@ -864,7 +864,7 @@ async def test_get_row():
                 print(f"ERROR: {result.get('error')}")
             else:
                 row = result.get("data", {})
-                print(f"SUCCESS: Retrieved row")
+                print("SUCCESS: Retrieved row")
                 print(f"ID: {row.get('id')}")
                 print(f"Created: {row.get('createdAt')}")
 
@@ -920,7 +920,7 @@ async def test_upsert_rows():
                 print(f"ERROR: {result.get('error')}")
             else:
                 data = result.get("data", {})
-                print(f"SUCCESS: Rows upserted (HTTP 202 - Processing)")
+                print("SUCCESS: Rows upserted (HTTP 202 - Processing)")
                 print(f"Request ID: {data.get('requestId', 'N/A')}")
 
             return result
@@ -981,7 +981,7 @@ async def test_update_row():
             if not result.get("result"):
                 print(f"ERROR: {result.get('error')}")
             else:
-                print(f"SUCCESS: Row updated (HTTP 202 - Processing)")
+                print("SUCCESS: Row updated (HTTP 202 - Processing)")
 
             return result
         except Exception as e:
@@ -1065,7 +1065,7 @@ async def test_delete_row():
             if not result.get("result"):
                 print(f"ERROR: {result.get('error')}")
             else:
-                print(f"SUCCESS: Row deleted (HTTP 202 - Processing)")
+                print("SUCCESS: Row deleted (HTTP 202 - Processing)")
 
             return result
         except Exception as e:

--- a/fergus/fergus.py
+++ b/fergus/fergus.py
@@ -5,6 +5,7 @@ from autohive_integrations_sdk import (
     ActionHandler,
     ActionResult,
     HTTPError,
+    RateLimitError,
 )
 
 fergus = Integration.load()
@@ -24,6 +25,16 @@ def _success(data: Dict[str, Any]) -> ActionResult:
 
 
 def _error(e: Exception) -> ActionResult:
+    if isinstance(e, RateLimitError):
+        return ActionResult(
+            data={
+                "result": False,
+                "error": e.message,
+                "error_type": "RateLimitError",
+                "status_code": e.status,
+                "response": e.response_data,
+            }
+        )
     if isinstance(e, HTTPError):
         return ActionResult(
             data={

--- a/fergus/requirements.txt
+++ b/fergus/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.1

--- a/fergus/requirements.txt
+++ b/fergus/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.1.1
+autohive-integrations-sdk~=1.0.2


### PR DESCRIPTION
## Summary
- ruff format for coda, fergus, jira
- nosec B105 on hardcoded tokens in coda tests (26 occurrences)
- fergus: added RateLimitError handler in _error() before HTTPError, since RateLimitError is a subclass of HTTPError and must be checked first to be caught correctly (same pattern as typeform)