### PR TITLE
chore: update integration tooling to 2.0.0

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@1.0.3
+        uses: autohive-ai/autohive-integrations-tooling@2.0.0
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Updates `autohive-integrations-tooling` from `1.0.3` to `2.0.0` to support the latest Integrations SDK version.

Closes #236