### PR TITLE
fix(spreadsheet-tools): add ActionResult and bump SDK to 2.0.0

### DIFF
--- a/spreadsheet-tools/requirements.txt
+++ b/spreadsheet-tools/requirements.txt
@@ -1,3 +1,3 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 openpyxl>=3.0.0
 xlrd>=2.0.0

--- a/spreadsheet-tools/spreadsheet_tools.py
+++ b/spreadsheet-tools/spreadsheet_tools.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 import base64
 import io
@@ -213,4 +213,7 @@ class ConvertToJsonAction(ActionHandler):
         base_name = file_name.rsplit(".", 1)[0] if "." in file_name else file_name
         output_filename = f"{base_name}.json"
 
-        return {"file": {"content": content_b64, "name": output_filename, "contentType": "application/json"}}
+        return ActionResult(
+            data={"file": {"content": content_b64, "name": output_filename, "contentType": "application/json"}},
+            cost_usd=0,
+        )


### PR DESCRIPTION
## Summary

Updates the Spreadsheet Tools integration to use the latest SDK 2.0 patterns. Wraps the action return value in `ActionResult(data={...}, cost_usd=0)` and bumps the SDK dependency from `~=1.0.2` to `~=2.0.0`.

## Changes

- `spreadsheet_tools.py` — imported `ActionResult`, wrapped `convert_to_json` return in `ActionResult`
- `requirements.txt` — bumped `autohive-integrations-sdk` to `~=2.0.0`

## Actions

| Action | Description |
|--------|-------------|
| `convert_to_json` | Converts CSV or Excel (.xlsx, .xls) files to JSON format |

## Validation

- [x] Linting (`ruff`) — clean