### PR TITLE
fix(google-looker,google-docs,google-tasks): update to use ActionResult from latest SDK

### DIFF
--- a/google-docs/google_docs.py
+++ b/google-docs/google_docs.py
@@ -24,7 +24,7 @@ class CreateDocument(ActionHandler):
             url = f"{DOCS_API_BASE}/documents"
             payload = {"title": title}
 
-            document = await context.fetch(url, method="POST", json=payload)
+            document = (await context.fetch(url, method="POST", json=payload)).data
 
             document_id = document.get("documentId")
             document_url = f"https://docs.google.com/document/d/{document_id}/edit"
@@ -57,7 +57,7 @@ class GetDocument(ActionHandler):
             if include_tabs:
                 params["includeTabsContent"] = "true"
 
-            document = await context.fetch(url, method="GET", params=params)
+            document = (await context.fetch(url, method="GET", params=params)).data
 
             return ActionResult(data={"document": document, "result": True}, cost_usd=0)
         except Exception as e:
@@ -110,7 +110,7 @@ class InsertParagraphs(ActionHandler):
                 else:
                     params["fields"] = "body/content(endIndex)"
 
-                document = await context.fetch(url, method="GET", params=params)
+                document = (await context.fetch(url, method="GET", params=params)).data
 
                 if tab_id:
                     index = None
@@ -231,7 +231,7 @@ class BatchUpdate(ActionHandler):
             url = f"{DOCS_API_BASE}/documents/{document_id}:batchUpdate"
             payload = {"requests": batch_requests}
 
-            result = await context.fetch(url, method="POST", json=payload)
+            result = (await context.fetch(url, method="POST", json=payload)).data
 
             return ActionResult(data={"replies": result.get("replies", []), "result": True}, cost_usd=0)
         except Exception as e:
@@ -255,7 +255,7 @@ class ParseStructure(ActionHandler):
             if tab_id:
                 params["includeTabsContent"] = "true"
 
-            document = await context.fetch(url, method="GET", params=params)
+            document = (await context.fetch(url, method="GET", params=params)).data
 
             # Get the body content
             if tab_id:
@@ -495,7 +495,7 @@ class InsertMarkdownContent(ActionHandler):
             params["fields"] = "body/content(endIndex)"
 
         try:
-            document = await context.fetch(url, method="GET", params=params)
+            document = (await context.fetch(url, method="GET", params=params)).data
         except Exception:
             return 1  # Default to beginning on error
 

--- a/google-docs/google_docs.py
+++ b/google-docs/google_docs.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List, Optional
 
 google_docs = Integration.load()
@@ -7,9 +7,9 @@ google_docs = Integration.load()
 DOCS_API_BASE = "https://docs.googleapis.com/v1"
 
 
-def handle_api_error(error: Exception, message: str = "Google API error") -> Dict[str, Any]:
+def handle_api_error(error: Exception, message: str = "Google API error") -> ActionResult:
     """Handle API error responses."""
-    return {"result": False, "error": f"{message}: {str(error)}"}
+    return ActionResult(data={"result": False, "error": f"{message}: {str(error)}"}, cost_usd=0)
 
 
 # ---- Action Handlers ----
@@ -29,12 +29,15 @@ class CreateDocument(ActionHandler):
             document_id = document.get("documentId")
             document_url = f"https://docs.google.com/document/d/{document_id}/edit"
 
-            return {
-                "documentId": document_id,
-                "documentUrl": document_url,
-                "title": document.get("title"),
-                "result": True,
-            }
+            return ActionResult(
+                data={
+                    "documentId": document_id,
+                    "documentUrl": document_url,
+                    "title": document.get("title"),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
         except Exception as e:
             return handle_api_error(e, "Failed to create document")
 
@@ -56,11 +59,11 @@ class GetDocument(ActionHandler):
 
             document = await context.fetch(url, method="GET", params=params)
 
-            return {"document": document, "result": True}
+            return ActionResult(data={"document": document, "result": True}, cost_usd=0)
         except Exception as e:
-            error_result = handle_api_error(e, "Failed to get document")
-            error_result["document"] = {}
-            return error_result
+            return ActionResult(
+                data={"document": {}, "result": False, "error": f"Failed to get document: {str(e)}"}, cost_usd=0
+            )
 
 
 @google_docs.action("docs_insert_paragraphs")
@@ -88,10 +91,12 @@ class InsertParagraphs(ActionHandler):
 
             # Validate paragraphs is an array
             if not isinstance(paragraphs, list):
-                return {"result": False, "error": "paragraphs must be an array of strings"}
+                return ActionResult(
+                    data={"result": False, "error": "paragraphs must be an array of strings"}, cost_usd=0
+                )
 
             if not paragraphs:
-                return {"result": False, "error": "paragraphs array is empty"}
+                return ActionResult(data={"result": False, "error": "paragraphs array is empty"}, cost_usd=0)
 
             # Get insertion index
             if append:
@@ -117,7 +122,9 @@ class InsertParagraphs(ActionHandler):
                             index = content[-1].get("endIndex", 1) - 1 if content else 1
                             break
                     if index is None:
-                        return {"result": False, "error": f"Tab with ID {tab_id} not found"}
+                        return ActionResult(
+                            data={"result": False, "error": f"Tab with ID {tab_id} not found"}, cost_usd=0
+                        )
                 else:
                     body = document.get("body", {})
                     content = body.get("content", [])
@@ -146,7 +153,9 @@ class InsertParagraphs(ActionHandler):
 
             await context.fetch(url, method="POST", json=payload)
 
-            return {"result": True, "paragraphs_inserted": len(paragraphs), "inserted_at_index": index}
+            return ActionResult(
+                data={"result": True, "paragraphs_inserted": len(paragraphs), "inserted_at_index": index}, cost_usd=0
+            )
         except Exception as e:
             return handle_api_error(e, "Failed to insert paragraphs")
 
@@ -217,18 +226,18 @@ class BatchUpdate(ActionHandler):
 
             # Validate requests is a list of dicts
             if not isinstance(batch_requests, list) or not all(isinstance(r, dict) for r in batch_requests):
-                return {"result": False, "error": "requests must be an array of objects"}
+                return ActionResult(data={"result": False, "error": "requests must be an array of objects"}, cost_usd=0)
 
             url = f"{DOCS_API_BASE}/documents/{document_id}:batchUpdate"
             payload = {"requests": batch_requests}
 
             result = await context.fetch(url, method="POST", json=payload)
 
-            return {"replies": result.get("replies", []), "result": True}
+            return ActionResult(data={"replies": result.get("replies", []), "result": True}, cost_usd=0)
         except Exception as e:
-            error_result = handle_api_error(e, "Failed to execute batch update")
-            error_result["replies"] = []
-            return error_result
+            return ActionResult(
+                data={"replies": [], "result": False, "error": f"Failed to execute batch update: {str(e)}"}, cost_usd=0
+            )
 
 
 @google_docs.action("docs_parse_structure")
@@ -258,7 +267,7 @@ class ParseStructure(ActionHandler):
                         body = doc_tab.get("body", {})
                         break
                 if body is None:
-                    return {"result": False, "error": f"Tab with ID {tab_id} not found"}
+                    return ActionResult(data={"result": False, "error": f"Tab with ID {tab_id} not found"}, cost_usd=0)
             else:
                 body = document.get("body", {})
 
@@ -310,11 +319,12 @@ class ParseStructure(ActionHandler):
                 elif "sectionBreak" in element:
                     structure.append({"type": "section_break", "startIndex": start_index, "endIndex": end_index})
 
-            return {"structure": structure, "result": True}
+            return ActionResult(data={"structure": structure, "result": True}, cost_usd=0)
         except Exception as e:
-            error_result = handle_api_error(e, "Failed to parse document structure")
-            error_result["structure"] = []
-            return error_result
+            return ActionResult(
+                data={"structure": [], "result": False, "error": f"Failed to parse document structure: {str(e)}"},
+                cost_usd=0,
+            )
 
 
 @google_docs.action("docs_insert_markdown_content")
@@ -346,7 +356,7 @@ class InsertMarkdownContent(ActionHandler):
             elements = self._parse_markdown(content)
 
             if not elements:
-                return {"result": False, "error": "No content found to insert"}
+                return ActionResult(data={"result": False, "error": "No content found to insert"}, cost_usd=0)
 
             # Step 2: Get the insertion index
             insertion_index = await self._get_insertion_index(context, document_id, tab_id, append)
@@ -603,12 +613,15 @@ class InsertMarkdownContent(ActionHandler):
 
             await context.fetch(url, method="POST", json=payload)
 
-            return {
-                "result": True,
-                "headings_inserted": heading_count,
-                "paragraphs_inserted": paragraph_count,
-                "total_elements": len(elements),
-            }
+            return ActionResult(
+                data={
+                    "result": True,
+                    "headings_inserted": heading_count,
+                    "paragraphs_inserted": paragraph_count,
+                    "total_elements": len(elements),
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
             return handle_api_error(e, "Failed to insert and style content")

--- a/google-docs/requirements.txt
+++ b/google-docs/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 requests>=2.31.0

--- a/google-looker/config.json
+++ b/google-looker/config.json
@@ -34,7 +34,20 @@
             "description": "Retrieve a list of all available dashboards in the Looker instance, including dashboard IDs, titles, and metadata",
             "input_schema": {
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "fields": {
+                        "type": "string",
+                        "description": "Comma-separated list of fields to return in the response"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number of results to return (1-based)"
+                    },
+                    "per_page": {
+                        "type": "integer",
+                        "description": "Number of results to return per page"
+                    }
+                },
                 "required": []
             },
             "output_schema": {

--- a/google-looker/google_looker.py
+++ b/google-looker/google_looker.py
@@ -45,12 +45,10 @@ class LookerAPIHelper:
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
 
-            if isinstance(response, dict):
-                token_data = response
-            else:
-                if response.status_code != 200:
-                    raise Exception(f"Authentication failed with status {response.status_code}: {response.text}")
-                token_data = response.json()
+            if response.status != 200:
+                raise Exception(f"Authentication failed with status {response.status}")
+
+            token_data = response.data
 
             self.access_token = token_data.get("access_token")
             expires_in = token_data.get("expires_in", 3600)
@@ -87,13 +85,10 @@ class LookerAPIHelper:
                 headers=headers,
             )
 
-            if isinstance(response, (dict, list)):
-                return response
-            else:
-                if response.status_code not in [200, 201, 202, 204]:
-                    raise Exception(f"API request failed: {response.status_code} - {response.text}")
+            if response.status not in [200, 201, 202, 204]:
+                raise Exception(f"API request failed: {response.status}")
 
-                return response.json() if response.text else {}
+            return response.data or {}
 
         except Exception:
             raise
@@ -132,12 +127,12 @@ class ListDashboards(ActionHandler):
             helper = build_looker_helper(context)
 
             params = {}
-            if "fields" in inputs:
-                params["fields"] = inputs["fields"]
-            if "page" in inputs:
-                params["page"] = inputs["page"]
-            if "per_page" in inputs:
-                params["per_page"] = inputs["per_page"]
+            if inputs.get("fields") is not None:
+                params["fields"] = inputs.get("fields")
+            if inputs.get("page") is not None:
+                params["page"] = inputs.get("page")
+            if inputs.get("per_page") is not None:
+                params["per_page"] = inputs.get("per_page")
 
             dashboards = await helper.make_request("GET", "/dashboards", params=params)
 
@@ -155,8 +150,8 @@ class GetDashboard(ActionHandler):
             dashboard_id = inputs["dashboard_id"]
 
             params = {}
-            if "fields" in inputs:
-                params["fields"] = inputs["fields"]
+            if inputs.get("fields") is not None:
+                params["fields"] = inputs.get("fields")
 
             dashboard = await helper.make_request("GET", f"/dashboards/{dashboard_id}", params=params)
 
@@ -174,16 +169,16 @@ class ExecuteLookMLQuery(ActionHandler):
 
             query_data = {"model": inputs["model"], "explore": inputs["explore"]}
 
-            if "dimensions" in inputs:
-                query_data["dimensions"] = inputs["dimensions"]
-            if "measures" in inputs:
-                query_data["measures"] = inputs["measures"]
-            if "filters" in inputs:
-                query_data["filters"] = inputs["filters"]
-            if "sorts" in inputs:
-                query_data["sorts"] = inputs["sorts"]
-            if "limit" in inputs:
-                query_data["limit"] = inputs["limit"]
+            if inputs.get("dimensions") is not None:
+                query_data["dimensions"] = inputs.get("dimensions")
+            if inputs.get("measures") is not None:
+                query_data["measures"] = inputs.get("measures")
+            if inputs.get("filters") is not None:
+                query_data["filters"] = inputs.get("filters")
+            if inputs.get("sorts") is not None:
+                query_data["sorts"] = inputs.get("sorts")
+            if inputs.get("limit") is not None:
+                query_data["limit"] = inputs.get("limit")
 
             query = await helper.make_request("POST", "/queries", data=query_data)
             query_id = query.get("id")
@@ -193,10 +188,10 @@ class ExecuteLookMLQuery(ActionHandler):
 
             result_format = inputs.get("result_format", "json")
             params = {"result_format": result_format}
-            if "apply_formatting" in inputs:
-                params["apply_formatting"] = inputs["apply_formatting"]
-            if "apply_vis" in inputs:
-                params["apply_vis"] = inputs["apply_vis"]
+            if inputs.get("apply_formatting") is not None:
+                params["apply_formatting"] = inputs.get("apply_formatting")
+            if inputs.get("apply_vis") is not None:
+                params["apply_vis"] = inputs.get("apply_vis")
 
             results = await helper.make_request("GET", f"/queries/{query_id}/run/{result_format}", params=params)
 
@@ -209,10 +204,7 @@ class ExecuteLookMLQuery(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(
-                data={"query_results": "[]", "result": False, "error": str(e)},
-                cost_usd=0,
-            )
+            return ActionResult(data={"query_results": "[]", "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_looker.action("list_models")
@@ -222,8 +214,8 @@ class ListModels(ActionHandler):
             helper = build_looker_helper(context)
 
             params = {}
-            if "fields" in inputs:
-                params["fields"] = inputs["fields"]
+            if inputs.get("fields") is not None:
+                params["fields"] = inputs.get("fields")
 
             models = await helper.make_request("GET", "/lookml_models", params=params)
 
@@ -241,8 +233,8 @@ class GetModel(ActionHandler):
             model_name = inputs["model_name"]
 
             params = {}
-            if "fields" in inputs:
-                params["fields"] = inputs["fields"]
+            if inputs.get("fields") is not None:
+                params["fields"] = inputs.get("fields")
 
             model = await helper.make_request("GET", f"/lookml_models/{model_name}", params=params)
 
@@ -260,17 +252,17 @@ class ExecuteSQLQuery(ActionHandler):
 
             sql_query_data = {"sql": inputs["sql"]}
 
-            if "connection_name" in inputs:
-                sql_query_data["connection_name"] = inputs["connection_name"]
-            elif "model_name" in inputs:
-                sql_query_data["model_name"] = inputs["model_name"]
+            if inputs.get("connection_name") is not None:
+                sql_query_data["connection_name"] = inputs.get("connection_name")
+            elif inputs.get("model_name") is not None:
+                sql_query_data["model_name"] = inputs.get("model_name")
             else:
                 raise ValueError("Either 'connection_name' or 'model_name' must be provided")
 
-            if "vis_config" in inputs:
-                sql_query_data["vis_config"] = inputs["vis_config"]
-            if "slug" in inputs:
-                sql_query_data["slug"] = inputs["slug"]
+            if inputs.get("vis_config") is not None:
+                sql_query_data["vis_config"] = inputs.get("vis_config")
+            if inputs.get("slug") is not None:
+                sql_query_data["slug"] = inputs.get("slug")
 
             sql_query = await helper.make_request("POST", "/sql_queries", data=sql_query_data)
 
@@ -280,8 +272,8 @@ class ExecuteSQLQuery(ActionHandler):
 
             result_format = inputs.get("result_format", "json")
             params = {}
-            if "download" in inputs:
-                params["download"] = inputs["download"]
+            if inputs.get("download") is not None:
+                params["download"] = inputs.get("download")
 
             results = await helper.make_request("POST", f"/sql_queries/{slug}/run/{result_format}", params=params)
 
@@ -295,15 +287,7 @@ class ExecuteSQLQuery(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(
-                data={
-                    "slug": "",
-                    "query_results": "",
-                    "result": False,
-                    "error": str(e),
-                },
-                cost_usd=0,
-            )
+            return ActionResult(data={"slug": "", "query_results": "", "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_looker.action("list_connections")
@@ -313,8 +297,8 @@ class ListConnections(ActionHandler):
             helper = build_looker_helper(context)
 
             params = {}
-            if "fields" in inputs:
-                params["fields"] = inputs["fields"]
+            if inputs.get("fields") is not None:
+                params["fields"] = inputs.get("fields")
 
             connections = await helper.make_request("GET", "/connections", params=params)
 

--- a/google-looker/google_looker.py
+++ b/google-looker/google_looker.py
@@ -1,4 +1,9 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import (
+    Integration,
+    ExecutionContext,
+    ActionHandler,
+    ActionResult,
+)
 from typing import Dict, Any, Optional
 
 import json
@@ -11,7 +16,13 @@ google_looker = Integration.load()
 
 
 class LookerAPIHelper:
-    def __init__(self, context: ExecutionContext, base_url: str, client_id: str, client_secret: str):
+    def __init__(
+        self,
+        context: ExecutionContext,
+        base_url: str,
+        client_id: str,
+        client_secret: str,
+    ):
         self.context = context
         self.base_url = base_url.rstrip("/")
         self.client_id = client_id
@@ -20,7 +31,11 @@ class LookerAPIHelper:
         self.token_expires_at = None
 
     async def _get_access_token(self) -> str:
-        if self.access_token and self.token_expires_at and datetime.now() < self.token_expires_at:
+        if (
+            self.access_token
+            and self.token_expires_at
+            and datetime.now() < self.token_expires_at
+        ):
             return self.access_token
 
         auth_url = f"{self.base_url}/api/4.0/login"
@@ -38,7 +53,9 @@ class LookerAPIHelper:
                 token_data = response
             else:
                 if response.status_code != 200:
-                    raise Exception(f"Authentication failed with status {response.status_code}: {response.text}")
+                    raise Exception(
+                        f"Authentication failed with status {response.status_code}: {response.text}"
+                    )
                 token_data = response.json()
 
             self.access_token = token_data.get("access_token")
@@ -58,7 +75,11 @@ class LookerAPIHelper:
         return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
     async def make_request(
-        self, method: str, endpoint: str, data: Optional[Dict] = None, params: Optional[Dict] = None
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Dict] = None,
+        params: Optional[Dict] = None,
     ) -> Dict[str, Any]:
         url = f"{self.base_url}/api/4.0{endpoint}"
         headers = await self._get_headers()
@@ -76,7 +97,9 @@ class LookerAPIHelper:
                 return response
             else:
                 if response.status_code not in [200, 201, 202, 204]:
-                    raise Exception(f"API request failed: {response.status_code} - {response.text}")
+                    raise Exception(
+                        f"API request failed: {response.status_code} - {response.text}"
+                    )
 
                 return response.json() if response.text else {}
 
@@ -126,10 +149,14 @@ class ListDashboards(ActionHandler):
 
             dashboards = await helper.make_request("GET", "/dashboards", params=params)
 
-            return {"dashboards": dashboards, "result": True}
+            return ActionResult(
+                data={"dashboards": dashboards, "result": True}, cost_usd=0
+            )
 
         except Exception as e:
-            return {"dashboards": [], "result": False, "error": str(e)}
+            return ActionResult(
+                data={"dashboards": [], "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @google_looker.action("get_dashboard")
@@ -143,12 +170,18 @@ class GetDashboard(ActionHandler):
             if "fields" in inputs:
                 params["fields"] = inputs["fields"]
 
-            dashboard = await helper.make_request("GET", f"/dashboards/{dashboard_id}", params=params)
+            dashboard = await helper.make_request(
+                "GET", f"/dashboards/{dashboard_id}", params=params
+            )
 
-            return {"dashboard": dashboard, "result": True}
+            return ActionResult(
+                data={"dashboard": dashboard, "result": True}, cost_usd=0
+            )
 
         except Exception as e:
-            return {"dashboard": {}, "result": False, "error": str(e)}
+            return ActionResult(
+                data={"dashboard": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @google_looker.action("execute_lookml_query")
@@ -183,15 +216,25 @@ class ExecuteLookMLQuery(ActionHandler):
             if "apply_vis" in inputs:
                 params["apply_vis"] = inputs["apply_vis"]
 
-            results = await helper.make_request("GET", f"/queries/{query_id}/run/{result_format}", params=params)
+            results = await helper.make_request(
+                "GET", f"/queries/{query_id}/run/{result_format}", params=params
+            )
 
-            return {
-                "query_results": json.dumps(results) if isinstance(results, (dict, list)) else str(results),
-                "result": True,
-            }
+            return ActionResult(
+                data={
+                    "query_results": json.dumps(results)
+                    if isinstance(results, (dict, list))
+                    else str(results),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return {"query_results": "[]", "result": False, "error": str(e)}
+            return ActionResult(
+                data={"query_results": "[]", "result": False, "error": str(e)},
+                cost_usd=0,
+            )
 
 
 @google_looker.action("list_models")
@@ -206,10 +249,12 @@ class ListModels(ActionHandler):
 
             models = await helper.make_request("GET", "/lookml_models", params=params)
 
-            return {"models": models, "result": True}
+            return ActionResult(data={"models": models, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"models": [], "result": False, "error": str(e)}
+            return ActionResult(
+                data={"models": [], "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @google_looker.action("get_model")
@@ -223,12 +268,16 @@ class GetModel(ActionHandler):
             if "fields" in inputs:
                 params["fields"] = inputs["fields"]
 
-            model = await helper.make_request("GET", f"/lookml_models/{model_name}", params=params)
+            model = await helper.make_request(
+                "GET", f"/lookml_models/{model_name}", params=params
+            )
 
-            return {"model": model, "result": True}
+            return ActionResult(data={"model": model, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"model": {}, "result": False, "error": str(e)}
+            return ActionResult(
+                data={"model": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @google_looker.action("execute_sql_query")
@@ -244,14 +293,18 @@ class ExecuteSQLQuery(ActionHandler):
             elif "model_name" in inputs:
                 sql_query_data["model_name"] = inputs["model_name"]
             else:
-                raise ValueError("Either 'connection_name' or 'model_name' must be provided")
+                raise ValueError(
+                    "Either 'connection_name' or 'model_name' must be provided"
+                )
 
             if "vis_config" in inputs:
                 sql_query_data["vis_config"] = inputs["vis_config"]
             if "slug" in inputs:
                 sql_query_data["slug"] = inputs["slug"]
 
-            sql_query = await helper.make_request("POST", "/sql_queries", data=sql_query_data)
+            sql_query = await helper.make_request(
+                "POST", "/sql_queries", data=sql_query_data
+            )
 
             slug = sql_query.get("slug")
             if not slug:
@@ -262,16 +315,31 @@ class ExecuteSQLQuery(ActionHandler):
             if "download" in inputs:
                 params["download"] = inputs["download"]
 
-            results = await helper.make_request("POST", f"/sql_queries/{slug}/run/{result_format}", params=params)
+            results = await helper.make_request(
+                "POST", f"/sql_queries/{slug}/run/{result_format}", params=params
+            )
 
-            return {
-                "slug": slug,
-                "query_results": json.dumps(results) if isinstance(results, (dict, list)) else str(results),
-                "result": True,
-            }
+            return ActionResult(
+                data={
+                    "slug": slug,
+                    "query_results": json.dumps(results)
+                    if isinstance(results, (dict, list))
+                    else str(results),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return {"slug": "", "query_results": "", "result": False, "error": str(e)}
+            return ActionResult(
+                data={
+                    "slug": "",
+                    "query_results": "",
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0,
+            )
 
 
 @google_looker.action("list_connections")
@@ -284,9 +352,15 @@ class ListConnections(ActionHandler):
             if "fields" in inputs:
                 params["fields"] = inputs["fields"]
 
-            connections = await helper.make_request("GET", "/connections", params=params)
+            connections = await helper.make_request(
+                "GET", "/connections", params=params
+            )
 
-            return {"connections": connections, "result": True}
+            return ActionResult(
+                data={"connections": connections, "result": True}, cost_usd=0
+            )
 
         except Exception as e:
-            return {"connections": [], "result": False, "error": str(e)}
+            return ActionResult(
+                data={"connections": [], "result": False, "error": str(e)}, cost_usd=0
+            )

--- a/google-looker/google_looker.py
+++ b/google-looker/google_looker.py
@@ -31,11 +31,7 @@ class LookerAPIHelper:
         self.token_expires_at = None
 
     async def _get_access_token(self) -> str:
-        if (
-            self.access_token
-            and self.token_expires_at
-            and datetime.now() < self.token_expires_at
-        ):
+        if self.access_token and self.token_expires_at and datetime.now() < self.token_expires_at:
             return self.access_token
 
         auth_url = f"{self.base_url}/api/4.0/login"
@@ -53,9 +49,7 @@ class LookerAPIHelper:
                 token_data = response
             else:
                 if response.status_code != 200:
-                    raise Exception(
-                        f"Authentication failed with status {response.status_code}: {response.text}"
-                    )
+                    raise Exception(f"Authentication failed with status {response.status_code}: {response.text}")
                 token_data = response.json()
 
             self.access_token = token_data.get("access_token")
@@ -97,9 +91,7 @@ class LookerAPIHelper:
                 return response
             else:
                 if response.status_code not in [200, 201, 202, 204]:
-                    raise Exception(
-                        f"API request failed: {response.status_code} - {response.text}"
-                    )
+                    raise Exception(f"API request failed: {response.status_code} - {response.text}")
 
                 return response.json() if response.text else {}
 
@@ -149,14 +141,10 @@ class ListDashboards(ActionHandler):
 
             dashboards = await helper.make_request("GET", "/dashboards", params=params)
 
-            return ActionResult(
-                data={"dashboards": dashboards, "result": True}, cost_usd=0
-            )
+            return ActionResult(data={"dashboards": dashboards, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(
-                data={"dashboards": [], "result": False, "error": str(e)}, cost_usd=0
-            )
+            return ActionResult(data={"dashboards": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_looker.action("get_dashboard")
@@ -170,18 +158,12 @@ class GetDashboard(ActionHandler):
             if "fields" in inputs:
                 params["fields"] = inputs["fields"]
 
-            dashboard = await helper.make_request(
-                "GET", f"/dashboards/{dashboard_id}", params=params
-            )
+            dashboard = await helper.make_request("GET", f"/dashboards/{dashboard_id}", params=params)
 
-            return ActionResult(
-                data={"dashboard": dashboard, "result": True}, cost_usd=0
-            )
+            return ActionResult(data={"dashboard": dashboard, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(
-                data={"dashboard": {}, "result": False, "error": str(e)}, cost_usd=0
-            )
+            return ActionResult(data={"dashboard": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_looker.action("execute_lookml_query")
@@ -216,15 +198,11 @@ class ExecuteLookMLQuery(ActionHandler):
             if "apply_vis" in inputs:
                 params["apply_vis"] = inputs["apply_vis"]
 
-            results = await helper.make_request(
-                "GET", f"/queries/{query_id}/run/{result_format}", params=params
-            )
+            results = await helper.make_request("GET", f"/queries/{query_id}/run/{result_format}", params=params)
 
             return ActionResult(
                 data={
-                    "query_results": json.dumps(results)
-                    if isinstance(results, (dict, list))
-                    else str(results),
+                    "query_results": json.dumps(results) if isinstance(results, (dict, list)) else str(results),
                     "result": True,
                 },
                 cost_usd=0,
@@ -252,9 +230,7 @@ class ListModels(ActionHandler):
             return ActionResult(data={"models": models, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(
-                data={"models": [], "result": False, "error": str(e)}, cost_usd=0
-            )
+            return ActionResult(data={"models": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_looker.action("get_model")
@@ -268,16 +244,12 @@ class GetModel(ActionHandler):
             if "fields" in inputs:
                 params["fields"] = inputs["fields"]
 
-            model = await helper.make_request(
-                "GET", f"/lookml_models/{model_name}", params=params
-            )
+            model = await helper.make_request("GET", f"/lookml_models/{model_name}", params=params)
 
             return ActionResult(data={"model": model, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(
-                data={"model": {}, "result": False, "error": str(e)}, cost_usd=0
-            )
+            return ActionResult(data={"model": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_looker.action("execute_sql_query")
@@ -293,18 +265,14 @@ class ExecuteSQLQuery(ActionHandler):
             elif "model_name" in inputs:
                 sql_query_data["model_name"] = inputs["model_name"]
             else:
-                raise ValueError(
-                    "Either 'connection_name' or 'model_name' must be provided"
-                )
+                raise ValueError("Either 'connection_name' or 'model_name' must be provided")
 
             if "vis_config" in inputs:
                 sql_query_data["vis_config"] = inputs["vis_config"]
             if "slug" in inputs:
                 sql_query_data["slug"] = inputs["slug"]
 
-            sql_query = await helper.make_request(
-                "POST", "/sql_queries", data=sql_query_data
-            )
+            sql_query = await helper.make_request("POST", "/sql_queries", data=sql_query_data)
 
             slug = sql_query.get("slug")
             if not slug:
@@ -315,16 +283,12 @@ class ExecuteSQLQuery(ActionHandler):
             if "download" in inputs:
                 params["download"] = inputs["download"]
 
-            results = await helper.make_request(
-                "POST", f"/sql_queries/{slug}/run/{result_format}", params=params
-            )
+            results = await helper.make_request("POST", f"/sql_queries/{slug}/run/{result_format}", params=params)
 
             return ActionResult(
                 data={
                     "slug": slug,
-                    "query_results": json.dumps(results)
-                    if isinstance(results, (dict, list))
-                    else str(results),
+                    "query_results": json.dumps(results) if isinstance(results, (dict, list)) else str(results),
                     "result": True,
                 },
                 cost_usd=0,
@@ -352,15 +316,9 @@ class ListConnections(ActionHandler):
             if "fields" in inputs:
                 params["fields"] = inputs["fields"]
 
-            connections = await helper.make_request(
-                "GET", "/connections", params=params
-            )
+            connections = await helper.make_request("GET", "/connections", params=params)
 
-            return ActionResult(
-                data={"connections": connections, "result": True}, cost_usd=0
-            )
+            return ActionResult(data={"connections": connections, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(
-                data={"connections": [], "result": False, "error": str(e)}, cost_usd=0
-            )
+            return ActionResult(data={"connections": [], "result": False, "error": str(e)}, cost_usd=0)

--- a/google-looker/requirements.txt
+++ b/google-looker/requirements.txt
@@ -1,1 +1,2 @@
 autohive-integrations-sdk~=1.0.2
+

--- a/google-looker/requirements.txt
+++ b/google-looker/requirements.txt
@@ -1,2 +1,1 @@
-autohive-integrations-sdk~=1.0.2
-
+autohive-integrations-sdk~=2.0.0

--- a/google-looker/tests/context.py
+++ b/google-looker/tests/context.py
@@ -3,6 +3,4 @@ import sys
 import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))

--- a/google-looker/tests/context.py
+++ b/google-looker/tests/context.py
@@ -3,6 +3,6 @@ import sys
 import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))
-
-from google_looker import google_looker
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+)

--- a/google-looker/tests/test_google_looker_integration.py
+++ b/google-looker/tests/test_google_looker_integration.py
@@ -29,7 +29,10 @@ class MockExecutionContext:
     ):
         # Route by endpoint suffix for simplicity
         if "/api/4.0/login" in url and method == "POST":
-            return self._responses.get("POST /login", {"access_token": "mock_token_123", "expires_in": 3600})  # nosec B105
+            return self._responses.get(
+                "POST /login",
+                {"access_token": "mock_token_123", "expires_in": 3600},  # nosec B105
+            )
         if "/api/4.0/dashboards/" in url and method == "GET":
             return self._responses.get("GET /dashboard", {"dashboard": {}})
         if "/api/4.0/dashboards" in url and method == "GET":
@@ -82,11 +85,15 @@ async def test_get_dashboard():
             "id": "123",
             "title": "Test Dashboard",
             "description": "A test dashboard",
-            "dashboard_elements": [{"id": "elem1", "type": "looker_line", "query": {"id": "query1"}}],
+            "dashboard_elements": [
+                {"id": "elem1", "type": "looker_line", "query": {"id": "query1"}}
+            ],
         }
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("get_dashboard", {"dashboard_id": "123"}, context)
+    result = await google_looker.execute_action(
+        "get_dashboard", {"dashboard_id": "123"}, context
+    )
     assert result["result"] is True
     assert result["dashboard"]["id"] == "123"
     assert result["dashboard"]["title"] == "Test Dashboard"
@@ -95,7 +102,10 @@ async def test_get_dashboard():
 async def test_execute_lookml_query():
     responses = {
         "POST /queries": {"id": "query_456"},
-        "GET /query_results": [{"dimension1": "value1", "measure1": 100}, {"dimension1": "value2", "measure1": 200}],
+        "GET /query_results": [
+            {"dimension1": "value1", "measure1": 100},
+            {"dimension1": "value2", "measure1": 200},
+        ],
     }
     context = MockExecutionContext(responses)
     result = await google_looker.execute_action(
@@ -119,8 +129,16 @@ async def test_execute_lookml_query():
 async def test_list_models():
     responses = {
         "GET /models": [
-            {"name": "sales", "label": "Sales Model", "explores": ["orders", "customers"]},
-            {"name": "marketing", "label": "Marketing Model", "explores": ["campaigns"]},
+            {
+                "name": "sales",
+                "label": "Sales Model",
+                "explores": ["orders", "customers"],
+            },
+            {
+                "name": "marketing",
+                "label": "Marketing Model",
+                "explores": ["campaigns"],
+            },
         ]
     }
     context = MockExecutionContext(responses)
@@ -135,11 +153,16 @@ async def test_get_model():
         "GET /model": {
             "name": "sales",
             "label": "Sales Model",
-            "explores": [{"name": "orders", "label": "Orders"}, {"name": "customers", "label": "Customers"}],
+            "explores": [
+                {"name": "orders", "label": "Orders"},
+                {"name": "customers", "label": "Customers"},
+            ],
         }
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("get_model", {"model_name": "sales"}, context)
+    result = await google_looker.execute_action(
+        "get_model", {"model_name": "sales"}, context
+    )
     assert result["result"] is True
     assert result["model"]["name"] == "sales"
     assert len(result["model"]["explores"]) == 2
@@ -155,7 +178,9 @@ async def test_execute_sql_query():
     }
     context = MockExecutionContext(responses)
     result = await google_looker.execute_action(
-        "execute_sql_query", {"sql": "SELECT * FROM orders LIMIT 10", "connection_name": "warehouse"}, context
+        "execute_sql_query",
+        {"sql": "SELECT * FROM orders LIMIT 10", "connection_name": "warehouse"},
+        context,
     )
     assert result["result"] is True
     assert result["slug"] == "sql_789"
@@ -209,7 +234,9 @@ async def test_execute_lookml_query_missing_required_fields():
     context = MockExecutionContext({})
     # Missing required model and explore fields - should raise ValidationError
     try:
-        await google_looker.execute_action("execute_lookml_query", {"dimensions": ["orders.status"]}, context)
+        await google_looker.execute_action(
+            "execute_lookml_query", {"dimensions": ["orders.status"]}, context
+        )
         assert False, "Should have raised ValidationError"
     except Exception as e:
         assert "required" in str(e).lower()
@@ -219,7 +246,9 @@ async def test_execute_lookml_query_missing_required_fields():
 async def test_execute_sql_query_missing_connection():
     context = MockExecutionContext({})
     # Missing both connection_name and model_name
-    result = await google_looker.execute_action("execute_sql_query", {"sql": "SELECT * FROM orders"}, context)
+    result = await google_looker.execute_action(
+        "execute_sql_query", {"sql": "SELECT * FROM orders"}, context
+    )
     assert result["result"] is False
     assert "error" in result
     assert "connection_name" in result["error"] or "model_name" in result["error"]

--- a/google-looker/tests/test_google_looker_integration.py
+++ b/google-looker/tests/test_google_looker_integration.py
@@ -85,15 +85,11 @@ async def test_get_dashboard():
             "id": "123",
             "title": "Test Dashboard",
             "description": "A test dashboard",
-            "dashboard_elements": [
-                {"id": "elem1", "type": "looker_line", "query": {"id": "query1"}}
-            ],
+            "dashboard_elements": [{"id": "elem1", "type": "looker_line", "query": {"id": "query1"}}],
         }
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action(
-        "get_dashboard", {"dashboard_id": "123"}, context
-    )
+    result = await google_looker.execute_action("get_dashboard", {"dashboard_id": "123"}, context)
     assert result["result"] is True
     assert result["dashboard"]["id"] == "123"
     assert result["dashboard"]["title"] == "Test Dashboard"
@@ -160,9 +156,7 @@ async def test_get_model():
         }
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action(
-        "get_model", {"model_name": "sales"}, context
-    )
+    result = await google_looker.execute_action("get_model", {"model_name": "sales"}, context)
     assert result["result"] is True
     assert result["model"]["name"] == "sales"
     assert len(result["model"]["explores"]) == 2
@@ -234,9 +228,7 @@ async def test_execute_lookml_query_missing_required_fields():
     context = MockExecutionContext({})
     # Missing required model and explore fields - should raise ValidationError
     try:
-        await google_looker.execute_action(
-            "execute_lookml_query", {"dimensions": ["orders.status"]}, context
-        )
+        await google_looker.execute_action("execute_lookml_query", {"dimensions": ["orders.status"]}, context)
         assert False, "Should have raised ValidationError"
     except Exception as e:
         assert "required" in str(e).lower()
@@ -246,9 +238,7 @@ async def test_execute_lookml_query_missing_required_fields():
 async def test_execute_sql_query_missing_connection():
     context = MockExecutionContext({})
     # Missing both connection_name and model_name
-    result = await google_looker.execute_action(
-        "execute_sql_query", {"sql": "SELECT * FROM orders"}, context
-    )
+    result = await google_looker.execute_action("execute_sql_query", {"sql": "SELECT * FROM orders"}, context)
     assert result["result"] is False
     assert "error" in result
     assert "connection_name" in result["error"] or "model_name" in result["error"]

--- a/google-tasks/google_tasks.py
+++ b/google-tasks/google_tasks.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -36,15 +36,15 @@ class ListTasklistsAction(ActionHandler):
             )
 
             tasklists = response.get("items", [])
-            result = {"tasklists": tasklists, "result": True}
+            data = {"tasklists": tasklists, "result": True}
 
             if "nextPageToken" in response:
-                result["nextPageToken"] = response["nextPageToken"]
+                data["nextPageToken"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=data, cost_usd=0)
 
         except Exception as e:
-            return {"tasklists": [], "result": False, "error": str(e)}
+            return ActionResult(data={"tasklists": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_tasks.action("get_tasklist")
@@ -57,10 +57,10 @@ class GetTasklistAction(ActionHandler):
 
             response = await context.fetch(f"{GOOGLE_TASKS_API_BASE_URL}/users/@me/lists/{tasklist_id}", method="GET")
 
-            return {"tasklist": response, "result": True}
+            return ActionResult(data={"tasklist": response, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"tasklist": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"tasklist": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Task Handlers ----
@@ -98,10 +98,10 @@ class CreateTaskAction(ActionHandler):
                 json=body,
             )
 
-            return {"task": response, "result": True}
+            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"task": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_tasks.action("list_tasks")
@@ -131,15 +131,15 @@ class ListTasksAction(ActionHandler):
             )
 
             tasks = response.get("items", [])
-            result = {"tasks": tasks, "result": True}
+            data = {"tasks": tasks, "result": True}
 
             if "nextPageToken" in response:
-                result["nextPageToken"] = response["nextPageToken"]
+                data["nextPageToken"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=data, cost_usd=0)
 
         except Exception as e:
-            return {"tasks": [], "result": False, "error": str(e)}
+            return ActionResult(data={"tasks": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_tasks.action("get_task")
@@ -155,10 +155,10 @@ class GetTaskAction(ActionHandler):
                 f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="GET"
             )
 
-            return {"task": response, "result": True}
+            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"task": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_tasks.action("update_task")
@@ -202,10 +202,10 @@ class UpdateTaskAction(ActionHandler):
                 f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="PUT", json=body
             )
 
-            return {"task": response, "result": True}
+            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"task": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_tasks.action("delete_task")
@@ -219,10 +219,10 @@ class DeleteTaskAction(ActionHandler):
 
             await context.fetch(f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="DELETE")
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_tasks.action("move_task")
@@ -247,7 +247,7 @@ class MoveTaskAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return {"task": response, "result": True}
+            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"task": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)

--- a/google-tasks/google_tasks.py
+++ b/google-tasks/google_tasks.py
@@ -26,14 +26,16 @@ class ListTasklistsAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             params = {}
-            if "maxResults" in inputs:
-                params["maxResults"] = inputs["maxResults"]
-            if "pageToken" in inputs:
-                params["pageToken"] = inputs["pageToken"]
+            if inputs.get("maxResults") is not None:
+                params["maxResults"] = inputs.get("maxResults")
+            if inputs.get("pageToken") is not None:
+                params["pageToken"] = inputs.get("pageToken")
 
-            response = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/users/@me/lists", method="GET", params=params if params else None
-            )
+            response = (
+                await context.fetch(
+                    f"{GOOGLE_TASKS_API_BASE_URL}/users/@me/lists", method="GET", params=params if params else None
+                )
+            ).data
 
             tasklists = response.get("items", [])
             data = {"tasklists": tasklists, "result": True}
@@ -55,9 +57,11 @@ class GetTasklistAction(ActionHandler):
         try:
             tasklist_id = inputs["tasklist"]
 
-            response = await context.fetch(f"{GOOGLE_TASKS_API_BASE_URL}/users/@me/lists/{tasklist_id}", method="GET")
+            tasklist = (
+                await context.fetch(f"{GOOGLE_TASKS_API_BASE_URL}/users/@me/lists/{tasklist_id}", method="GET")
+            ).data
 
-            return ActionResult(data={"tasklist": response, "result": True}, cost_usd=0)
+            return ActionResult(data={"tasklist": tasklist, "result": True}, cost_usd=0)
 
         except Exception as e:
             return ActionResult(data={"tasklist": {}, "result": False, "error": str(e)}, cost_usd=0)
@@ -77,28 +81,30 @@ class CreateTaskAction(ActionHandler):
             # Build task body
             body = {"title": inputs["title"]}
 
-            if "notes" in inputs and inputs["notes"]:
-                body["notes"] = inputs["notes"]
-            if "due" in inputs and inputs["due"]:
-                body["due"] = inputs["due"]
-            if "status" in inputs and inputs["status"]:
-                body["status"] = inputs["status"]
+            if inputs.get("notes"):
+                body["notes"] = inputs.get("notes")
+            if inputs.get("due"):
+                body["due"] = inputs.get("due")
+            if inputs.get("status"):
+                body["status"] = inputs.get("status")
 
             # Build query params for positioning
             params = {}
-            if "parent" in inputs and inputs["parent"]:
-                params["parent"] = inputs["parent"]
-            if "previous" in inputs and inputs["previous"]:
-                params["previous"] = inputs["previous"]
+            if inputs.get("parent"):
+                params["parent"] = inputs.get("parent")
+            if inputs.get("previous"):
+                params["previous"] = inputs.get("previous")
 
-            response = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks",
-                method="POST",
-                params=params if params else None,
-                json=body,
-            )
+            task = (
+                await context.fetch(
+                    f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks",
+                    method="POST",
+                    params=params if params else None,
+                    json=body,
+                )
+            ).data
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
+            return ActionResult(data={"task": task, "result": True}, cost_usd=0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)
@@ -113,22 +119,24 @@ class ListTasksAction(ActionHandler):
             tasklist_id = inputs["tasklist"]
 
             params = {}
-            if "maxResults" in inputs:
-                params["maxResults"] = inputs["maxResults"]
-            if "pageToken" in inputs:
-                params["pageToken"] = inputs["pageToken"]
-            if "showCompleted" in inputs and inputs["showCompleted"] is not None:
-                params["showCompleted"] = str(inputs["showCompleted"]).lower()
-            if "showHidden" in inputs and inputs["showHidden"] is not None:
-                params["showHidden"] = str(inputs["showHidden"]).lower()
-            if "dueMin" in inputs:
-                params["dueMin"] = inputs["dueMin"]
-            if "dueMax" in inputs:
-                params["dueMax"] = inputs["dueMax"]
+            if inputs.get("maxResults") is not None:
+                params["maxResults"] = inputs.get("maxResults")
+            if inputs.get("pageToken") is not None:
+                params["pageToken"] = inputs.get("pageToken")
+            if inputs.get("showCompleted") is not None:
+                params["showCompleted"] = str(inputs.get("showCompleted")).lower()
+            if inputs.get("showHidden") is not None:
+                params["showHidden"] = str(inputs.get("showHidden")).lower()
+            if inputs.get("dueMin") is not None:
+                params["dueMin"] = inputs.get("dueMin")
+            if inputs.get("dueMax") is not None:
+                params["dueMax"] = inputs.get("dueMax")
 
-            response = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks", method="GET", params=params
-            )
+            response = (
+                await context.fetch(
+                    f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks", method="GET", params=params
+                )
+            ).data
 
             tasks = response.get("items", [])
             data = {"tasks": tasks, "result": True}
@@ -151,11 +159,11 @@ class GetTaskAction(ActionHandler):
             tasklist_id = inputs["tasklist"]
             task_id = inputs["task"]
 
-            response = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="GET"
-            )
+            task = (
+                await context.fetch(f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="GET")
+            ).data
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
+            return ActionResult(data={"task": task, "result": True}, cost_usd=0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)
@@ -171,9 +179,9 @@ class UpdateTaskAction(ActionHandler):
             task_id = inputs["task"]
 
             # First, fetch the existing task to preserve unmodified fields
-            existing_task = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="GET"
-            )
+            existing_task = (
+                await context.fetch(f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="GET")
+            ).data
 
             # Build update body starting with existing task data
             # NOTE: Google Tasks API requires 'id' in the body even though it's in the URL
@@ -189,20 +197,22 @@ class UpdateTaskAction(ActionHandler):
                 body["due"] = existing_task["due"]
 
             # Override with any provided fields
-            if "title" in inputs and inputs["title"]:
-                body["title"] = inputs["title"]
-            if "notes" in inputs and inputs["notes"] is not None:
-                body["notes"] = inputs["notes"]
+            if inputs.get("title"):
+                body["title"] = inputs.get("title")
+            if inputs.get("notes") is not None:
+                body["notes"] = inputs.get("notes")
             if "due" in inputs:
-                body["due"] = inputs["due"]
-            if "status" in inputs and inputs["status"]:
-                body["status"] = inputs["status"]
+                body["due"] = inputs.get("due")
+            if inputs.get("status"):
+                body["status"] = inputs.get("status")
 
-            response = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="PUT", json=body
-            )
+            task = (
+                await context.fetch(
+                    f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}", method="PUT", json=body
+                )
+            ).data
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
+            return ActionResult(data={"task": task, "result": True}, cost_usd=0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)
@@ -236,18 +246,20 @@ class MoveTaskAction(ActionHandler):
 
             # Build query params
             params = {}
-            if "parent" in inputs and inputs["parent"]:
-                params["parent"] = inputs["parent"]
-            if "previous" in inputs and inputs["previous"]:
-                params["previous"] = inputs["previous"]
+            if inputs.get("parent"):
+                params["parent"] = inputs.get("parent")
+            if inputs.get("previous"):
+                params["previous"] = inputs.get("previous")
 
-            response = await context.fetch(
-                f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}/move",
-                method="POST",
-                params=params if params else None,
-            )
+            task = (
+                await context.fetch(
+                    f"{GOOGLE_TASKS_API_BASE_URL}/lists/{tasklist_id}/tasks/{task_id}/move",
+                    method="POST",
+                    params=params if params else None,
+                )
+            ).data
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0)
+            return ActionResult(data={"task": task, "result": True}, cost_usd=0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0)

--- a/google-tasks/requirements.txt
+++ b/google-tasks/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0


### PR DESCRIPTION
## Summary

Updates three Google integrations to use the latest `autohive-integrations-sdk` patterns. All action handlers now return `ActionResult(data={...}, cost_usd=0)` instead of plain dicts, consistent with other recently updated integrations.

## Changes

### google-looker
- Imported `ActionResult` from `autohive_integrations_sdk`
- Updated all 7 action handlers to return `ActionResult`:
  `list_dashboards`, `get_dashboard`, `execute_lookml_query`, `list_models`, `get_model`, `execute_sql_query`, `list_connections`
- Added missing `fields`, `page`, `per_page` to `list_dashboards` input schema
- Applied ruff formatting (line-length 120)

### google-docs
- Imported `ActionResult` from `autohive_integrations_sdk`
- Updated all action handlers and the shared `handle_api_error` helper to return `ActionResult`:
  `docs_create`, `docs_get`, `docs_insert_paragraphs`, `docs_batch_update`, `docs_parse_structure`, `docs_insert_markdown_content`

### google-tasks
- Imported `ActionResult` from `autohive_integrations_sdk`
- Updated all 7 action handlers to return `ActionResult`:
  `list_tasklists`, `get_tasklist`, `create_task`, `list_tasks`, `get_task`, `update_task`, `delete_task`, `move_task`

## Validation

- [x] `validate_integration.py` — passed (all 3)
- [x] `check_code.py` — passed (all 3)
- [x] Linting (`ruff`) — clean
- [x] Fetch patterns — OK