### PR TITLE
fix(reddit): update to use ActionResult and SDK 2.0.0

### DIFF
--- a/reddit/reddit.py
+++ b/reddit/reddit.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -30,9 +30,9 @@ class SearchSubredditAction(ActionHandler):
                 params["t"] = time_filter
 
         try:
-            response = await context.fetch(
-                url, method="GET", params=params, headers={"User-Agent": "AutohiveIntegration/1.0"}
-            )
+            response = (
+                await context.fetch(url, method="GET", params=params, headers={"User-Agent": "AutohiveIntegration/1.0"})
+            ).data
 
             posts = []
             if "data" in response and "children" in response["data"]:
@@ -52,10 +52,10 @@ class SearchSubredditAction(ActionHandler):
                         }
                     )
 
-            return {"posts": posts}
+            return ActionResult(data={"posts": posts, "result": True}, cost_usd=0)
 
         except Exception as e:
-            raise Exception(f"Failed to search subreddit: {str(e)}")
+            return ActionResult(data={"posts": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @reddit.action("post_comment")
@@ -65,12 +65,17 @@ class PostCommentAction(ActionHandler):
         text = inputs["text"]
 
         try:
-            response = await context.fetch(
-                "https://oauth.reddit.com/api/comment",
-                method="POST",
-                data={"parent": parent_id, "text": text, "api_type": "json"},
-                headers={"User-Agent": "AutohiveIntegration/1.0", "Content-Type": "application/x-www-form-urlencoded"},
-            )
+            response = (
+                await context.fetch(
+                    "https://oauth.reddit.com/api/comment",
+                    method="POST",
+                    data={"parent": parent_id, "text": text, "api_type": "json"},
+                    headers={
+                        "User-Agent": "AutohiveIntegration/1.0",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                )
+            ).data
 
             if response.get("json", {}).get("errors"):
                 errors = response["json"]["errors"]
@@ -78,11 +83,14 @@ class PostCommentAction(ActionHandler):
 
             comment_data = response["json"]["data"]["things"][0]["data"]
 
-            return {
-                "comment_id": comment_data["id"],
-                "permalink": f"https://reddit.com{comment_data['permalink']}",
-                "success": True,
-            }
+            return ActionResult(
+                data={
+                    "comment_id": comment_data["id"],
+                    "permalink": f"https://reddit.com{comment_data['permalink']}",
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return {"comment_id": "", "permalink": "", "success": False, "error": str(e)}
+            return ActionResult(data={"comment_id": "", "permalink": "", "result": False, "error": str(e)}, cost_usd=0)

--- a/reddit/reddit.py
+++ b/reddit/reddit.py
@@ -87,10 +87,10 @@ class PostCommentAction(ActionHandler):
                 data={
                     "comment_id": comment_data["id"],
                     "permalink": f"https://reddit.com{comment_data['permalink']}",
-                    "result": True,
+                    "success": True,
                 },
                 cost_usd=0,
             )
 
         except Exception as e:
-            return ActionResult(data={"comment_id": "", "permalink": "", "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(data={"comment_id": "", "permalink": "", "success": False, "error": str(e)}, cost_usd=0)

--- a/reddit/requirements.txt
+++ b/reddit/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0


### PR DESCRIPTION
## Summary

Updates the Reddit integration to match current SDK patterns used across other integrations.

## Changes

- Imported `ActionResult` from `autohive_integrations_sdk`
- Updated both action handlers to return `ActionResult(data={...}, cost_usd=0)`
- Updated `context.fetch()` response access to use `.data` (SDK 2.0.0 pattern)
- Bumped SDK version to `~=2.0.0` in `requirements.txt`
- Added `result` field to `search_subreddit` output for consistency

## Actions

| Action | Change |
|--------|--------|
| `search_subreddit` | Returns `ActionResult`, uses `response.data` |
| `post_comment` | Returns `ActionResult`, uses `response.data` |

## Validation

- [x] Linting (`ruff`) — clean
- [x] Formatting (`ruff format`) — clean