### PR TITLE
chore: migrate shopify through zoom to SDK 2.0.0

### DIFF
--- a/shopify-admin/requirements.txt
+++ b/shopify-admin/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.8.0
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/shopify-admin/shopify_admin.py
+++ b/shopify-admin/shopify_admin.py
@@ -127,11 +127,11 @@ async def execute_graphql(context: ExecutionContext, query: str, variables: dict
     response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
     # Check for GraphQL errors
-    if "errors" in response:
-        error_messages = [e.get("message", str(e)) for e in response["errors"]]
+    if "errors" in response.data:
+        error_messages = [e.get("message", str(e)) for e in response.data["errors"]]
         raise Exception(f"GraphQL Error: {'; '.join(error_messages)}")
 
-    return response.get("data", {})
+    return response.data.get("data", {})
 
 
 def escape_graphql_query_value(value: str) -> str:
@@ -460,7 +460,7 @@ class ListCustomersHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params, headers=headers)
 
-            customers = response.get("customers", [])
+            customers = response.data.get("customers", [])
             return success_response(customers=customers, count=len(customers))
         except Exception as e:
             return error_response(e, customers=[], count=0)
@@ -478,7 +478,7 @@ class GetCustomerHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return success_response(customer=response.get("customer", {}))
+            return success_response(customer=response.data.get("customer", {}))
         except Exception as e:
             return error_response(e, customer=None)
 
@@ -500,7 +500,7 @@ class SearchCustomersHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params, headers=headers)
 
-            customers = response.get("customers", [])
+            customers = response.data.get("customers", [])
             return success_response(customers=customers, count=len(customers))
         except Exception as e:
             return error_response(e, customers=[], count=0)
@@ -538,7 +538,7 @@ class CreateCustomerHandler(ActionHandler):
             payload = {"customer": customer_data}
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-            return success_response(customer=response.get("customer", {}))
+            return success_response(customer=response.data.get("customer", {}))
         except Exception as e:
             return error_response(e, customer=None)
 
@@ -571,7 +571,7 @@ class UpdateCustomerHandler(ActionHandler):
             payload = {"customer": customer_data}
             response = await context.fetch(url, method="PUT", json=payload, headers=headers)
 
-            return success_response(customer=response.get("customer", {}))
+            return success_response(customer=response.data.get("customer", {}))
         except Exception as e:
             return error_response(e, customer=None)
 
@@ -608,7 +608,7 @@ class ListOrdersHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params, headers=headers)
 
-            orders = response.get("orders", [])
+            orders = response.data.get("orders", [])
             return success_response(orders=orders, count=len(orders))
         except Exception as e:
             return error_response(e, orders=[], count=0)
@@ -626,7 +626,7 @@ class GetOrderHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return success_response(order=response.get("order", {}))
+            return success_response(order=response.data.get("order", {}))
         except Exception as e:
             return error_response(e, order=None)
 
@@ -665,7 +665,7 @@ class CreateOrderHandler(ActionHandler):
             payload = {"order": order_data}
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-            return success_response(order=response.get("order", {}))
+            return success_response(order=response.data.get("order", {}))
         except Exception as e:
             return error_response(e, order=None)
 
@@ -690,7 +690,7 @@ class CancelOrderHandler(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=cancel_data, headers=headers)
 
-            return success_response(order=response.get("order", {}))
+            return success_response(order=response.data.get("order", {}))
         except Exception as e:
             return error_response(e, order=None)
 
@@ -941,7 +941,7 @@ class GetInventoryLevelsHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params, headers=headers)
 
-            inventory_levels = response.get("inventory_levels", [])
+            inventory_levels = response.data.get("inventory_levels", [])
             return success_response(inventory_levels=inventory_levels, count=len(inventory_levels))
         except Exception as e:
             return error_response(e, inventory_levels=[], count=0)
@@ -964,7 +964,7 @@ class SetInventoryLevelHandler(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-            return success_response(inventory_level=response.get("inventory_level", {}))
+            return success_response(inventory_level=response.data.get("inventory_level", {}))
         except Exception as e:
             return error_response(e, inventory_level=None)
 
@@ -985,7 +985,7 @@ class ListLocationsHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", headers=headers)
 
-            locations = response.get("locations", [])
+            locations = response.data.get("locations", [])
             return success_response(locations=locations, count=len(locations))
         except Exception as e:
             return error_response(e, locations=[], count=0)
@@ -1003,7 +1003,7 @@ class GetLocationHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return success_response(location=response.get("location", {}))
+            return success_response(location=response.data.get("location", {}))
         except Exception as e:
             return error_response(e, location=None)
 
@@ -1024,7 +1024,7 @@ class GetShopHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return success_response(shop=response.get("shop", {}))
+            return success_response(shop=response.data.get("shop", {}))
         except Exception as e:
             return error_response(e, shop=None)
 
@@ -1051,7 +1051,7 @@ class ListDraftOrdersHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params, headers=headers)
 
-            draft_orders = response.get("draft_orders", [])
+            draft_orders = response.data.get("draft_orders", [])
             return success_response(draft_orders=draft_orders, count=len(draft_orders))
         except Exception as e:
             return error_response(e, draft_orders=[], count=0)
@@ -1088,7 +1088,7 @@ class CreateDraftOrderHandler(ActionHandler):
             payload = {"draft_order": draft_order_data}
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-            return success_response(draft_order=response.get("draft_order", {}))
+            return success_response(draft_order=response.data.get("draft_order", {}))
         except Exception as e:
             return error_response(e, draft_order=None)
 
@@ -1109,7 +1109,7 @@ class CompleteDraftOrderHandler(ActionHandler):
 
             response = await context.fetch(url, method="PUT", params=params, headers=headers)
 
-            return success_response(draft_order=response.get("draft_order", {}))
+            return success_response(draft_order=response.data.get("draft_order", {}))
         except Exception as e:
             return error_response(e, draft_order=None)
 
@@ -1148,7 +1148,7 @@ class ListFulfillmentsHandler(ActionHandler):
 
             response = await context.fetch(url, method="GET", headers=headers)
 
-            fulfillments = response.get("fulfillments", [])
+            fulfillments = response.data.get("fulfillments", [])
             return success_response(fulfillments=fulfillments, count=len(fulfillments))
         except Exception as e:
             return error_response(e, fulfillments=[], count=0)
@@ -1181,7 +1181,7 @@ class CreateFulfillmentHandler(ActionHandler):
             payload = {"fulfillment": fulfillment_data}
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-            return success_response(fulfillment=response.get("fulfillment", {}))
+            return success_response(fulfillment=response.data.get("fulfillment", {}))
         except Exception as e:
             return error_response(e, fulfillment=None)
 
@@ -1213,6 +1213,6 @@ class UpdateFulfillmentTrackingHandler(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-            return success_response(fulfillment=response.get("fulfillment", {}))
+            return success_response(fulfillment=response.data.get("fulfillment", {}))
         except Exception as e:
             return error_response(e, fulfillment=None)

--- a/shopify-customer/requirements.txt
+++ b/shopify-customer/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/shopify-customer/shopify_customer.py
+++ b/shopify-customer/shopify_customer.py
@@ -90,18 +90,8 @@ async def execute_graphql(context: ExecutionContext, query: str, variables: Dict
 
     response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-    # Handle response - context.fetch may return dict directly or response object
-    if hasattr(response, "json"):
-        # Response object - need to parse JSON
-        if callable(response.json):
-            import asyncio
-
-            if asyncio.iscoroutinefunction(response.json):
-                return await response.json()
-            return response.json()
-
-    # Already a dict (some SDK versions return parsed JSON directly)
-    return response
+    # SDK 2.0: response.data contains the parsed JSON body
+    return response.data
 
 
 def success_response(**kwargs) -> ActionResult:
@@ -836,26 +826,16 @@ class ExchangeCodeHandler(ActionHandler):
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
 
-            # Handle response object if needed
-            if hasattr(response, "json"):
-                if callable(response.json):
-                    import asyncio
-
-                    if asyncio.iscoroutinefunction(response.json):
-                        response = await response.json()
-                    else:
-                        response = response.json()
-
-            if "error" in response:
-                return error_response(response.get("error_description", response["error"]))
+            if "error" in response.data:
+                return error_response(response.data.get("error_description", response.data["error"]))
 
             return success_response(
-                access_token=response.get("access_token"),
-                refresh_token=response.get("refresh_token"),
-                id_token=response.get("id_token"),
-                token_type=response.get("token_type"),
-                expires_in=response.get("expires_in"),
-                scope=response.get("scope"),
+                access_token=response.data.get("access_token"),
+                refresh_token=response.data.get("refresh_token"),
+                id_token=response.data.get("id_token"),
+                token_type=response.data.get("token_type"),
+                expires_in=response.data.get("expires_in"),
+                scope=response.data.get("scope"),
             )
         except Exception as e:
             return error_response(e)
@@ -891,24 +871,14 @@ class RefreshTokenHandler(ActionHandler):
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
 
-            # Handle response object if needed
-            if hasattr(response, "json"):
-                if callable(response.json):
-                    import asyncio
-
-                    if asyncio.iscoroutinefunction(response.json):
-                        response = await response.json()
-                    else:
-                        response = response.json()
-
-            if "error" in response:
-                return error_response(response.get("error_description", response["error"]))
+            if "error" in response.data:
+                return error_response(response.data.get("error_description", response.data["error"]))
 
             return success_response(
-                access_token=response.get("access_token"),
-                refresh_token=response.get("refresh_token"),
-                token_type=response.get("token_type"),
-                expires_in=response.get("expires_in"),
+                access_token=response.data.get("access_token"),
+                refresh_token=response.data.get("refresh_token"),
+                token_type=response.data.get("token_type"),
+                expires_in=response.data.get("expires_in"),
             )
         except Exception as e:
             return error_response(e)

--- a/shopify-storefront/requirements.txt
+++ b/shopify-storefront/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/shopify-storefront/shopify_storefront.py
+++ b/shopify-storefront/shopify_storefront.py
@@ -142,7 +142,7 @@ async def execute_graphql(context: ExecutionContext, query: str, variables: Dict
         payload["variables"] = variables
 
     response = await context.fetch(url, method="POST", json=payload, headers=headers)
-    return response
+    return response.data
 
 
 def success_response(**kwargs) -> ActionResult:

--- a/slider/requirements.txt
+++ b/slider/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 python-pptx
 markdown>=3.4.0
 beautifulsoup4>=4.12.0

--- a/slider/slide_maker.py
+++ b/slider/slide_maker.py
@@ -2028,7 +2028,7 @@ class CreatePresentationAction(ActionHandler):
 
         result = {"presentation_id": presentation_id, "slide_count": len(prs.slides)}
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context, custom_filename)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context, custom_filename))
 
 
 @slide_maker.action("add_slide")
@@ -2047,7 +2047,7 @@ class AddSlideAction(ActionHandler):
         prs.slides.add_slide(slide_layout)
 
         original_result = {"slide_index": len(prs.slides) - 1, "slide_count": len(prs.slides)}
-        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context))
 
 
 @slide_maker.action("add_image")
@@ -2127,7 +2127,7 @@ class AddImageAction(ActionHandler):
             pic = slide.shapes.add_picture(image_file, left, top)
 
         original_result = {"shape_id": str(pic.shape_id)}
-        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context))
 
 
 @slide_maker.action("add_chart")
@@ -2187,7 +2187,7 @@ class AddChartAction(ActionHandler):
         chart_shape = slide.shapes.add_chart(chart_type_enum, left, top, width, height, chart_data)
 
         original_result = {"chart_id": str(chart_shape.shape_id)}
-        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context))
 
 
 @slide_maker.action("set_text_autosize")
@@ -2258,7 +2258,7 @@ class SetTextAutosizeAction(ActionHandler):
             shape.height = original_height
 
         original_result = {"success": True, "autosize_type": autosize_type, "word_wrap": text_frame.word_wrap}
-        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context))
 
 
 @slide_maker.action("set_text_margins")
@@ -2313,7 +2313,7 @@ class SetTextMarginsAction(ActionHandler):
 
         result = {"success": True, "margins_set": margins}
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("set_text_alignment")
@@ -2364,7 +2364,7 @@ class SetTextAlignmentAction(ActionHandler):
 
         result = {"success": True, "vertical_anchor": vertical_anchor}
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("set_slide_background_color")
@@ -2439,7 +2439,7 @@ class SetSlideBackgroundColorAction(ActionHandler):
 
         result = {"success": True, "color_set": color}
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("set_slide_background_gradient")
@@ -2510,7 +2510,7 @@ class SetSlideBackgroundGradientAction(ActionHandler):
             "gradient_stops_applied": len(gradient_stops) if gradient_stops else 2,
         }
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("add_background_image_workaround")
@@ -2575,7 +2575,7 @@ class AddBackgroundImageWorkaroundAction(ActionHandler):
             "note": "Image added as full-slide picture. Add other elements after this for proper layering.",
         }
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("reset_slide_background")
@@ -2629,7 +2629,7 @@ class ResetSlideBackgroundAction(ActionHandler):
             "note": "Slide background reset to inherit from master/layout",
         }
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("delete_element")
@@ -2695,7 +2695,7 @@ class DeleteElementAction(ActionHandler):
 
         result = {"deleted": True, "element_type": element_type, "remaining_shapes": remaining_shapes}
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("get_slide_elements")
@@ -3009,7 +3009,7 @@ class RepositionElementAction(ActionHandler):
             },
         }
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("get_element_styling")
@@ -3922,7 +3922,7 @@ class FindAndReplaceAction(ActionHandler):
             "warnings": warnings,
         }
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
 
 @slide_maker.action("add_elements")
@@ -3990,7 +3990,7 @@ class AddElementsAction(ActionHandler):
                 "elements_skipped": [],
             }
 
-            return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+            return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))
 
         # GRANULAR MODE: Array of elements with position control
         elements_to_add = inputs.get("elements")
@@ -4126,4 +4126,4 @@ class AddElementsAction(ActionHandler):
             "elements_skipped": elements_skipped,
         }
 
-        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context))

--- a/slider/slide_maker.py
+++ b/slider/slide_maker.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 from pptx import Presentation
 from pptx.util import Inches, Pt
@@ -2028,7 +2028,7 @@ class CreatePresentationAction(ActionHandler):
 
         result = {"presentation_id": presentation_id, "slide_count": len(prs.slides)}
 
-        return await save_and_return_presentation(result, presentation_id, context, custom_filename)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context, custom_filename)
 
 
 @slide_maker.action("add_slide")
@@ -2047,7 +2047,7 @@ class AddSlideAction(ActionHandler):
         prs.slides.add_slide(slide_layout)
 
         original_result = {"slide_index": len(prs.slides) - 1, "slide_count": len(prs.slides)}
-        return await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
 
 
 @slide_maker.action("add_image")
@@ -2127,7 +2127,7 @@ class AddImageAction(ActionHandler):
             pic = slide.shapes.add_picture(image_file, left, top)
 
         original_result = {"shape_id": str(pic.shape_id)}
-        return await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
 
 
 @slide_maker.action("add_chart")
@@ -2187,7 +2187,7 @@ class AddChartAction(ActionHandler):
         chart_shape = slide.shapes.add_chart(chart_type_enum, left, top, width, height, chart_data)
 
         original_result = {"chart_id": str(chart_shape.shape_id)}
-        return await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
 
 
 @slide_maker.action("set_text_autosize")
@@ -2258,7 +2258,7 @@ class SetTextAutosizeAction(ActionHandler):
             shape.height = original_height
 
         original_result = {"success": True, "autosize_type": autosize_type, "word_wrap": text_frame.word_wrap}
-        return await save_and_return_presentation(original_result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(original_result, presentation_id, context)
 
 
 @slide_maker.action("set_text_margins")
@@ -2313,7 +2313,7 @@ class SetTextMarginsAction(ActionHandler):
 
         result = {"success": True, "margins_set": margins}
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("set_text_alignment")
@@ -2364,7 +2364,7 @@ class SetTextAlignmentAction(ActionHandler):
 
         result = {"success": True, "vertical_anchor": vertical_anchor}
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("set_slide_background_color")
@@ -2439,7 +2439,7 @@ class SetSlideBackgroundColorAction(ActionHandler):
 
         result = {"success": True, "color_set": color}
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("set_slide_background_gradient")
@@ -2510,7 +2510,7 @@ class SetSlideBackgroundGradientAction(ActionHandler):
             "gradient_stops_applied": len(gradient_stops) if gradient_stops else 2,
         }
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("add_background_image_workaround")
@@ -2575,7 +2575,7 @@ class AddBackgroundImageWorkaroundAction(ActionHandler):
             "note": "Image added as full-slide picture. Add other elements after this for proper layering.",
         }
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("reset_slide_background")
@@ -2629,7 +2629,7 @@ class ResetSlideBackgroundAction(ActionHandler):
             "note": "Slide background reset to inherit from master/layout",
         }
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("delete_element")
@@ -2695,7 +2695,7 @@ class DeleteElementAction(ActionHandler):
 
         result = {"deleted": True, "element_type": element_type, "remaining_shapes": remaining_shapes}
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("get_slide_elements")
@@ -3009,7 +3009,7 @@ class RepositionElementAction(ActionHandler):
             },
         }
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("get_element_styling")
@@ -3922,7 +3922,7 @@ class FindAndReplaceAction(ActionHandler):
             "warnings": warnings,
         }
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
 
 @slide_maker.action("add_elements")
@@ -3990,7 +3990,7 @@ class AddElementsAction(ActionHandler):
                 "elements_skipped": [],
             }
 
-            return await save_and_return_presentation(result, presentation_id, context)
+            return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)
 
         # GRANULAR MODE: Array of elements with position control
         elements_to_add = inputs.get("elements")
@@ -4126,4 +4126,4 @@ class AddElementsAction(ActionHandler):
             "elements_skipped": elements_skipped,
         }
 
-        return await save_and_return_presentation(result, presentation_id, context)
+        return ActionResult(data=await save_and_return_presentation(result, presentation_id, context)

--- a/stripe/requirements.txt
+++ b/stripe/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk==1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/stripe/stripe.py
+++ b/stripe/stripe.py
@@ -93,10 +93,10 @@ class ListCustomersAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers", method="GET", headers=headers, params=params
             )
 
-            customers = response.get("data", [])
+            customers = response.data.get("data", [])
 
             return ActionResult(
-                data={"customers": customers, "has_more": response.get("has_more", False), "result": True}, cost_usd=0.0
+                data={"customers": customers, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -118,7 +118,7 @@ class GetCustomerAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers/{customer_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"customer": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -153,7 +153,7 @@ class CreateCustomerAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers", method="POST", headers=headers, data=form_data
             )
 
-            return ActionResult(data={"customer": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -192,7 +192,7 @@ class UpdateCustomerAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"customer": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -212,7 +212,7 @@ class DeleteCustomerAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"id": response.get("id", customer_id), "deleted": response.get("deleted", True), "result": True},
+                data={"id": response.data.get("id", customer_id), "deleted": response.data.get("deleted", True), "result": True},
                 cost_usd=0.0,
             )
 
@@ -250,10 +250,10 @@ class ListInvoicesAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices", method="GET", headers=headers, params=params
             )
 
-            invoices = response.get("data", [])
+            invoices = response.data.get("data", [])
 
             return ActionResult(
-                data={"invoices": invoices, "has_more": response.get("has_more", False), "result": True}, cost_usd=0.0
+                data={"invoices": invoices, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -367,7 +367,7 @@ class DeleteInvoiceAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"id": response.get("id", invoice_id), "deleted": response.get("deleted", True), "result": True},
+                data={"id": response.data.get("id", invoice_id), "deleted": response.data.get("deleted", True), "result": True},
                 cost_usd=0.0,
             )
 
@@ -497,10 +497,10 @@ class ListInvoiceItemsAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems", method="GET", headers=headers, params=params
             )
 
-            invoice_items = response.get("data", [])
+            invoice_items = response.data.get("data", [])
 
             return ActionResult(
-                data={"invoice_items": invoice_items, "has_more": response.get("has_more", False), "result": True},
+                data={"invoice_items": invoice_items, "has_more": response.data.get("has_more", False), "result": True},
                 cost_usd=0.0,
             )
 
@@ -618,8 +618,8 @@ class DeleteInvoiceItemAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response.get("id", invoice_item_id),
-                    "deleted": response.get("deleted", True),
+                    "id": response.data.get("id", invoice_item_id),
+                    "deleted": response.data.get("deleted", True),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -659,10 +659,10 @@ class ListProductsAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/products", method="GET", headers=headers, params=params
             )
 
-            products = response.get("data", [])
+            products = response.data.get("data", [])
 
             return ActionResult(
-                data={"products": products, "has_more": response.get("has_more", False), "result": True}, cost_usd=0.0
+                data={"products": products, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -805,10 +805,10 @@ class ListPricesAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices", method="GET", headers=headers, params=params
             )
 
-            prices = response.get("data", [])
+            prices = response.data.get("data", [])
 
             return ActionResult(
-                data={"prices": prices, "has_more": response.get("has_more", False), "result": True}, cost_usd=0.0
+                data={"prices": prices, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -944,10 +944,10 @@ class ListSubscriptionsAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions", method="GET", headers=headers, params=params
             )
 
-            subscriptions = response.get("data", [])
+            subscriptions = response.data.get("data", [])
 
             return ActionResult(
-                data={"subscriptions": subscriptions, "has_more": response.get("has_more", False), "result": True},
+                data={"subscriptions": subscriptions, "has_more": response.data.get("has_more", False), "result": True},
                 cost_usd=0.0,
             )
 
@@ -1144,10 +1144,10 @@ class ListPaymentMethodsAction(ActionHandler):
                 f"{STRIPE_API_BASE_URL}/{API_VERSION}/payment_methods", method="GET", headers=headers, params=params
             )
 
-            payment_methods = response.get("data", [])
+            payment_methods = response.data.get("data", [])
 
             return ActionResult(
-                data={"payment_methods": payment_methods, "has_more": response.get("has_more", False), "result": True},
+                data={"payment_methods": payment_methods, "has_more": response.data.get("has_more", False), "result": True},
                 cost_usd=0.0,
             )
 

--- a/stripe/stripe.py
+++ b/stripe/stripe.py
@@ -1,4 +1,9 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
+from autohive_integrations_sdk import (
+    Integration,
+    ExecutionContext,
+    ActionHandler,
+    ActionResult,
+)
 from typing import Dict, Any
 
 
@@ -18,7 +23,10 @@ def get_common_headers() -> Dict[str, str]:
     Return common headers for Stripe API requests.
     Auth headers are automatically added by the SDK when using platform auth.
     """
-    return {"Content-Type": "application/x-www-form-urlencoded", "Stripe-Version": "2025-12-15.preview"}
+    return {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Stripe-Version": "2025-12-15.preview",
+    }
 
 
 def build_form_data(data: Dict[str, Any], prefix: str = "") -> Dict[str, str]:
@@ -90,18 +98,32 @@ class ListCustomersAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             customers = response.data.get("data", [])
 
             return ActionResult(
-                data={"customers": customers, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
+                data={
+                    "customers": customers,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"customers": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "customers": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -115,13 +137,19 @@ class GetCustomerAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers/{customer_id}", method="GET", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers/{customer_id}",
+                method="GET",
+                headers=headers,
             )
 
-            return ActionResult(data={"customer": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"customer": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("create_customer")
@@ -150,13 +178,20 @@ class CreateCustomerAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
-            return ActionResult(data={"customer": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"customer": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("update_customer")
@@ -192,10 +227,14 @@ class UpdateCustomerAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"customer": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"customer": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("delete_customer")
@@ -208,17 +247,28 @@ class DeleteCustomerAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers/{customer_id}", method="DELETE", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/customers/{customer_id}",
+                method="DELETE",
+                headers=headers,
             )
 
             return ActionResult(
-                data={"id": response.data.get("id", customer_id), "deleted": response.data.get("deleted", True), "result": True},
+                data={
+                    "id": response.data.get("id", customer_id),
+                    "deleted": response.data.get("deleted", True),
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"id": inputs.get("customer_id", ""), "deleted": False, "result": False, "error": str(e)},
+                data={
+                    "id": inputs.get("customer_id", ""),
+                    "deleted": False,
+                    "result": False,
+                    "error": str(e),
+                },
                 cost_usd=0.0,
             )
 
@@ -247,18 +297,32 @@ class ListInvoicesAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             invoices = response.data.get("data", [])
 
             return ActionResult(
-                data={"invoices": invoices, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
+                data={
+                    "invoices": invoices,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"invoices": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "invoices": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -272,13 +336,19 @@ class GetInvoiceAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}", method="GET", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}",
+                method="GET",
+                headers=headers,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("create_invoice")
@@ -307,13 +377,20 @@ class CreateInvoiceAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("update_invoice")
@@ -347,10 +424,14 @@ class UpdateInvoiceAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("delete_invoice")
@@ -363,17 +444,28 @@ class DeleteInvoiceAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}", method="DELETE", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}",
+                method="DELETE",
+                headers=headers,
             )
 
             return ActionResult(
-                data={"id": response.data.get("id", invoice_id), "deleted": response.data.get("deleted", True), "result": True},
+                data={
+                    "id": response.data.get("id", invoice_id),
+                    "deleted": response.data.get("deleted", True),
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"id": inputs.get("invoice_id", ""), "deleted": False, "result": False, "error": str(e)},
+                data={
+                    "id": inputs.get("invoice_id", ""),
+                    "deleted": False,
+                    "result": False,
+                    "error": str(e),
+                },
                 cost_usd=0.0,
             )
 
@@ -400,10 +492,14 @@ class FinalizeInvoiceAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("send_invoice")
@@ -416,13 +512,19 @@ class SendInvoiceAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}/send", method="POST", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}/send",
+                method="POST",
+                headers=headers,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("pay_invoice")
@@ -447,10 +549,14 @@ class PayInvoiceAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("void_invoice")
@@ -463,13 +569,19 @@ class VoidInvoiceAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}/void", method="POST", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoices/{invoice_id}/void",
+                method="POST",
+                headers=headers,
             )
 
-            return ActionResult(data={"invoice": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Invoice Item Action Handlers ----
@@ -494,19 +606,32 @@ class ListInvoiceItemsAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             invoice_items = response.data.get("data", [])
 
             return ActionResult(
-                data={"invoice_items": invoice_items, "has_more": response.data.get("has_more", False), "result": True},
+                data={
+                    "invoice_items": invoice_items,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"invoice_items": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "invoice_items": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -520,13 +645,20 @@ class GetInvoiceItemAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems/{invoice_item_id}", method="GET", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems/{invoice_item_id}",
+                method="GET",
+                headers=headers,
             )
 
-            return ActionResult(data={"invoice_item": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice_item": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice_item": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice_item": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("create_invoice_item")
@@ -557,13 +689,21 @@ class CreateInvoiceItemAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
-            return ActionResult(data={"invoice_item": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice_item": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice_item": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice_item": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("update_invoice_item")
@@ -597,10 +737,15 @@ class UpdateInvoiceItemAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"invoice_item": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice_item": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"invoice_item": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"invoice_item": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("delete_invoice_item")
@@ -613,7 +758,9 @@ class DeleteInvoiceItemAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems/{invoice_item_id}", method="DELETE", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/invoiceitems/{invoice_item_id}",
+                method="DELETE",
+                headers=headers,
             )
 
             return ActionResult(
@@ -627,7 +774,12 @@ class DeleteInvoiceItemAction(ActionHandler):
 
         except Exception as e:
             return ActionResult(
-                data={"id": inputs.get("invoice_item_id", ""), "deleted": False, "result": False, "error": str(e)},
+                data={
+                    "id": inputs.get("invoice_item_id", ""),
+                    "deleted": False,
+                    "result": False,
+                    "error": str(e),
+                },
                 cost_usd=0.0,
             )
 
@@ -656,18 +808,32 @@ class ListProductsAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/products", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/products",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             products = response.data.get("data", [])
 
             return ActionResult(
-                data={"products": products, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
+                data={
+                    "products": products,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"products": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "products": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -681,13 +847,19 @@ class GetProductAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/products/{product_id}", method="GET", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/products/{product_id}",
+                method="GET",
+                headers=headers,
             )
 
-            return ActionResult(data={"product": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"product": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("create_product")
@@ -720,13 +892,20 @@ class CreateProductAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/products", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/products",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
-            return ActionResult(data={"product": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"product": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("update_product")
@@ -768,10 +947,14 @@ class UpdateProductAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"product": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"product": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Price Action Handlers ----
@@ -802,17 +985,33 @@ class ListPricesAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             prices = response.data.get("data", [])
 
             return ActionResult(
-                data={"prices": prices, "has_more": response.data.get("has_more", False), "result": True}, cost_usd=0.0
+                data={
+                    "prices": prices,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"prices": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={
+                    "prices": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("get_price")
@@ -825,13 +1024,17 @@ class GetPriceAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices/{price_id}", method="GET", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices/{price_id}",
+                method="GET",
+                headers=headers,
             )
 
             return ActionResult(data={"price": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return ActionResult(data={"price": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"price": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("create_price")
@@ -840,7 +1043,10 @@ class CreatePriceAction(ActionHandler):
 
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            body = {"currency": inputs.get("currency", "usd"), "product": inputs["product"]}
+            body = {
+                "currency": inputs.get("currency", "usd"),
+                "product": inputs["product"],
+            }
 
             # Add unit_amount or custom_unit_amount
             if "unit_amount" in inputs and inputs["unit_amount"] is not None:
@@ -870,13 +1076,18 @@ class CreatePriceAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
             return ActionResult(data={"price": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return ActionResult(data={"price": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"price": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @stripe.action("update_price")
@@ -902,13 +1113,18 @@ class UpdatePriceAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices/{price_id}", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/prices/{price_id}",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
             return ActionResult(data={"price": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return ActionResult(data={"price": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"price": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Subscription Action Handlers ----
@@ -933,27 +1149,46 @@ class ListSubscriptionsAction(ActionHandler):
                 params["created[gte]"] = inputs["created_gte"]
             if "created_lte" in inputs and inputs["created_lte"]:
                 params["created[lte]"] = inputs["created_lte"]
-            if "current_period_start_gte" in inputs and inputs["current_period_start_gte"]:
+            if (
+                "current_period_start_gte" in inputs
+                and inputs["current_period_start_gte"]
+            ):
                 params["current_period_start[gte]"] = inputs["current_period_start_gte"]
-            if "current_period_start_lte" in inputs and inputs["current_period_start_lte"]:
+            if (
+                "current_period_start_lte" in inputs
+                and inputs["current_period_start_lte"]
+            ):
                 params["current_period_start[lte]"] = inputs["current_period_start_lte"]
 
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             subscriptions = response.data.get("data", [])
 
             return ActionResult(
-                data={"subscriptions": subscriptions, "has_more": response.data.get("has_more", False), "result": True},
+                data={
+                    "subscriptions": subscriptions,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"subscriptions": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "subscriptions": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -967,13 +1202,20 @@ class GetSubscriptionAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions/{subscription_id}", method="GET", headers=headers
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions/{subscription_id}",
+                method="GET",
+                headers=headers,
             )
 
-            return ActionResult(data={"subscription": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"subscription": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("create_subscription")
@@ -995,7 +1237,10 @@ class CreateSubscriptionAction(ActionHandler):
                 body["payment_behavior"] = inputs["payment_behavior"]
             if "billing_cycle_anchor" in inputs and inputs["billing_cycle_anchor"]:
                 body["billing_cycle_anchor"] = inputs["billing_cycle_anchor"]
-            if "cancel_at_period_end" in inputs and inputs["cancel_at_period_end"] is not None:
+            if (
+                "cancel_at_period_end" in inputs
+                and inputs["cancel_at_period_end"] is not None
+            ):
                 body["cancel_at_period_end"] = inputs["cancel_at_period_end"]
             if "cancel_at" in inputs and inputs["cancel_at"]:
                 body["cancel_at"] = inputs["cancel_at"]
@@ -1016,13 +1261,21 @@ class CreateSubscriptionAction(ActionHandler):
             form_data = build_form_data(body)
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions", method="POST", headers=headers, data=form_data
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/subscriptions",
+                method="POST",
+                headers=headers,
+                data=form_data,
             )
 
-            return ActionResult(data={"subscription": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"subscription": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("update_subscription")
@@ -1041,7 +1294,10 @@ class UpdateSubscriptionAction(ActionHandler):
                 body["default_payment_method"] = inputs["default_payment_method"]
             if "payment_behavior" in inputs and inputs["payment_behavior"]:
                 body["payment_behavior"] = inputs["payment_behavior"]
-            if "cancel_at_period_end" in inputs and inputs["cancel_at_period_end"] is not None:
+            if (
+                "cancel_at_period_end" in inputs
+                and inputs["cancel_at_period_end"] is not None
+            ):
                 body["cancel_at_period_end"] = inputs["cancel_at_period_end"]
             if "cancel_at" in inputs and inputs["cancel_at"]:
                 body["cancel_at"] = inputs["cancel_at"]
@@ -1066,10 +1322,15 @@ class UpdateSubscriptionAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"subscription": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"subscription": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("cancel_subscription")
@@ -1114,10 +1375,15 @@ class CancelSubscriptionAction(ActionHandler):
                     data=form_data if form_data else None,
                 )
 
-            return ActionResult(data={"subscription": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"subscription": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"subscription": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 # ---- Payment Method Action Handlers ----
@@ -1141,19 +1407,32 @@ class ListPaymentMethodsAction(ActionHandler):
             headers = get_common_headers()
 
             response = await context.fetch(
-                f"{STRIPE_API_BASE_URL}/{API_VERSION}/payment_methods", method="GET", headers=headers, params=params
+                f"{STRIPE_API_BASE_URL}/{API_VERSION}/payment_methods",
+                method="GET",
+                headers=headers,
+                params=params,
             )
 
             payment_methods = response.data.get("data", [])
 
             return ActionResult(
-                data={"payment_methods": payment_methods, "has_more": response.data.get("has_more", False), "result": True},
+                data={
+                    "payment_methods": payment_methods,
+                    "has_more": response.data.get("has_more", False),
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
         except Exception as e:
             return ActionResult(
-                data={"payment_methods": [], "has_more": False, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "payment_methods": [],
+                    "has_more": False,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -1172,10 +1451,15 @@ class GetPaymentMethodAction(ActionHandler):
                 headers=headers,
             )
 
-            return ActionResult(data={"payment_method": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"payment_method": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"payment_method": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"payment_method": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("attach_payment_method")
@@ -1197,10 +1481,15 @@ class AttachPaymentMethodAction(ActionHandler):
                 data=form_data,
             )
 
-            return ActionResult(data={"payment_method": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"payment_method": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"payment_method": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"payment_method": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @stripe.action("detach_payment_method")
@@ -1218,7 +1507,12 @@ class DetachPaymentMethodAction(ActionHandler):
                 headers=headers,
             )
 
-            return ActionResult(data={"payment_method": response, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"payment_method": response, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
-            return ActionResult(data={"payment_method": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"payment_method": {}, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )

--- a/substack/requirements.txt
+++ b/substack/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp>=3.9.0

--- a/substack/substack.py
+++ b/substack/substack.py
@@ -88,7 +88,7 @@ class GetPublicationPostsAction(ActionHandler):
             params=params,
             headers=headers,
         )
-        posts = [_format_post(p) for p in (posts_raw or [])]
+        posts = [_format_post(p) for p in (posts_raw.data or [])]
         return ActionResult(data={"posts": posts, "count": len(posts)}, cost_usd=0.0)
 
 
@@ -144,7 +144,7 @@ class SearchPublicationsAction(ActionHandler):
             params=params,
             headers=headers,
         )
-        pubs_raw = response.get("publications", []) if isinstance(response, dict) else response
+        pubs_raw = response.data.get("publications", []) if isinstance(response.data, dict) else response.data
         pubs = [
             _drop_none(
                 {
@@ -159,7 +159,7 @@ class SearchPublicationsAction(ActionHandler):
             )
             for p in pubs_raw
         ]
-        more = response.get("more", False) if isinstance(response, dict) else False
+        more = response.data.get("more", False) if isinstance(response.data, dict) else False
         return ActionResult(data={"publications": pubs, "more": more}, cost_usd=0.0)
 
 
@@ -184,7 +184,7 @@ class SearchPostsAction(ActionHandler):
             params=params,
             headers=headers,
         )
-        posts = [_format_post(p) for p in (posts_raw or [])]
+        posts = [_format_post(p) for p in (posts_raw.data or [])]
         return ActionResult(data={"posts": posts, "count": len(posts)}, cost_usd=0.0)
 
 
@@ -207,5 +207,5 @@ class GetPostCommentsAction(ActionHandler):
             params=params,
             headers=headers,
         )
-        comments = response.get("comments", []) if isinstance(response, dict) else []
+        comments = response.data.get("comments", []) if isinstance(response.data, dict) else []
         return ActionResult(data={"comments": comments, "count": len(comments)}, cost_usd=0.0)

--- a/substack/substack.py
+++ b/substack/substack.py
@@ -106,21 +106,21 @@ class GetPostAction(ActionHandler):
         )
         result = _drop_none(
             {
-                "id": post.get("id"),
-                "slug": post.get("slug", ""),
-                "title": post.get("title", ""),
-                "subtitle": post.get("subtitle", ""),
-                "body_html": post.get("body_html", ""),
-                "post_date": post.get("post_date", ""),
-                "canonical_url": post.get("canonical_url", ""),
-                "audience": post.get("audience", ""),
-                "paywall": post.get("paywall", False),
-                "reading_time_minutes": post.get("reading_time_minutes"),
-                "cover_image": post.get("cover_image"),
-                "like_count": post.get("like_count", 0),
-                "comment_count": post.get("comment_count", 0),
-                "type": post.get("type", ""),
-                "audio_url": post.get("audio_url"),
+                "id": post.data.get("id"),
+                "slug": post.data.get("slug", ""),
+                "title": post.data.get("title", ""),
+                "subtitle": post.data.get("subtitle", ""),
+                "body_html": post.data.get("body_html", ""),
+                "post_date": post.data.get("post_date", ""),
+                "canonical_url": post.data.get("canonical_url", ""),
+                "audience": post.data.get("audience", ""),
+                "paywall": post.data.get("paywall", False),
+                "reading_time_minutes": post.data.get("reading_time_minutes"),
+                "cover_image": post.data.get("cover_image"),
+                "like_count": post.data.get("like_count", 0),
+                "comment_count": post.data.get("comment_count", 0),
+                "type": post.data.get("type", ""),
+                "audio_url": post.data.get("audio_url"),
             }
         )
         return ActionResult(data=result, cost_usd=0.0)

--- a/supabase/requirements.txt
+++ b/supabase/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/supabase/supabase.py
+++ b/supabase/supabase.py
@@ -409,7 +409,7 @@ class DeleteFilesAction(ActionHandler):
 
             if isinstance(response.data, dict) and response.data.get("error"):
                 return ActionResult(
-                    data={"deleted": [], "result": False, "error": response.data.get("message", response["error"])},
+                    data={"deleted": [], "result": False, "error": response.data.get("message", response.data["error"])},
                     cost_usd=0.0,
                 )
 

--- a/supabase/supabase.py
+++ b/supabase/supabase.py
@@ -68,7 +68,7 @@ class SelectRecordsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            records = response if isinstance(response, list) else []
+            records = response.data if isinstance(response.data, list) else []
 
             return ActionResult(
                 data={"records": records, "count": len(records), "result": True},
@@ -114,7 +114,7 @@ class InsertRecordsAction(ActionHandler):
                 json=records,
             )
 
-            result_records = response if isinstance(response, list) else []
+            result_records = response.data if isinstance(response.data, list) else []
             count = len(result_records) if result_records else len(records)
 
             return ActionResult(
@@ -163,7 +163,7 @@ class UpdateRecordsAction(ActionHandler):
                 json=data,
             )
 
-            result_records = response if isinstance(response, list) else []
+            result_records = response.data if isinstance(response.data, list) else []
             count = None if return_minimal else len(result_records)
 
             return ActionResult(
@@ -212,7 +212,7 @@ class DeleteRecordsAction(ActionHandler):
                 params=params,
             )
 
-            result_records = response if isinstance(response, list) else []
+            result_records = response.data if isinstance(response.data, list) else []
             count = None if return_minimal else len(result_records)
 
             return ActionResult(
@@ -269,7 +269,7 @@ class ListBucketsAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/storage/v1/bucket", method="GET", headers=headers)
 
-            buckets = response if isinstance(response, list) else []
+            buckets = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"buckets": buckets, "result": True}, cost_usd=0.0)
 
@@ -381,7 +381,7 @@ class ListFilesAction(ActionHandler):
                 json=body,
             )
 
-            files = response if isinstance(response, list) else []
+            files = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"files": files, "result": True}, cost_usd=0.0)
 
@@ -407,13 +407,13 @@ class DeleteFilesAction(ActionHandler):
                 json={"prefixes": paths},
             )
 
-            if isinstance(response, dict) and response.get("error"):
+            if isinstance(response.data, dict) and response.data.get("error"):
                 return ActionResult(
-                    data={"deleted": [], "result": False, "error": response.get("message", response["error"])},
+                    data={"deleted": [], "result": False, "error": response.data.get("message", response["error"])},
                     cost_usd=0.0,
                 )
 
-            deleted = response if isinstance(response, list) else []
+            deleted = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"deleted": deleted, "result": True}, cost_usd=0.0)
 
@@ -464,8 +464,8 @@ class ListUsersAction(ActionHandler):
                 params=params if params else None,
             )
 
-            users = response.get("users", []) if isinstance(response, dict) else []
-            total = response.get("total", len(users)) if isinstance(response, dict) else len(users)
+            users = response.data.get("users", []) if isinstance(response.data, dict) else []
+            total = response.data.get("total", len(users)) if isinstance(response.data, dict) else len(users)
 
             return ActionResult(data={"users": users, "total": total, "result": True}, cost_usd=0.0)
 

--- a/supadata/requirements.txt
+++ b/supadata/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 supadata

--- a/supadata/supadata_transcribe.py
+++ b/supadata/supadata_transcribe.py
@@ -1,4 +1,9 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
+from autohive_integrations_sdk import (
+    Integration,
+    ExecutionContext,
+    ActionHandler,
+    ActionResult,
+)
 from typing import Dict, Any
 from supadata import Supadata, SupadataError
 
@@ -25,11 +30,16 @@ class GetTranscriptAction(ActionHandler):
             # Format as SRT-style text
             formatted_transcript = self._format_as_srt(transcript_response.content)
 
-            return ActionResult(data={
-                "transcript": formatted_transcript,
-                "language": getattr(transcript_response, "lang", ""),
-                "available_languages": getattr(transcript_response, "available_langs", []),
-            }, cost_usd=0)
+            return ActionResult(
+                data={
+                    "transcript": formatted_transcript,
+                    "language": getattr(transcript_response, "lang", ""),
+                    "available_languages": getattr(
+                        transcript_response, "available_langs", []
+                    ),
+                },
+                cost_usd=0,
+            )
 
         except SupadataError as e:
             raise ValueError(f"Supadata API error: {str(e)}")
@@ -49,7 +59,11 @@ class GetTranscriptAction(ActionHandler):
 
         formatted_lines = []
         for i, chunk in enumerate(chunks, 1):
-            if hasattr(chunk, "text") and hasattr(chunk, "offset") and hasattr(chunk, "duration"):
+            if (
+                hasattr(chunk, "text")
+                and hasattr(chunk, "offset")
+                and hasattr(chunk, "duration")
+            ):
                 start_time = self._ms_to_timestamp(chunk.offset)
                 end_time = self._ms_to_timestamp(chunk.offset + chunk.duration)
                 formatted_lines.append(f"{start_time} --> {end_time}")

--- a/supadata/supadata_transcribe.py
+++ b/supadata/supadata_transcribe.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 from supadata import Supadata, SupadataError
 
@@ -25,11 +25,11 @@ class GetTranscriptAction(ActionHandler):
             # Format as SRT-style text
             formatted_transcript = self._format_as_srt(transcript_response.content)
 
-            return {
+            return ActionResult(data={
                 "transcript": formatted_transcript,
                 "language": getattr(transcript_response, "lang", ""),
                 "available_languages": getattr(transcript_response, "available_langs", []),
-            }
+            }, cost_usd=0)
 
         except SupadataError as e:
             raise ValueError(f"Supadata API error: {str(e)}")

--- a/tiktok/requirements.txt
+++ b/tiktok/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/tiktok/tiktok.py
+++ b/tiktok/tiktok.py
@@ -341,7 +341,7 @@ class TikTokConnectedAccountHandler(ConnectedAccountHandler):
             method="GET",
             params={"fields": ",".join(BASIC_USER_INFO_FIELDS)},
         )
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
         user = data.get("user", data)
         return ConnectedAccountInfo(
             user_id=user.get("open_id", ""),
@@ -367,7 +367,7 @@ class GetUserInfoHandler(ActionHandler):
             method="GET",
             params={"fields": ",".join(ALL_USER_INFO_FIELDS)},
         )
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
         return ActionResult(data=_build_user_info(data))
 
 
@@ -377,7 +377,7 @@ class GetCreatorInfoHandler(ActionHandler):
 
     async def execute(self, inputs: dict, context: ExecutionContext) -> ActionResult:
         response = await context.fetch(CREATOR_INFO_ENDPOINT, method="POST", json={})
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
         return ActionResult(data=_build_creator_info(data))
 
 
@@ -424,7 +424,7 @@ class CreateVideoPostHandler(ActionHandler):
         }
 
         response = await context.fetch(VIDEO_INIT_ENDPOINT, method="POST", json=request_body)
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
 
         publish_id = data.get("publish_id", "")
         upload_url = data.get("upload_url", "")
@@ -466,7 +466,7 @@ class UploadVideoDraftHandler(ActionHandler):
         }
 
         response = await context.fetch(INBOX_VIDEO_INIT_ENDPOINT, method="POST", json=request_body)
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
 
         publish_id = data.get("publish_id", "")
         upload_url = data.get("upload_url", "")
@@ -496,7 +496,7 @@ class GetPostStatusHandler(ActionHandler):
             raise ValueError("publish_id is required")
 
         response = await context.fetch(STATUS_FETCH_ENDPOINT, method="POST", json={"publish_id": publish_id})
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
         return ActionResult(data=_build_post_status(data))
 
 
@@ -521,7 +521,7 @@ class GetVideosHandler(ActionHandler):
             request_body["cursor"] = cursor
 
         response = await context.fetch(VIDEO_LIST_ENDPOINT, method="POST", json=request_body)
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
 
         return ActionResult(
             data={
@@ -560,6 +560,6 @@ class CreatePhotoPostHandler(ActionHandler):
         }
 
         response = await context.fetch(PHOTO_INIT_ENDPOINT, method="POST", json=request_body)
-        data = _check_api_response(response)
+        data = _check_api_response(response.data)
 
         return ActionResult(data={"publish_id": data.get("publish_id", ""), "status": "PROCESSING_DOWNLOAD"})

--- a/toggl/requirements.txt
+++ b/toggl/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/toggl/toggl.py
+++ b/toggl/toggl.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 import base64
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 
 # Create the integration using the config.json
 toggl = Integration.load()
@@ -49,4 +49,4 @@ class CreateTimeEntry(ActionHandler):
         resp = await context.fetch(url, method="POST", headers=headers, json=body)
 
         # The SDK returns parsed JSON for JSON responses; if it's bytes/string parse may be needed.
-        return resp
+        return ActionResult(data=resp.data, cost_usd=0)

--- a/trello/requirements.txt
+++ b/trello/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/trello/trello.py
+++ b/trello/trello.py
@@ -36,7 +36,7 @@ class GetCurrentMemberAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/members/me", method="GET", params=auth_params)
 
-            return ActionResult(data={"member": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"member": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"member": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -68,7 +68,7 @@ class CreateBoardAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/boards/", method="POST", params=merged_params)
 
-            return ActionResult(data={"board": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"board": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -93,7 +93,7 @@ class GetBoardAction(ActionHandler):
                 f"{TRELLO_API_BASE_URL}/boards/{board_id}", method="GET", params=merged_params
             )
 
-            return ActionResult(data={"board": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"board": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -125,7 +125,7 @@ class UpdateBoardAction(ActionHandler):
                 f"{TRELLO_API_BASE_URL}/boards/{board_id}", method="PUT", params=merged_params
             )
 
-            return ActionResult(data={"board": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"board": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -150,7 +150,7 @@ class ListBoardsAction(ActionHandler):
             )
 
             # Response is already an array
-            boards = response if isinstance(response, list) else []
+            boards = response.data if isinstance(response.data, list) else []
             return ActionResult(data={"boards": boards, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -176,7 +176,7 @@ class CreateListAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/lists", method="POST", params=merged_params)
 
-            return ActionResult(data={"list": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"list": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"list": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -193,7 +193,7 @@ class GetListAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/lists/{list_id}", method="GET", params=auth_params)
 
-            return ActionResult(data={"list": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"list": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"list": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -220,7 +220,7 @@ class UpdateListAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/lists/{list_id}", method="PUT", params=merged_params)
 
-            return ActionResult(data={"list": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"list": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"list": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -245,7 +245,7 @@ class ListListsAction(ActionHandler):
                 f"{TRELLO_API_BASE_URL}/boards/{board_id}/lists", method="GET", params=merged_params
             )
 
-            lists = response if isinstance(response, list) else []
+            lists = response.data if isinstance(response.data, list) else []
             return ActionResult(data={"lists": lists, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -280,7 +280,7 @@ class CreateCardAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/cards", method="POST", params=merged_params)
 
-            return ActionResult(data={"card": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"card": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"card": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -303,7 +303,7 @@ class GetCardAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/cards/{card_id}", method="GET", params=merged_params)
 
-            return ActionResult(data={"card": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"card": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"card": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -339,7 +339,7 @@ class UpdateCardAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/cards/{card_id}", method="PUT", params=merged_params)
 
-            return ActionResult(data={"card": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"card": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"card": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -388,7 +388,7 @@ class ListCardsAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=merged_params)
 
-            cards = response if isinstance(response, list) else []
+            cards = response.data if isinstance(response.data, list) else []
             return ActionResult(data={"cards": cards, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -411,7 +411,7 @@ class CreateChecklistAction(ActionHandler):
 
             response = await context.fetch(f"{TRELLO_API_BASE_URL}/checklists", method="POST", params=merged_params)
 
-            return ActionResult(data={"checklist": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"checklist": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"checklist": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -438,7 +438,7 @@ class AddChecklistItemAction(ActionHandler):
                 f"{TRELLO_API_BASE_URL}/checklists/{checklist_id}/checkItems", method="POST", params=merged_params
             )
 
-            return ActionResult(data={"checkItem": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"checkItem": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"checkItem": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -463,7 +463,7 @@ class AddCommentAction(ActionHandler):
                 f"{TRELLO_API_BASE_URL}/cards/{card_id}/actions/comments", method="POST", params=merged_params
             )
 
-            return ActionResult(data={"comment": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"comment": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/typeform/requirements.txt
+++ b/typeform/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -127,7 +127,7 @@ class GetCurrentUserAction(ActionHandler):
         try:
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/me", method="GET")
 
-            return ActionResult(data={"user": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"user": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -167,8 +167,8 @@ class ListFormsAction(ActionHandler):
                 f"{TYPEFORM_API_BASE_URL}/forms", method="GET", params=params if params else None
             )
 
-            forms = response.get("items", []) if isinstance(response, dict) else []
-            total_items = response.get("total_items", len(forms)) if isinstance(response, dict) else len(forms)
+            forms = response.data.get("items", []) if isinstance(response.data, dict) else []
+            total_items = response.data.get("total_items", len(forms)) if isinstance(response.data, dict) else len(forms)
 
             return ActionResult(data={"forms": forms, "total_items": total_items, "result": True}, cost_usd=0.0)
 
@@ -197,7 +197,7 @@ class GetFormAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="GET")
 
-            return ActionResult(data={"form": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"form": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -237,7 +237,7 @@ class CreateFormAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms", method="POST", json=body)
 
-            return ActionResult(data={"form": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"form": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -273,7 +273,7 @@ class UpdateFormAction(ActionHandler):
 
             # Start with full existing form and remove only read-only fields
             # This prevents data loss when updating specific fields
-            body = {k: v for k, v in existing_form.items() if k not in FORM_READONLY_FIELDS}
+            body = {k: v for k, v in existing_form.data.items() if k not in FORM_READONLY_FIELDS}
 
             # Apply updates from inputs (only if provided)
             if inputs.get("title"):
@@ -292,7 +292,7 @@ class UpdateFormAction(ActionHandler):
             # Use PUT to replace the entire form
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="PUT", json=body)
 
-            return ActionResult(data={"form": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"form": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -360,9 +360,9 @@ class ListResponsesAction(ActionHandler):
                 f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/responses", method="GET", params=params if params else None
             )
 
-            responses = response.get("items", []) if isinstance(response, dict) else []
-            total_items = response.get("total_items", 0) if isinstance(response, dict) else 0
-            page_count = response.get("page_count", 1) if isinstance(response, dict) else 1
+            responses = response.data.get("items", []) if isinstance(response.data, dict) else []
+            total_items = response.data.get("total_items", 0) if isinstance(response.data, dict) else 0
+            page_count = response.data.get("page_count", 1) if isinstance(response.data, dict) else 1
 
             return ActionResult(
                 data={"responses": responses, "total_items": total_items, "page_count": page_count, "result": True},
@@ -440,9 +440,9 @@ class ListWorkspacesAction(ActionHandler):
                 f"{TYPEFORM_API_BASE_URL}/workspaces", method="GET", params=params if params else None
             )
 
-            workspaces = response.get("items", []) if isinstance(response, dict) else []
+            workspaces = response.data.get("items", []) if isinstance(response.data, dict) else []
             total_items = (
-                response.get("total_items", len(workspaces)) if isinstance(response, dict) else len(workspaces)
+                response.data.get("total_items", len(workspaces)) if isinstance(response.data, dict) else len(workspaces)
             )
 
             return ActionResult(
@@ -476,7 +476,7 @@ class GetWorkspaceAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="GET")
 
-            return ActionResult(data={"workspace": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"workspace": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -503,7 +503,7 @@ class CreateWorkspaceAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces", method="POST", json=body)
 
-            return ActionResult(data={"workspace": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"workspace": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -538,7 +538,7 @@ class UpdateWorkspaceAction(ActionHandler):
             # Fetch the updated workspace to return
             updated_workspace = await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="GET")
 
-            return ActionResult(data={"workspace": updated_workspace, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"workspace": updated_workspace.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -601,8 +601,8 @@ class ListThemesAction(ActionHandler):
                 f"{TYPEFORM_API_BASE_URL}/themes", method="GET", params=params if params else None
             )
 
-            themes = response.get("items", []) if isinstance(response, dict) else []
-            total_items = response.get("total_items", len(themes)) if isinstance(response, dict) else len(themes)
+            themes = response.data.get("items", []) if isinstance(response.data, dict) else []
+            total_items = response.data.get("total_items", len(themes)) if isinstance(response.data, dict) else len(themes)
 
             return ActionResult(data={"themes": themes, "total_items": total_items, "result": True}, cost_usd=0.0)
 
@@ -631,7 +631,7 @@ class GetThemeAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/themes/{theme_id}", method="GET")
 
-            return ActionResult(data={"theme": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"theme": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -667,7 +667,7 @@ class CreateThemeAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/themes", method="POST", json=body)
 
-            return ActionResult(data={"theme": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"theme": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -730,8 +730,8 @@ class ListImagesAction(ActionHandler):
                 f"{TYPEFORM_API_BASE_URL}/images", method="GET", params=params if params else None
             )
 
-            images = response.get("items", []) if isinstance(response, dict) else []
-            total_items = response.get("total_items", len(images)) if isinstance(response, dict) else len(images)
+            images = response.data.get("items", []) if isinstance(response.data, dict) else []
+            total_items = response.data.get("total_items", len(images)) if isinstance(response.data, dict) else len(images)
 
             return ActionResult(data={"images": images, "total_items": total_items, "result": True}, cost_usd=0.0)
 
@@ -760,7 +760,7 @@ class GetImageAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/images/{image_id}", method="GET")
 
-            return ActionResult(data={"image": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"image": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -817,7 +817,7 @@ class ListWebhooksAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks", method="GET")
 
-            webhooks = response.get("items", []) if isinstance(response, dict) else []
+            webhooks = response.data.get("items", []) if isinstance(response.data, dict) else []
 
             return ActionResult(data={"webhooks": webhooks, "result": True}, cost_usd=0.0)
 
@@ -847,7 +847,7 @@ class GetWebhookAction(ActionHandler):
 
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}", method="GET")
 
-            return ActionResult(data={"webhook": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"webhook": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -884,7 +884,7 @@ class CreateWebhookAction(ActionHandler):
                 f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}", method="PUT", json=body
             )
 
-            return ActionResult(data={"webhook": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"webhook": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -1,4 +1,9 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
+from autohive_integrations_sdk import (
+    Integration,
+    ExecutionContext,
+    ActionHandler,
+    ActionResult,
+)
 from autohive_integrations_sdk.integration import RateLimitError
 from typing import Dict, Any
 
@@ -10,7 +15,14 @@ TYPEFORM_API_BASE_URL = "https://api.typeform.com"
 
 # Read-only fields that cannot be sent back to the API on form updates
 # These are returned by GET but must be removed before PUT
-FORM_READONLY_FIELDS = {"id", "_links", "created_at", "last_updated_at", "published_at", "self"}
+FORM_READONLY_FIELDS = {
+    "id",
+    "_links",
+    "created_at",
+    "last_updated_at",
+    "published_at",
+    "self",
+}
 
 # Rate limit configuration
 # Typeform rate limits can require 30+ second waits, which exceeds Lambda timeout.
@@ -31,7 +43,10 @@ MAX_RATE_LIMIT_RETRIES = 3  # Maximum recommended retries for rate limit errors
 
 
 def create_rate_limit_response(
-    retry_after_seconds: int, retry_attempt: int = 0, action_name: str = "", empty_data: Dict[str, Any] = None
+    retry_after_seconds: int,
+    retry_attempt: int = 0,
+    action_name: str = "",
+    empty_data: Dict[str, Any] = None,
 ) -> ActionResult:
     """
     Create a structured rate limit response for the LLM.
@@ -108,7 +123,11 @@ def is_rate_limit_error(error: Exception) -> tuple[bool, int]:
     # so we default to 60s (Typeform's typical rate limit window).
     error_str = str(error)
     error_lower = error_str.lower()
-    if "429" in error_str or "rate limit" in error_lower or "too many requests" in error_lower:
+    if (
+        "429" in error_str
+        or "rate limit" in error_lower
+        or "too many requests" in error_lower
+    ):
         return True, 60
 
     return False, 0
@@ -127,7 +146,9 @@ class GetCurrentUserAction(ActionHandler):
         try:
             response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/me", method="GET")
 
-            return ActionResult(data={"user": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"user": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -139,7 +160,9 @@ class GetCurrentUserAction(ActionHandler):
                     empty_data={"user": {}},
                 )
 
-            return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Form Handlers ----
@@ -164,13 +187,26 @@ class ListFormsAction(ActionHandler):
                 params["page_size"] = inputs["page_size"]
 
             response = await context.fetch(
-                f"{TYPEFORM_API_BASE_URL}/forms", method="GET", params=params if params else None
+                f"{TYPEFORM_API_BASE_URL}/forms",
+                method="GET",
+                params=params if params else None,
             )
 
-            forms = response.data.get("items", []) if isinstance(response.data, dict) else []
-            total_items = response.data.get("total_items", len(forms)) if isinstance(response.data, dict) else len(forms)
+            forms = (
+                response.data.get("items", [])
+                if isinstance(response.data, dict)
+                else []
+            )
+            total_items = (
+                response.data.get("total_items", len(forms))
+                if isinstance(response.data, dict)
+                else len(forms)
+            )
 
-            return ActionResult(data={"forms": forms, "total_items": total_items, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"forms": forms, "total_items": total_items, "result": True},
+                cost_usd=0.0,
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -182,7 +218,10 @@ class ListFormsAction(ActionHandler):
                     empty_data={"forms": [], "total_items": 0},
                 )
 
-            return ActionResult(data={"forms": [], "total_items": 0, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"forms": [], "total_items": 0, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @typeform.action("get_form")
@@ -195,9 +234,13 @@ class GetFormAction(ActionHandler):
         try:
             form_id = inputs["form_id"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="GET")
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="GET"
+            )
 
-            return ActionResult(data={"form": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"form": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -209,7 +252,9 @@ class GetFormAction(ActionHandler):
                     empty_data={"form": {}},
                 )
 
-            return ActionResult(data={"form": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"form": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("create_form")
@@ -223,21 +268,29 @@ class CreateFormAction(ActionHandler):
             body = {"title": inputs["title"]}
 
             if inputs.get("workspace_id"):
-                body["workspace"] = {"href": f"{TYPEFORM_API_BASE_URL}/workspaces/{inputs['workspace_id']}"}
+                body["workspace"] = {
+                    "href": f"{TYPEFORM_API_BASE_URL}/workspaces/{inputs['workspace_id']}"
+                }
             if inputs.get("fields"):
                 body["fields"] = inputs["fields"]
             if inputs.get("settings"):
                 body["settings"] = inputs["settings"]
             if inputs.get("theme_id"):
-                body["theme"] = {"href": f"{TYPEFORM_API_BASE_URL}/themes/{inputs['theme_id']}"}
+                body["theme"] = {
+                    "href": f"{TYPEFORM_API_BASE_URL}/themes/{inputs['theme_id']}"
+                }
             if inputs.get("welcome_screens"):
                 body["welcome_screens"] = inputs["welcome_screens"]
             if inputs.get("thankyou_screens"):
                 body["thankyou_screens"] = inputs["thankyou_screens"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms", method="POST", json=body)
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms", method="POST", json=body
+            )
 
-            return ActionResult(data={"form": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"form": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -249,7 +302,9 @@ class CreateFormAction(ActionHandler):
                     empty_data={"form": {}},
                 )
 
-            return ActionResult(data={"form": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"form": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("update_form")
@@ -269,11 +324,17 @@ class UpdateFormAction(ActionHandler):
             form_id = inputs["form_id"]
 
             # First get the existing form - PUT requires full form definition
-            existing_form = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="GET")
+            existing_form = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="GET"
+            )
 
             # Start with full existing form and remove only read-only fields
             # This prevents data loss when updating specific fields
-            body = {k: v for k, v in existing_form.data.items() if k not in FORM_READONLY_FIELDS}
+            body = {
+                k: v
+                for k, v in existing_form.data.items()
+                if k not in FORM_READONLY_FIELDS
+            }
 
             # Apply updates from inputs (only if provided)
             if inputs.get("title"):
@@ -283,16 +344,22 @@ class UpdateFormAction(ActionHandler):
             if inputs.get("settings"):
                 body["settings"] = inputs["settings"]
             if inputs.get("theme_id"):
-                body["theme"] = {"href": f"{TYPEFORM_API_BASE_URL}/themes/{inputs['theme_id']}"}
+                body["theme"] = {
+                    "href": f"{TYPEFORM_API_BASE_URL}/themes/{inputs['theme_id']}"
+                }
             if inputs.get("welcome_screens"):
                 body["welcome_screens"] = inputs["welcome_screens"]
             if inputs.get("thankyou_screens"):
                 body["thankyou_screens"] = inputs["thankyou_screens"]
 
             # Use PUT to replace the entire form
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="PUT", json=body)
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="PUT", json=body
+            )
 
-            return ActionResult(data={"form": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"form": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -304,7 +371,9 @@ class UpdateFormAction(ActionHandler):
                     empty_data={"form": {}},
                 )
 
-            return ActionResult(data={"form": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"form": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("delete_form")
@@ -317,7 +386,9 @@ class DeleteFormAction(ActionHandler):
         try:
             form_id = inputs["form_id"]
 
-            await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="DELETE")
+            await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}", method="DELETE"
+            )
 
             return ActionResult(data={"deleted": True, "result": True}, cost_usd=0.0)
 
@@ -331,7 +402,9 @@ class DeleteFormAction(ActionHandler):
                     empty_data={"deleted": False},
                 )
 
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Response Handlers ----
@@ -348,7 +421,16 @@ class ListResponsesAction(ActionHandler):
             form_id = inputs["form_id"]
             params = {}
 
-            param_keys = ["page_size", "since", "until", "after", "before", "sort", "query", "fields"]
+            param_keys = [
+                "page_size",
+                "since",
+                "until",
+                "after",
+                "before",
+                "sort",
+                "query",
+                "fields",
+            ]
             for key in param_keys:
                 if inputs.get(key):
                     params[key] = inputs[key]
@@ -357,15 +439,34 @@ class ListResponsesAction(ActionHandler):
                 params["completed"] = str(inputs["completed"]).lower()
 
             response = await context.fetch(
-                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/responses", method="GET", params=params if params else None
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/responses",
+                method="GET",
+                params=params if params else None,
             )
 
-            responses = response.data.get("items", []) if isinstance(response.data, dict) else []
-            total_items = response.data.get("total_items", 0) if isinstance(response.data, dict) else 0
-            page_count = response.data.get("page_count", 1) if isinstance(response.data, dict) else 1
+            responses = (
+                response.data.get("items", [])
+                if isinstance(response.data, dict)
+                else []
+            )
+            total_items = (
+                response.data.get("total_items", 0)
+                if isinstance(response.data, dict)
+                else 0
+            )
+            page_count = (
+                response.data.get("page_count", 1)
+                if isinstance(response.data, dict)
+                else 1
+            )
 
             return ActionResult(
-                data={"responses": responses, "total_items": total_items, "page_count": page_count, "result": True},
+                data={
+                    "responses": responses,
+                    "total_items": total_items,
+                    "page_count": page_count,
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
@@ -380,7 +481,13 @@ class ListResponsesAction(ActionHandler):
                 )
 
             return ActionResult(
-                data={"responses": [], "total_items": 0, "page_count": 0, "result": False, "error": str(e)},
+                data={
+                    "responses": [],
+                    "total_items": 0,
+                    "page_count": 0,
+                    "result": False,
+                    "error": str(e),
+                },
                 cost_usd=0.0,
             )
 
@@ -414,7 +521,9 @@ class DeleteResponsesAction(ActionHandler):
                     empty_data={"deleted": False},
                 )
 
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Workspace Handlers ----
@@ -437,16 +546,29 @@ class ListWorkspacesAction(ActionHandler):
                 params["page_size"] = inputs["page_size"]
 
             response = await context.fetch(
-                f"{TYPEFORM_API_BASE_URL}/workspaces", method="GET", params=params if params else None
+                f"{TYPEFORM_API_BASE_URL}/workspaces",
+                method="GET",
+                params=params if params else None,
             )
 
-            workspaces = response.data.get("items", []) if isinstance(response.data, dict) else []
+            workspaces = (
+                response.data.get("items", [])
+                if isinstance(response.data, dict)
+                else []
+            )
             total_items = (
-                response.data.get("total_items", len(workspaces)) if isinstance(response.data, dict) else len(workspaces)
+                response.data.get("total_items", len(workspaces))
+                if isinstance(response.data, dict)
+                else len(workspaces)
             )
 
             return ActionResult(
-                data={"workspaces": workspaces, "total_items": total_items, "result": True}, cost_usd=0.0
+                data={
+                    "workspaces": workspaces,
+                    "total_items": total_items,
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
@@ -460,7 +582,13 @@ class ListWorkspacesAction(ActionHandler):
                 )
 
             return ActionResult(
-                data={"workspaces": [], "total_items": 0, "result": False, "error": str(e)}, cost_usd=0.0
+                data={
+                    "workspaces": [],
+                    "total_items": 0,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0.0,
             )
 
 
@@ -474,9 +602,13 @@ class GetWorkspaceAction(ActionHandler):
         try:
             workspace_id = inputs["workspace_id"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="GET")
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="GET"
+            )
 
-            return ActionResult(data={"workspace": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"workspace": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -488,7 +620,9 @@ class GetWorkspaceAction(ActionHandler):
                     empty_data={"workspace": {}},
                 )
 
-            return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("create_workspace")
@@ -501,9 +635,13 @@ class CreateWorkspaceAction(ActionHandler):
         try:
             body = {"name": inputs["name"]}
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces", method="POST", json=body)
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/workspaces", method="POST", json=body
+            )
 
-            return ActionResult(data={"workspace": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"workspace": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -515,7 +653,9 @@ class CreateWorkspaceAction(ActionHandler):
                     empty_data={"workspace": {}},
                 )
 
-            return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("update_workspace")
@@ -533,12 +673,20 @@ class UpdateWorkspaceAction(ActionHandler):
             body = [{"op": "replace", "path": "/name", "value": inputs["name"]}]
 
             # PATCH returns 204 No Content on success
-            await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="PATCH", json=body)
+            await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}",
+                method="PATCH",
+                json=body,
+            )
 
             # Fetch the updated workspace to return
-            updated_workspace = await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="GET")
+            updated_workspace = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="GET"
+            )
 
-            return ActionResult(data={"workspace": updated_workspace.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"workspace": updated_workspace.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -550,7 +698,9 @@ class UpdateWorkspaceAction(ActionHandler):
                     empty_data={"workspace": {}},
                 )
 
-            return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("delete_workspace")
@@ -563,7 +713,9 @@ class DeleteWorkspaceAction(ActionHandler):
         try:
             workspace_id = inputs["workspace_id"]
 
-            await context.fetch(f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="DELETE")
+            await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/workspaces/{workspace_id}", method="DELETE"
+            )
 
             return ActionResult(data={"deleted": True, "result": True}, cost_usd=0.0)
 
@@ -577,7 +729,9 @@ class DeleteWorkspaceAction(ActionHandler):
                     empty_data={"deleted": False},
                 )
 
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Theme Handlers ----
@@ -598,13 +752,26 @@ class ListThemesAction(ActionHandler):
                 params["page_size"] = inputs["page_size"]
 
             response = await context.fetch(
-                f"{TYPEFORM_API_BASE_URL}/themes", method="GET", params=params if params else None
+                f"{TYPEFORM_API_BASE_URL}/themes",
+                method="GET",
+                params=params if params else None,
             )
 
-            themes = response.data.get("items", []) if isinstance(response.data, dict) else []
-            total_items = response.data.get("total_items", len(themes)) if isinstance(response.data, dict) else len(themes)
+            themes = (
+                response.data.get("items", [])
+                if isinstance(response.data, dict)
+                else []
+            )
+            total_items = (
+                response.data.get("total_items", len(themes))
+                if isinstance(response.data, dict)
+                else len(themes)
+            )
 
-            return ActionResult(data={"themes": themes, "total_items": total_items, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"themes": themes, "total_items": total_items, "result": True},
+                cost_usd=0.0,
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -616,7 +783,10 @@ class ListThemesAction(ActionHandler):
                     empty_data={"themes": [], "total_items": 0},
                 )
 
-            return ActionResult(data={"themes": [], "total_items": 0, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"themes": [], "total_items": 0, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @typeform.action("get_theme")
@@ -629,9 +799,13 @@ class GetThemeAction(ActionHandler):
         try:
             theme_id = inputs["theme_id"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/themes/{theme_id}", method="GET")
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/themes/{theme_id}", method="GET"
+            )
 
-            return ActionResult(data={"theme": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"theme": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -643,7 +817,9 @@ class GetThemeAction(ActionHandler):
                     empty_data={"theme": {}},
                 )
 
-            return ActionResult(data={"theme": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"theme": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("create_theme")
@@ -665,9 +841,13 @@ class CreateThemeAction(ActionHandler):
             if inputs.get("background"):
                 body["background"] = inputs["background"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/themes", method="POST", json=body)
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/themes", method="POST", json=body
+            )
 
-            return ActionResult(data={"theme": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"theme": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -679,7 +859,9 @@ class CreateThemeAction(ActionHandler):
                     empty_data={"theme": {}},
                 )
 
-            return ActionResult(data={"theme": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"theme": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("delete_theme")
@@ -692,7 +874,9 @@ class DeleteThemeAction(ActionHandler):
         try:
             theme_id = inputs["theme_id"]
 
-            await context.fetch(f"{TYPEFORM_API_BASE_URL}/themes/{theme_id}", method="DELETE")
+            await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/themes/{theme_id}", method="DELETE"
+            )
 
             return ActionResult(data={"deleted": True, "result": True}, cost_usd=0.0)
 
@@ -706,7 +890,9 @@ class DeleteThemeAction(ActionHandler):
                     empty_data={"deleted": False},
                 )
 
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Image Handlers ----
@@ -727,13 +913,26 @@ class ListImagesAction(ActionHandler):
                 params["page_size"] = inputs["page_size"]
 
             response = await context.fetch(
-                f"{TYPEFORM_API_BASE_URL}/images", method="GET", params=params if params else None
+                f"{TYPEFORM_API_BASE_URL}/images",
+                method="GET",
+                params=params if params else None,
             )
 
-            images = response.data.get("items", []) if isinstance(response.data, dict) else []
-            total_items = response.data.get("total_items", len(images)) if isinstance(response.data, dict) else len(images)
+            images = (
+                response.data.get("items", [])
+                if isinstance(response.data, dict)
+                else []
+            )
+            total_items = (
+                response.data.get("total_items", len(images))
+                if isinstance(response.data, dict)
+                else len(images)
+            )
 
-            return ActionResult(data={"images": images, "total_items": total_items, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"images": images, "total_items": total_items, "result": True},
+                cost_usd=0.0,
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -745,7 +944,10 @@ class ListImagesAction(ActionHandler):
                     empty_data={"images": [], "total_items": 0},
                 )
 
-            return ActionResult(data={"images": [], "total_items": 0, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"images": [], "total_items": 0, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @typeform.action("get_image")
@@ -758,9 +960,13 @@ class GetImageAction(ActionHandler):
         try:
             image_id = inputs["image_id"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/images/{image_id}", method="GET")
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/images/{image_id}", method="GET"
+            )
 
-            return ActionResult(data={"image": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"image": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -772,7 +978,9 @@ class GetImageAction(ActionHandler):
                     empty_data={"image": {}},
                 )
 
-            return ActionResult(data={"image": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"image": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("delete_image")
@@ -785,7 +993,9 @@ class DeleteImageAction(ActionHandler):
         try:
             image_id = inputs["image_id"]
 
-            await context.fetch(f"{TYPEFORM_API_BASE_URL}/images/{image_id}", method="DELETE")
+            await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/images/{image_id}", method="DELETE"
+            )
 
             return ActionResult(data={"deleted": True, "result": True}, cost_usd=0.0)
 
@@ -799,7 +1009,9 @@ class DeleteImageAction(ActionHandler):
                     empty_data={"deleted": False},
                 )
 
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Webhook Handlers ----
@@ -815,11 +1027,19 @@ class ListWebhooksAction(ActionHandler):
         try:
             form_id = inputs["form_id"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks", method="GET")
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks", method="GET"
+            )
 
-            webhooks = response.data.get("items", []) if isinstance(response.data, dict) else []
+            webhooks = (
+                response.data.get("items", [])
+                if isinstance(response.data, dict)
+                else []
+            )
 
-            return ActionResult(data={"webhooks": webhooks, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"webhooks": webhooks, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -831,7 +1051,9 @@ class ListWebhooksAction(ActionHandler):
                     empty_data={"webhooks": []},
                 )
 
-            return ActionResult(data={"webhooks": [], "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"webhooks": [], "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("get_webhook")
@@ -845,9 +1067,13 @@ class GetWebhookAction(ActionHandler):
             form_id = inputs["form_id"]
             tag = inputs["tag"]
 
-            response = await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}", method="GET")
+            response = await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}", method="GET"
+            )
 
-            return ActionResult(data={"webhook": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"webhook": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -859,7 +1085,9 @@ class GetWebhookAction(ActionHandler):
                     empty_data={"webhook": {}},
                 )
 
-            return ActionResult(data={"webhook": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"webhook": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("create_webhook")
@@ -881,10 +1109,14 @@ class CreateWebhookAction(ActionHandler):
                 body["secret"] = inputs["secret"]
 
             response = await context.fetch(
-                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}", method="PUT", json=body
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}",
+                method="PUT",
+                json=body,
             )
 
-            return ActionResult(data={"webhook": response.data, "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"webhook": response.data, "result": True}, cost_usd=0.0
+            )
 
         except Exception as e:
             is_rate_limit, retry_after = is_rate_limit_error(e)
@@ -896,7 +1128,9 @@ class CreateWebhookAction(ActionHandler):
                     empty_data={"webhook": {}},
                 )
 
-            return ActionResult(data={"webhook": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"webhook": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @typeform.action("delete_webhook")
@@ -910,7 +1144,10 @@ class DeleteWebhookAction(ActionHandler):
             form_id = inputs["form_id"]
             tag = inputs["tag"]
 
-            await context.fetch(f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}", method="DELETE")
+            await context.fetch(
+                f"{TYPEFORM_API_BASE_URL}/forms/{form_id}/webhooks/{tag}",
+                method="DELETE",
+            )
 
             return ActionResult(data={"deleted": True, "result": True}, cost_usd=0.0)
 
@@ -924,4 +1161,6 @@ class DeleteWebhookAction(ActionHandler):
                     empty_data={"deleted": False},
                 )
 
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )

--- a/uber/requirements.txt
+++ b/uber/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/uber/uber.py
+++ b/uber/uber.py
@@ -223,7 +223,7 @@ async def uber_fetch(
         kwargs["json"] = json_body
 
     response = await context.fetch(url, **kwargs)
-    return response
+    return response.data.data
 
 
 # =============================================================================
@@ -577,7 +577,7 @@ async def uber_fetch_v1(
         kwargs["json"] = json_body
 
     response = await context.fetch(url, **kwargs)
-    return response
+    return response.data.data
 
 
 @uber.action("link_loyalty_account")

--- a/webcal/requirements.txt
+++ b/webcal/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 icalendar
 pytz
 requests

--- a/webcal/webcal.py
+++ b/webcal/webcal.py
@@ -20,7 +20,7 @@ class WebCalendarAPI:
         response = await context.fetch(url)
 
         # Parse the iCal data
-        return Calendar.from_ical(response)
+        return Calendar.from_ical(response.data)
 
     @staticmethod
     def convert_to_timezone(dt, timezone_str: str):

--- a/whatsapp/requirements.txt
+++ b/whatsapp/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/whatsapp/whatsapp.py
+++ b/whatsapp/whatsapp.py
@@ -89,13 +89,13 @@ class SendMessageAction(ActionHandler):
             )
 
             # Check for successful response containing message ID
-            if isinstance(response, dict) and "messages" in response and response["messages"]:
-                message_id = response["messages"][0]["id"]
+            if isinstance(response.data, dict) and "messages" in response.data and response.data["messages"]:
+                message_id = response.data["messages"][0]["id"]
                 return ActionResult(data={"message_id": message_id, "success": True})
             else:
                 # Handle API errors or unexpected response structure
-                if isinstance(response, dict):
-                    error_msg = response.get("error", {}).get("message", "Unknown error")
+                if isinstance(response.data, dict):
+                    error_msg = response.data.get("error", {}).get("message", "Unknown error")
                 else:
                     error_msg = f"Unexpected response: {response}"
 
@@ -166,15 +166,15 @@ class SendTemplateMessageAction(ActionHandler):
                 json=template_payload,
             )
 
-            if "messages" in response and response["messages"]:
-                message_id = response["messages"][0]["id"]
+            if "messages" in response.data and response.data["messages"]:
+                message_id = response.data["messages"][0]["id"]
                 return ActionResult(data={"message_id": message_id, "success": True})
             else:
                 return ActionResult(
                     data={
                         "message_id": None,
                         "success": False,
-                        "error": response.get("error", {}).get("message", "Unknown error"),
+                        "error": response.data.get("error", {}).get("message", "Unknown error"),
                     }
                 )
 
@@ -255,15 +255,15 @@ class SendMediaMessageAction(ActionHandler):
                 json=media_payload,
             )
 
-            if "messages" in response and response["messages"]:
-                message_id = response["messages"][0]["id"]
+            if "messages" in response.data and response.data["messages"]:
+                message_id = response.data["messages"][0]["id"]
                 return ActionResult(data={"message_id": message_id, "success": True})
             else:
                 return ActionResult(
                     data={
                         "message_id": None,
                         "success": False,
-                        "error": response.get("error", {}).get("message", "Unknown error"),
+                        "error": response.data.get("error", {}).get("message", "Unknown error"),
                     }
                 )
 
@@ -304,17 +304,17 @@ class GetPhoneNumberHealthAction(ActionHandler):
                 headers={"Authorization": f"Bearer {creds['access_token']}", "Content-Type": "application/json"},
             )
 
-            if "status" in response:
+            if "status" in response.data:
                 return ActionResult(
                     data={
-                        "status": response.get("status", "UNKNOWN"),
-                        "quality_rating": response.get("quality_rating", "UNKNOWN"),
+                        "status": response.data.get("status", "UNKNOWN"),
+                        "quality_rating": response.data.get("quality_rating", "UNKNOWN"),
                         "success": True,
                     }
                 )
             else:
-                if isinstance(response, dict):
-                    error_msg = response.get("error", {}).get("message", "Unknown error")
+                if isinstance(response.data, dict):
+                    error_msg = response.data.get("error", {}).get("message", "Unknown error")
                 else:
                     error_msg = f"Unexpected response: {response}"
 

--- a/x/requirements.txt
+++ b/x/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/x/x.py
+++ b/x/x.py
@@ -31,7 +31,9 @@ class XConnectedAccountHandler(ConnectedAccountHandler):
     async def get_account_info(self, context: ExecutionContext) -> ConnectedAccountInfo:
         """Fetch X user information for the connected account."""
         response = await context.fetch(
-            f"{X_API_BASE_URL}/users/me", method="GET", params={"user.fields": "username,name,profile_image_url"}
+            f"{X_API_BASE_URL}/users/me",
+            method="GET",
+            params={"user.fields": "username,name,profile_image_url"},
         )
 
         user_data = response.data.get("data", {})
@@ -48,14 +50,20 @@ class XConnectedAccountHandler(ConnectedAccountHandler):
             last_name = name_parts[1] if len(name_parts) > 1 else None
 
         return ConnectedAccountInfo(
-            username=username, first_name=first_name, last_name=last_name, user_id=user_id, avatar_url=profile_image
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            user_id=user_id,
+            avatar_url=profile_image,
         )
 
 
 # ---- Media Upload Helper ----
 
 
-async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) -> Dict[str, Any]:
+async def _upload_media(
+    context: ExecutionContext, file_data: Dict[str, Any]
+) -> Dict[str, Any]:
     """Internal helper to upload media using X API v2 chunked upload. Returns dict with media_id or error."""
     media_content = file_data.get("content", "")
     content_type = file_data.get("contentType", "image/jpeg")
@@ -75,11 +83,17 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
     init_response = await context.fetch(
         f"{X_MEDIA_UPLOAD_URL}/initialize",
         method="POST",
-        json={"media_category": media_category, "media_type": content_type, "total_bytes": total_bytes},
+        json={
+            "media_category": media_category,
+            "media_type": content_type,
+            "total_bytes": total_bytes,
+        },
     )
 
     if isinstance(init_response.data, dict) and "errors" in init_response.data:
-        error_msg = init_response.data.get("errors", [{}])[0].get("message", str(init_response))
+        error_msg = init_response.data.get("errors", [{}])[0].get(
+            "message", str(init_response)
+        )
         return {"error": f"Initialize failed: {error_msg}"}
 
     # Extract media_id from response (v2 returns in data object)
@@ -88,7 +102,9 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
         if "data" in init_response.data:
             media_id = init_response.data.get("data", {}).get("id")
         else:
-            media_id = init_response.data.get("media_id_string") or init_response.data.get("media_id")
+            media_id = init_response.data.get(
+                "media_id_string"
+            ) or init_response.data.get("media_id")
 
     if not media_id:
         return {"error": f"No media_id returned: {str(init_response)[:300]}"}
@@ -111,25 +127,31 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
         )
 
         if isinstance(append_response.data, dict) and "errors" in append_response.data:
-            error_msg = append_response.data.get("errors", [{}])[0].get("message", str(append_response))
+            error_msg = append_response.data.get("errors", [{}])[0].get(
+                "message", str(append_response)
+            )
             return {"error": f"Append chunk {segment_index} failed: {error_msg}"}
 
         segment_index += 1
 
     # Step 3: FINALIZE - Complete the upload
-    finalize_response = await context.fetch(f"{X_MEDIA_UPLOAD_URL}/{media_id}/finalize", method="POST")
+    finalize_response = await context.fetch(
+        f"{X_MEDIA_UPLOAD_URL}/{media_id}/finalize", method="POST"
+    )
 
     if isinstance(finalize_response.data, dict) and "errors" in finalize_response.data:
-        error_msg = finalize_response.data.get("errors", [{}])[0].get("message", str(finalize_response))
+        error_msg = finalize_response.data.get("errors", [{}])[0].get(
+            "message", str(finalize_response)
+        )
         return {"error": f"Finalize failed: {error_msg}"}
 
     # Step 4: STATUS - Poll for processing completion (for videos/gifs)
     if media_category in ["tweet_video", "tweet_gif"]:
         processing_info = None
         if isinstance(finalize_response.data, dict):
-            processing_info = finalize_response.data.get("data", {}).get("processing_info") or finalize_response.data.get(
+            processing_info = finalize_response.data.get("data", {}).get(
                 "processing_info"
-            )
+            ) or finalize_response.data.get("processing_info")
 
         if processing_info:
             max_attempts = 30
@@ -141,18 +163,22 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
                 if state == "succeeded":
                     break
                 elif state == "failed":
-                    error_msg = processing_info.get("error", {}).get("message", "Processing failed")
+                    error_msg = processing_info.get("error", {}).get(
+                        "message", "Processing failed"
+                    )
                     return {"error": error_msg}
 
                 wait_time = processing_info.get("check_after_secs", 5)
                 await asyncio.sleep(wait_time)
 
-                status_response = await context.fetch(X_MEDIA_UPLOAD_URL, method="GET", params={"id": media_id})
+                status_response = await context.fetch(
+                    X_MEDIA_UPLOAD_URL, method="GET", params={"id": media_id}
+                )
 
                 if isinstance(status_response.data, dict):
-                    processing_info = status_response.data.get("data", {}).get("processing_info") or status_response.data.get(
+                    processing_info = status_response.data.get("data", {}).get(
                         "processing_info"
-                    )
+                    ) or status_response.data.get("processing_info")
                     if not processing_info:
                         break
                 else:
@@ -186,7 +212,12 @@ class CreateTweetAction(ActionHandler):
                 upload_result = await _upload_media(context, file_data)
                 if "error" in upload_result:
                     return ActionResult(
-                        data={"post": {}, "result": False, "error": upload_result["error"]}, cost_usd=0.0
+                        data={
+                            "post": {},
+                            "result": False,
+                            "error": upload_result["error"],
+                        },
+                        cost_usd=0.0,
                     )
                 media_id = upload_result["media_id"]
                 data["media"] = {"media_ids": [media_id]}
@@ -203,12 +234,21 @@ class CreateTweetAction(ActionHandler):
                     "duration_minutes": inputs.get("poll_duration_minutes", 1440),
                 }
 
-            response = await context.fetch(f"{X_API_BASE_URL}/tweets", method="POST", json=data)
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/tweets", method="POST", json=data
+            )
 
             if isinstance(response.data, dict) and "errors" in response.data:
-                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
+                error_msg = response.data.get("errors", [{}])[0].get(
+                    "message", str(response)
+                )
                 return ActionResult(
-                    data={"post": {}, "media_id": media_id, "result": False, "error": f"Tweet failed: {error_msg}"},
+                    data={
+                        "post": {},
+                        "media_id": media_id,
+                        "result": False,
+                        "error": f"Tweet failed: {error_msg}",
+                    },
                     cost_usd=0.0,
                 )
 
@@ -219,7 +259,9 @@ class CreateTweetAction(ActionHandler):
             return ActionResult(data=result_data, cost_usd=0.0)
 
         except Exception as e:
-            return ActionResult(data={"post": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"post": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("get_tweet")
@@ -231,7 +273,12 @@ class GetTweetAction(ActionHandler):
             post_id = inputs["post_id"]
             params = {}
             expansions = []
-            tweet_fields = ["created_at", "public_metrics", "author_id", "conversation_id"]
+            tweet_fields = [
+                "created_at",
+                "public_metrics",
+                "author_id",
+                "conversation_id",
+            ]
 
             if inputs.get("include_user"):
                 expansions.append("author_id")
@@ -245,16 +292,24 @@ class GetTweetAction(ActionHandler):
             params["tweet.fields"] = ",".join(tweet_fields)
 
             response = await context.fetch(
-                f"{X_API_BASE_URL}/tweets/{post_id}", method="GET", params=params if params else None
+                f"{X_API_BASE_URL}/tweets/{post_id}",
+                method="GET",
+                params=params if params else None,
             )
 
             return ActionResult(
-                data={"post": response.data.get("data", {}), "includes": response.data.get("includes", {}), "result": True},
+                data={
+                    "post": response.data.get("data", {}),
+                    "includes": response.data.get("includes", {}),
+                    "result": True,
+                },
                 cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"post": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"post": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("delete_tweet")
@@ -264,14 +319,22 @@ class DeleteTweetAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             post_id = inputs["post_id"]
-            response = await context.fetch(f"{X_API_BASE_URL}/tweets/{post_id}", method="DELETE")
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/tweets/{post_id}", method="DELETE"
+            )
 
             return ActionResult(
-                data={"deleted": response.data.get("data", {}).get("deleted", False), "result": True}, cost_usd=0.0
+                data={
+                    "deleted": response.data.get("data", {}).get("deleted", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"deleted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("search_tweets")
@@ -296,7 +359,9 @@ class SearchTweetsAction(ActionHandler):
             if inputs.get("next_token"):
                 params["next_token"] = inputs["next_token"]
 
-            response = await context.fetch(f"{X_API_BASE_URL}/tweets/search/recent", method="GET", params=params)
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/tweets/search/recent", method="GET", params=params
+            )
 
             return ActionResult(
                 data={
@@ -309,7 +374,9 @@ class SearchTweetsAction(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("get_user_tweets")
@@ -335,14 +402,23 @@ class GetUserTweetsAction(ActionHandler):
             if excludes:
                 params["exclude"] = ",".join(excludes)
 
-            response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/tweets", method="GET", params=params)
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/users/{user_id}/tweets", method="GET", params=params
+            )
 
             return ActionResult(
-                data={"posts": response.data.get("data", []), "meta": response.data.get("meta", {}), "result": True}, cost_usd=0.0
+                data={
+                    "posts": response.data.get("data", []),
+                    "meta": response.data.get("meta", {}),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("get_liked_tweets")
@@ -363,7 +439,9 @@ class GetLikedTweetsAction(ActionHandler):
                 params["pagination_token"] = inputs["pagination_token"]
 
             response = await context.fetch(
-                f"{X_API_BASE_URL}/users/{user_id}/liked_tweets", method="GET", params=params
+                f"{X_API_BASE_URL}/users/{user_id}/liked_tweets",
+                method="GET",
+                params=params,
             )
 
             return ActionResult(
@@ -377,7 +455,9 @@ class GetLikedTweetsAction(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("get_bookmarks")
@@ -397,11 +477,20 @@ class GetBookmarksAction(ActionHandler):
             if inputs.get("pagination_token"):
                 params["pagination_token"] = inputs["pagination_token"]
 
-            response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/bookmarks", method="GET", params=params)
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/users/{user_id}/bookmarks",
+                method="GET",
+                params=params,
+            )
 
             if isinstance(response.data, dict) and "errors" in response.data:
-                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
-                return ActionResult(data={"posts": [], "result": False, "error": error_msg}, cost_usd=0.0)
+                error_msg = response.data.get("errors", [{}])[0].get(
+                    "message", str(response)
+                )
+                return ActionResult(
+                    data={"posts": [], "result": False, "error": error_msg},
+                    cost_usd=0.0,
+                )
 
             return ActionResult(
                 data={
@@ -414,7 +503,9 @@ class GetBookmarksAction(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"posts": [], "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("bookmark_tweet")
@@ -427,19 +518,33 @@ class BookmarkTweetAction(ActionHandler):
             post_id = inputs["post_id"]
 
             response = await context.fetch(
-                f"{X_API_BASE_URL}/users/{user_id}/bookmarks", method="POST", json={"tweet_id": post_id}
+                f"{X_API_BASE_URL}/users/{user_id}/bookmarks",
+                method="POST",
+                json={"tweet_id": post_id},
             )
 
             if isinstance(response.data, dict) and "errors" in response.data:
-                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
-                return ActionResult(data={"bookmarked": False, "result": False, "error": error_msg}, cost_usd=0.0)
+                error_msg = response.data.get("errors", [{}])[0].get(
+                    "message", str(response)
+                )
+                return ActionResult(
+                    data={"bookmarked": False, "result": False, "error": error_msg},
+                    cost_usd=0.0,
+                )
 
             return ActionResult(
-                data={"bookmarked": response.data.get("data", {}).get("bookmarked", True), "result": True}, cost_usd=0.0
+                data={
+                    "bookmarked": response.data.get("data", {}).get("bookmarked", True),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"bookmarked": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"bookmarked": False, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 @x.action("remove_bookmark")
@@ -451,18 +556,33 @@ class RemoveBookmarkAction(ActionHandler):
             user_id = inputs["user_id"]
             post_id = inputs["post_id"]
 
-            response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/bookmarks/{post_id}", method="DELETE")
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/users/{user_id}/bookmarks/{post_id}", method="DELETE"
+            )
 
             if isinstance(response.data, dict) and "errors" in response.data:
-                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
-                return ActionResult(data={"removed": False, "result": False, "error": error_msg}, cost_usd=0.0)
+                error_msg = response.data.get("errors", [{}])[0].get(
+                    "message", str(response)
+                )
+                return ActionResult(
+                    data={"removed": False, "result": False, "error": error_msg},
+                    cost_usd=0.0,
+                )
 
             return ActionResult(
-                data={"removed": not response.data.get("data", {}).get("bookmarked", True), "result": True}, cost_usd=0.0
+                data={
+                    "removed": not response.data.get("data", {}).get(
+                        "bookmarked", True
+                    ),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"removed": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"removed": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 # ---- Repost Handlers ----
@@ -478,15 +598,23 @@ class RetweetAction(ActionHandler):
             post_id = inputs["post_id"]
 
             response = await context.fetch(
-                f"{X_API_BASE_URL}/users/{user_id}/retweets", method="POST", json={"tweet_id": post_id}
+                f"{X_API_BASE_URL}/users/{user_id}/retweets",
+                method="POST",
+                json={"tweet_id": post_id},
             )
 
             return ActionResult(
-                data={"reposted": response.data.get("data", {}).get("retweeted", False), "result": True}, cost_usd=0.0
+                data={
+                    "reposted": response.data.get("data", {}).get("retweeted", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"reposted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"reposted": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("unretweet")
@@ -498,14 +626,25 @@ class UnretweetAction(ActionHandler):
             user_id = inputs["user_id"]
             post_id = inputs["post_id"]
 
-            response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/retweets/{post_id}", method="DELETE")
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/users/{user_id}/retweets/{post_id}", method="DELETE"
+            )
 
             return ActionResult(
-                data={"unreposted": not response.data.get("data", {}).get("retweeted", True), "result": True}, cost_usd=0.0
+                data={
+                    "unreposted": not response.data.get("data", {}).get(
+                        "retweeted", True
+                    ),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"unreposted": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"unreposted": False, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )
 
 
 # ---- User Handlers ----
@@ -517,7 +656,9 @@ class GetUserAction(ActionHandler):
 
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            params = {"user.fields": "created_at,description,location,public_metrics,verified,profile_image_url,url"}
+            params = {
+                "user.fields": "created_at,description,location,public_metrics,verified,profile_image_url,url"
+            }
 
             if inputs.get("user_id"):
                 url = f"{X_API_BASE_URL}/users/{inputs['user_id']}"
@@ -525,15 +666,25 @@ class GetUserAction(ActionHandler):
                 url = f"{X_API_BASE_URL}/users/by/username/{inputs['username']}"
             else:
                 return ActionResult(
-                    data={"user": {}, "result": False, "error": "Either user_id or username is required"}, cost_usd=0.0
+                    data={
+                        "user": {},
+                        "result": False,
+                        "error": "Either user_id or username is required",
+                    },
+                    cost_usd=0.0,
                 )
 
             response = await context.fetch(url, method="GET", params=params)
 
-            return ActionResult(data={"user": response.data.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"user": response.data.get("data", {}), "result": True},
+                cost_usd=0.0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("get_me")
@@ -542,14 +693,23 @@ class GetMeAction(ActionHandler):
 
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            params = {"user.fields": "created_at,description,location,public_metrics,verified,profile_image_url,url"}
+            params = {
+                "user.fields": "created_at,description,location,public_metrics,verified,profile_image_url,url"
+            }
 
-            response = await context.fetch(f"{X_API_BASE_URL}/users/me", method="GET", params=params)
+            response = await context.fetch(
+                f"{X_API_BASE_URL}/users/me", method="GET", params=params
+            )
 
-            return ActionResult(data={"user": response.data.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(
+                data={"user": response.data.get("data", {}), "result": True},
+                cost_usd=0.0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("follow_user")
@@ -568,11 +728,17 @@ class FollowUserAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"followed": response.data.get("data", {}).get("following", False), "result": True}, cost_usd=0.0
+                data={
+                    "followed": response.data.get("data", {}).get("following", False),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"followed": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"followed": False, "result": False, "error": str(e)}, cost_usd=0.0
+            )
 
 
 @x.action("unfollow_user")
@@ -585,12 +751,22 @@ class UnfollowUserAction(ActionHandler):
             target_user_id = inputs["target_user_id"]
 
             response = await context.fetch(
-                f"{X_API_BASE_URL}/users/{source_user_id}/following/{target_user_id}", method="DELETE"
+                f"{X_API_BASE_URL}/users/{source_user_id}/following/{target_user_id}",
+                method="DELETE",
             )
 
             return ActionResult(
-                data={"unfollowed": not response.data.get("data", {}).get("following", True), "result": True}, cost_usd=0.0
+                data={
+                    "unfollowed": not response.data.get("data", {}).get(
+                        "following", True
+                    ),
+                    "result": True,
+                },
+                cost_usd=0.0,
             )
 
         except Exception as e:
-            return ActionResult(data={"unfollowed": False, "result": False, "error": str(e)}, cost_usd=0.0)
+            return ActionResult(
+                data={"unfollowed": False, "result": False, "error": str(e)},
+                cost_usd=0.0,
+            )

--- a/x/x.py
+++ b/x/x.py
@@ -34,7 +34,7 @@ class XConnectedAccountHandler(ConnectedAccountHandler):
             f"{X_API_BASE_URL}/users/me", method="GET", params={"user.fields": "username,name,profile_image_url"}
         )
 
-        user_data = response.get("data", {})
+        user_data = response.data.get("data", {})
         username = user_data.get("username")
         name = user_data.get("name", "")
         user_id = user_data.get("id")
@@ -78,17 +78,17 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
         json={"media_category": media_category, "media_type": content_type, "total_bytes": total_bytes},
     )
 
-    if isinstance(init_response, dict) and "errors" in init_response:
-        error_msg = init_response.get("errors", [{}])[0].get("message", str(init_response))
+    if isinstance(init_response.data, dict) and "errors" in init_response.data:
+        error_msg = init_response.data.get("errors", [{}])[0].get("message", str(init_response))
         return {"error": f"Initialize failed: {error_msg}"}
 
     # Extract media_id from response (v2 returns in data object)
     media_id = None
-    if isinstance(init_response, dict):
-        if "data" in init_response:
-            media_id = init_response.get("data", {}).get("id")
+    if isinstance(init_response.data, dict):
+        if "data" in init_response.data:
+            media_id = init_response.data.get("data", {}).get("id")
         else:
-            media_id = init_response.get("media_id_string") or init_response.get("media_id")
+            media_id = init_response.data.get("media_id_string") or init_response.data.get("media_id")
 
     if not media_id:
         return {"error": f"No media_id returned: {str(init_response)[:300]}"}
@@ -110,8 +110,8 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
             json={"media": chunk_base64, "segment_index": segment_index},
         )
 
-        if isinstance(append_response, dict) and "errors" in append_response:
-            error_msg = append_response.get("errors", [{}])[0].get("message", str(append_response))
+        if isinstance(append_response.data, dict) and "errors" in append_response.data:
+            error_msg = append_response.data.get("errors", [{}])[0].get("message", str(append_response))
             return {"error": f"Append chunk {segment_index} failed: {error_msg}"}
 
         segment_index += 1
@@ -119,15 +119,15 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
     # Step 3: FINALIZE - Complete the upload
     finalize_response = await context.fetch(f"{X_MEDIA_UPLOAD_URL}/{media_id}/finalize", method="POST")
 
-    if isinstance(finalize_response, dict) and "errors" in finalize_response:
-        error_msg = finalize_response.get("errors", [{}])[0].get("message", str(finalize_response))
+    if isinstance(finalize_response.data, dict) and "errors" in finalize_response.data:
+        error_msg = finalize_response.data.get("errors", [{}])[0].get("message", str(finalize_response))
         return {"error": f"Finalize failed: {error_msg}"}
 
     # Step 4: STATUS - Poll for processing completion (for videos/gifs)
     if media_category in ["tweet_video", "tweet_gif"]:
         processing_info = None
-        if isinstance(finalize_response, dict):
-            processing_info = finalize_response.get("data", {}).get("processing_info") or finalize_response.get(
+        if isinstance(finalize_response.data, dict):
+            processing_info = finalize_response.data.get("data", {}).get("processing_info") or finalize_response.data.get(
                 "processing_info"
             )
 
@@ -149,8 +149,8 @@ async def _upload_media(context: ExecutionContext, file_data: Dict[str, Any]) ->
 
                 status_response = await context.fetch(X_MEDIA_UPLOAD_URL, method="GET", params={"id": media_id})
 
-                if isinstance(status_response, dict):
-                    processing_info = status_response.get("data", {}).get("processing_info") or status_response.get(
+                if isinstance(status_response.data, dict):
+                    processing_info = status_response.data.get("data", {}).get("processing_info") or status_response.data.get(
                         "processing_info"
                     )
                     if not processing_info:
@@ -205,14 +205,14 @@ class CreateTweetAction(ActionHandler):
 
             response = await context.fetch(f"{X_API_BASE_URL}/tweets", method="POST", json=data)
 
-            if isinstance(response, dict) and "errors" in response:
-                error_msg = response.get("errors", [{}])[0].get("message", str(response))
+            if isinstance(response.data, dict) and "errors" in response.data:
+                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
                 return ActionResult(
                     data={"post": {}, "media_id": media_id, "result": False, "error": f"Tweet failed: {error_msg}"},
                     cost_usd=0.0,
                 )
 
-            result_data = {"post": response.get("data", {}), "result": True}
+            result_data = {"post": response.data.get("data", {}), "result": True}
             if media_id:
                 result_data["media_id"] = media_id
 
@@ -249,7 +249,7 @@ class GetTweetAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"post": response.get("data", {}), "includes": response.get("includes", {}), "result": True},
+                data={"post": response.data.get("data", {}), "includes": response.data.get("includes", {}), "result": True},
                 cost_usd=0.0,
             )
 
@@ -267,7 +267,7 @@ class DeleteTweetAction(ActionHandler):
             response = await context.fetch(f"{X_API_BASE_URL}/tweets/{post_id}", method="DELETE")
 
             return ActionResult(
-                data={"deleted": response.get("data", {}).get("deleted", False), "result": True}, cost_usd=0.0
+                data={"deleted": response.data.get("data", {}).get("deleted", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -300,9 +300,9 @@ class SearchTweetsAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "posts": response.get("data", []),
-                    "includes": response.get("includes", {}),
-                    "meta": response.get("meta", {}),
+                    "posts": response.data.get("data", []),
+                    "includes": response.data.get("includes", {}),
+                    "meta": response.data.get("meta", {}),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -338,7 +338,7 @@ class GetUserTweetsAction(ActionHandler):
             response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/tweets", method="GET", params=params)
 
             return ActionResult(
-                data={"posts": response.get("data", []), "meta": response.get("meta", {}), "result": True}, cost_usd=0.0
+                data={"posts": response.data.get("data", []), "meta": response.data.get("meta", {}), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -368,9 +368,9 @@ class GetLikedTweetsAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "posts": response.get("data", []),
-                    "includes": response.get("includes", {}),
-                    "meta": response.get("meta", {}),
+                    "posts": response.data.get("data", []),
+                    "includes": response.data.get("includes", {}),
+                    "meta": response.data.get("meta", {}),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -399,15 +399,15 @@ class GetBookmarksAction(ActionHandler):
 
             response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/bookmarks", method="GET", params=params)
 
-            if isinstance(response, dict) and "errors" in response:
-                error_msg = response.get("errors", [{}])[0].get("message", str(response))
+            if isinstance(response.data, dict) and "errors" in response.data:
+                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
                 return ActionResult(data={"posts": [], "result": False, "error": error_msg}, cost_usd=0.0)
 
             return ActionResult(
                 data={
-                    "posts": response.get("data", []),
-                    "includes": response.get("includes", {}),
-                    "meta": response.get("meta", {}),
+                    "posts": response.data.get("data", []),
+                    "includes": response.data.get("includes", {}),
+                    "meta": response.data.get("meta", {}),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -430,12 +430,12 @@ class BookmarkTweetAction(ActionHandler):
                 f"{X_API_BASE_URL}/users/{user_id}/bookmarks", method="POST", json={"tweet_id": post_id}
             )
 
-            if isinstance(response, dict) and "errors" in response:
-                error_msg = response.get("errors", [{}])[0].get("message", str(response))
+            if isinstance(response.data, dict) and "errors" in response.data:
+                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
                 return ActionResult(data={"bookmarked": False, "result": False, "error": error_msg}, cost_usd=0.0)
 
             return ActionResult(
-                data={"bookmarked": response.get("data", {}).get("bookmarked", True), "result": True}, cost_usd=0.0
+                data={"bookmarked": response.data.get("data", {}).get("bookmarked", True), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -453,12 +453,12 @@ class RemoveBookmarkAction(ActionHandler):
 
             response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/bookmarks/{post_id}", method="DELETE")
 
-            if isinstance(response, dict) and "errors" in response:
-                error_msg = response.get("errors", [{}])[0].get("message", str(response))
+            if isinstance(response.data, dict) and "errors" in response.data:
+                error_msg = response.data.get("errors", [{}])[0].get("message", str(response))
                 return ActionResult(data={"removed": False, "result": False, "error": error_msg}, cost_usd=0.0)
 
             return ActionResult(
-                data={"removed": not response.get("data", {}).get("bookmarked", True), "result": True}, cost_usd=0.0
+                data={"removed": not response.data.get("data", {}).get("bookmarked", True), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -482,7 +482,7 @@ class RetweetAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"reposted": response.get("data", {}).get("retweeted", False), "result": True}, cost_usd=0.0
+                data={"reposted": response.data.get("data", {}).get("retweeted", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -501,7 +501,7 @@ class UnretweetAction(ActionHandler):
             response = await context.fetch(f"{X_API_BASE_URL}/users/{user_id}/retweets/{post_id}", method="DELETE")
 
             return ActionResult(
-                data={"unreposted": not response.get("data", {}).get("retweeted", True), "result": True}, cost_usd=0.0
+                data={"unreposted": not response.data.get("data", {}).get("retweeted", True), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -530,7 +530,7 @@ class GetUserAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params)
 
-            return ActionResult(data={"user": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"user": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -546,7 +546,7 @@ class GetMeAction(ActionHandler):
 
             response = await context.fetch(f"{X_API_BASE_URL}/users/me", method="GET", params=params)
 
-            return ActionResult(data={"user": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"user": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -568,7 +568,7 @@ class FollowUserAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"followed": response.get("data", {}).get("following", False), "result": True}, cost_usd=0.0
+                data={"followed": response.data.get("data", {}).get("following", False), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:
@@ -589,7 +589,7 @@ class UnfollowUserAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"unfollowed": not response.get("data", {}).get("following", True), "result": True}, cost_usd=0.0
+                data={"unfollowed": not response.data.get("data", {}).get("following", True), "result": True}, cost_usd=0.0
             )
 
         except Exception as e:

--- a/xero/requirements.txt
+++ b/xero/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp
 pytest
 pytest-asyncio

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -39,10 +39,10 @@ class XeroConnectedAccountHandler(ConnectedAccountHandler):
             "https://api.xero.com/connections", method="GET", headers={"Accept": "application/json"}
         )
 
-        if not response or not isinstance(response, list) or len(response) == 0:
+        if not response.data or not isinstance(response.data, list) or len(response.data) == 0:
             return ConnectedAccountInfo(username="Unknown Organization")
 
-        first_connection = response[0]
+        first_connection = response.data[0]
         tenant_name = first_connection.get("tenantName", "Unknown Organization")
 
         return ConnectedAccountInfo(username=tenant_name, user_id=first_connection.get("tenantId"))
@@ -101,7 +101,7 @@ class XeroRateLimiter:
         for attempt in range(self.max_retries + 1):
             try:
                 response = await context.fetch(url, **kwargs)
-                return response
+                return response.data
 
             except Exception as e:
                 last_error = e
@@ -147,10 +147,10 @@ async def get_all_connections(context: ExecutionContext) -> list:
             "https://api.xero.com/connections", method="GET", headers={"Accept": "application/json"}
         )
 
-        if not response or not isinstance(response, list) or len(response) == 0:
+        if not response.data or not isinstance(response.data, list) or len(response.data) == 0:
             raise ValueError("No Xero connections found")
 
-        return response
+        return response.data
 
     except Exception as e:
         raise Exception(f"Failed to get connections: {str(e)}")

--- a/youtube/requirements.txt
+++ b/youtube/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 Pillow

--- a/youtube/youtube.py
+++ b/youtube/youtube.py
@@ -1,4 +1,9 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
+from autohive_integrations_sdk import (
+    Integration,
+    ExecutionContext,
+    ActionHandler,
+    ActionResult,
+)
 from typing import Dict, Any
 import base64
 from io import BytesIO
@@ -42,7 +47,9 @@ class YouTubeParser:
         """
         snippet = item.get("snippet", {})
         thumbnails = snippet.get("thumbnails", {})
-        default_thumbnail = thumbnails.get("high", thumbnails.get("medium", thumbnails.get("default", {})))
+        default_thumbnail = thumbnails.get(
+            "high", thumbnails.get("medium", thumbnails.get("default", {}))
+        )
 
         return {
             "id": item.get("id", {}),
@@ -147,7 +154,9 @@ class YouTubeParser:
             "text": comment_snippet.get("textDisplay", ""),
             "text_original": comment_snippet.get("textOriginal", ""),
             "author_display_name": comment_snippet.get("authorDisplayName", ""),
-            "author_channel_id": comment_snippet.get("authorChannelId", {}).get("value", ""),
+            "author_channel_id": comment_snippet.get("authorChannelId", {}).get(
+                "value", ""
+            ),
             "like_count": comment_snippet.get("likeCount", 0),
             "published_at": comment_snippet.get("publishedAt", ""),
             "updated_at": comment_snippet.get("updatedAt", ""),
@@ -184,7 +193,9 @@ class Search(ActionHandler):
             if "page_token" in inputs:
                 params["pageToken"] = inputs["page_token"]
 
-            response = await context.fetch(service_endpoint + "search", method="GET", params=params)
+            response = await context.fetch(
+                service_endpoint + "search", method="GET", params=params
+            )
 
             items = []
             for item in response.data.get("items", []):
@@ -192,7 +203,9 @@ class Search(ActionHandler):
 
             result = {
                 "items": items,
-                "total_results": response.data.get("pageInfo", {}).get("totalResults", 0),
+                "total_results": response.data.get("pageInfo", {}).get(
+                    "totalResults", 0
+                ),
                 "result": True,
             }
 
@@ -202,7 +215,15 @@ class Search(ActionHandler):
             return result
 
         except Exception as e:
-            return ActionResult(data={"items": [], "total_results": 0, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={
+                    "items": [],
+                    "total_results": 0,
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0,
+            )
 
 
 # ---- Video Management ----
@@ -215,19 +236,27 @@ class GetVideo(ActionHandler):
             response = await context.fetch(
                 service_endpoint + "videos",
                 method="GET",
-                params={"part": "snippet,statistics,contentDetails", "id": inputs["video_id"]},
+                params={
+                    "part": "snippet,statistics,contentDetails",
+                    "id": inputs["video_id"],
+                },
             )
 
             items = response.data.get("items", [])
             if not items:
-                return ActionResult(data={"video": {}, "result": False, "error": "Video not found"}, cost_usd=0)
+                return ActionResult(
+                    data={"video": {}, "result": False, "error": "Video not found"},
+                    cost_usd=0,
+                )
 
             video = YouTubeParser.parse_video(items[0])
 
             return ActionResult(data={"video": video, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(data={"video": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"video": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("update_video")
@@ -238,12 +267,17 @@ class UpdateVideo(ActionHandler):
 
             # First, get the existing video
             existing_response = await context.fetch(
-                service_endpoint + "videos", method="GET", params={"part": "snippet,status", "id": video_id}
+                service_endpoint + "videos",
+                method="GET",
+                params={"part": "snippet,status", "id": video_id},
             )
 
             items = existing_response.data.get("items", [])
             if not items:
-                return ActionResult(data={"video": {}, "result": False, "error": "Video not found"}, cost_usd=0)
+                return ActionResult(
+                    data={"video": {}, "result": False, "error": "Video not found"},
+                    cost_usd=0,
+                )
 
             existing_video = items[0]
             snippet = existing_video.get("snippet", {})
@@ -267,18 +301,31 @@ class UpdateVideo(ActionHandler):
             update_data = {"id": video_id, "snippet": snippet, "status": status}
 
             response = await context.fetch(
-                service_endpoint + "videos", method="PUT", params={"part": "snippet,status"}, json=update_data
+                service_endpoint + "videos",
+                method="PUT",
+                params={"part": "snippet,status"},
+                json=update_data,
             )
 
-            return ActionResult(data={"video": YouTubeParser.parse_video(response.data), "result": True}, cost_usd=0)
+            return ActionResult(
+                data={
+                    "video": YouTubeParser.parse_video(response.data),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"video": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"video": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("upload_thumbnail")
 class UploadThumbnail(ActionHandler):
-    def _compress_image(self, image_data: bytes, max_size_mb: float = 2.0) -> tuple[bytes, str]:
+    def _compress_image(
+        self, image_data: bytes, max_size_mb: float = 2.0
+    ) -> tuple[bytes, str]:
         """
         Compress image if it's larger than max_size_mb.
         Returns: (compressed_image_data, mimetype)
@@ -304,7 +351,9 @@ class UploadThumbnail(ActionHandler):
             background = Image.new("RGB", img.size, (255, 255, 255))
             if img.mode == "P":
                 img = img.convert("RGBA")
-            background.paste(img, mask=img.split()[-1] if img.mode in ("RGBA", "LA") else None)
+            background.paste(
+                img, mask=img.split()[-1] if img.mode in ("RGBA", "LA") else None
+            )
             img = background
         elif img.mode != "RGB":
             img = img.convert("RGB")
@@ -327,7 +376,10 @@ class UploadThumbnail(ActionHandler):
         scale_factor = 0.9
 
         while len(compressed_data) > max_size_bytes and min(current_size) > 100:
-            new_size = (int(current_size[0] * scale_factor), int(current_size[1] * scale_factor))
+            new_size = (
+                int(current_size[0] * scale_factor),
+                int(current_size[1] * scale_factor),
+            )
             resized_img = img.resize(new_size, Image.Resampling.LANCZOS)
             output = BytesIO()
             resized_img.save(output, format="JPEG", quality=85, optimize=True)
@@ -358,7 +410,14 @@ class UploadThumbnail(ActionHandler):
                 if content_b64:
                     image_data = base64.b64decode(content_b64)
                 else:
-                    return ActionResult(data={"thumbnail": {}, "result": False, "error": "File object missing 'content' field"}, cost_usd=0)
+                    return ActionResult(
+                        data={
+                            "thumbnail": {},
+                            "result": False,
+                            "error": "File object missing 'content' field",
+                        },
+                        cost_usd=0,
+                    )
             elif image_url:
                 # Fetch the image data from the URL (including conversation file:// URLs)
                 image_response = await context.fetch(image_url, method="GET")
@@ -366,7 +425,10 @@ class UploadThumbnail(ActionHandler):
                 # Get the image content as bytes
                 if isinstance(image_response.data, bytes):
                     image_data = image_response.data
-                elif isinstance(image_response, dict) and "content" in image_response.data:
+                elif (
+                    isinstance(image_response.data, dict)
+                    and "content" in image_response.data
+                ):
                     image_data = image_response.data["content"]
                 else:
                     image_data = str(image_response.data).encode()
@@ -388,7 +450,9 @@ class UploadThumbnail(ActionHandler):
                 compression_info = {
                     "original_size_mb": round(original_size / (1024 * 1024), 2),
                     "compressed_size_mb": round(compressed_size / (1024 * 1024), 2),
-                    "reduction_percent": round(((original_size - compressed_size) / original_size) * 100, 2),
+                    "reduction_percent": round(
+                        ((original_size - compressed_size) / original_size) * 100, 2
+                    ),
                 }
 
             # Upload the thumbnail directly using raw bytes
@@ -410,7 +474,9 @@ class UploadThumbnail(ActionHandler):
             return result
 
         except Exception as e:
-            return ActionResult(data={"thumbnail": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"thumbnail": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 # ---- Channel Management ----
@@ -436,18 +502,25 @@ class GetChannel(ActionHandler):
                     "error": "Must provide channel_id, channel_handle, or set mine=true",
                 }
 
-            response = await context.fetch(service_endpoint + "channels", method="GET", params=params)
+            response = await context.fetch(
+                service_endpoint + "channels", method="GET", params=params
+            )
 
             items = response.data.get("items", [])
             if not items:
-                return ActionResult(data={"channel": {}, "result": False, "error": "Channel not found"}, cost_usd=0)
+                return ActionResult(
+                    data={"channel": {}, "result": False, "error": "Channel not found"},
+                    cost_usd=0,
+                )
 
             channel = YouTubeParser.parse_channel(items[0])
 
             return ActionResult(data={"channel": channel, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return ActionResult(data={"channel": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"channel": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 # ---- Playlist Management ----
@@ -457,19 +530,31 @@ class GetChannel(ActionHandler):
 class ListPlaylists(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            params = {"part": "snippet,contentDetails", "maxResults": inputs.get("max_results", 5)}
+            params = {
+                "part": "snippet,contentDetails",
+                "maxResults": inputs.get("max_results", 5),
+            }
 
             if inputs.get("mine"):
                 params["mine"] = "true"
             elif "channel_id" in inputs:
                 params["channelId"] = inputs["channel_id"]
             else:
-                return ActionResult(data={"playlists": [], "result": False, "error": "Must provide channel_id or set mine=true"}, cost_usd=0)
+                return ActionResult(
+                    data={
+                        "playlists": [],
+                        "result": False,
+                        "error": "Must provide channel_id or set mine=true",
+                    },
+                    cost_usd=0,
+                )
 
             if "page_token" in inputs:
                 params["pageToken"] = inputs["page_token"]
 
-            response = await context.fetch(service_endpoint + "playlists", method="GET", params=params)
+            response = await context.fetch(
+                service_endpoint + "playlists", method="GET", params=params
+            )
 
             playlists = []
             for item in response.data.get("items", []):
@@ -483,7 +568,9 @@ class ListPlaylists(ActionHandler):
             return result
 
         except Exception as e:
-            return ActionResult(data={"playlists": [], "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"playlists": [], "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("create_playlist")
@@ -499,13 +586,24 @@ class CreatePlaylist(ActionHandler):
                 playlist_data["snippet"]["description"] = inputs["description"]
 
             response = await context.fetch(
-                service_endpoint + "playlists", method="POST", params={"part": "snippet,status"}, json=playlist_data
+                service_endpoint + "playlists",
+                method="POST",
+                params={"part": "snippet,status"},
+                json=playlist_data,
             )
 
-            return ActionResult(data={"playlist": YouTubeParser.parse_playlist(response.data), "result": True}, cost_usd=0)
+            return ActionResult(
+                data={
+                    "playlist": YouTubeParser.parse_playlist(response.data),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"playlist": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"playlist": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("update_playlist")
@@ -516,12 +614,21 @@ class UpdatePlaylist(ActionHandler):
 
             # Get existing playlist
             existing_response = await context.fetch(
-                service_endpoint + "playlists", method="GET", params={"part": "snippet,status", "id": playlist_id}
+                service_endpoint + "playlists",
+                method="GET",
+                params={"part": "snippet,status", "id": playlist_id},
             )
 
             items = existing_response.data.get("items", [])
             if not items:
-                return ActionResult(data={"playlist": {}, "result": False, "error": "Playlist not found"}, cost_usd=0)
+                return ActionResult(
+                    data={
+                        "playlist": {},
+                        "result": False,
+                        "error": "Playlist not found",
+                    },
+                    cost_usd=0,
+                )
 
             existing_playlist = items[0]
             snippet = existing_playlist.get("snippet", {})
@@ -538,20 +645,35 @@ class UpdatePlaylist(ActionHandler):
             update_data = {"id": playlist_id, "snippet": snippet, "status": status}
 
             response = await context.fetch(
-                service_endpoint + "playlists", method="PUT", params={"part": "snippet,status"}, json=update_data
+                service_endpoint + "playlists",
+                method="PUT",
+                params={"part": "snippet,status"},
+                json=update_data,
             )
 
-            return ActionResult(data={"playlist": YouTubeParser.parse_playlist(response.data), "result": True}, cost_usd=0)
+            return ActionResult(
+                data={
+                    "playlist": YouTubeParser.parse_playlist(response.data),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"playlist": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"playlist": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("delete_playlist")
 class DeletePlaylist(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            await context.fetch(service_endpoint + "playlists", method="DELETE", params={"id": inputs["playlist_id"]})
+            await context.fetch(
+                service_endpoint + "playlists",
+                method="DELETE",
+                params={"id": inputs["playlist_id"]},
+            )
 
             return ActionResult(data={"result": True}, cost_usd=0)
 
@@ -572,7 +694,9 @@ class ListPlaylistItems(ActionHandler):
             if "page_token" in inputs:
                 params["pageToken"] = inputs["page_token"]
 
-            response = await context.fetch(service_endpoint + "playlistItems", method="GET", params=params)
+            response = await context.fetch(
+                service_endpoint + "playlistItems", method="GET", params=params
+            )
 
             items = []
             for item in response.data.get("items", []):
@@ -598,7 +722,9 @@ class ListPlaylistItems(ActionHandler):
             return result
 
         except Exception as e:
-            return ActionResult(data={"items": [], "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"items": [], "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("add_video_to_playlist")
@@ -608,7 +734,10 @@ class AddVideoToPlaylist(ActionHandler):
             playlist_item_data = {
                 "snippet": {
                     "playlistId": inputs["playlist_id"],
-                    "resourceId": {"kind": "youtube#video", "videoId": inputs["video_id"]},
+                    "resourceId": {
+                        "kind": "youtube#video",
+                        "videoId": inputs["video_id"],
+                    },
                 }
             }
 
@@ -616,13 +745,20 @@ class AddVideoToPlaylist(ActionHandler):
                 playlist_item_data["snippet"]["position"] = inputs["position"]
 
             response = await context.fetch(
-                service_endpoint + "playlistItems", method="POST", params={"part": "snippet"}, json=playlist_item_data
+                service_endpoint + "playlistItems",
+                method="POST",
+                params={"part": "snippet"},
+                json=playlist_item_data,
             )
 
-            return ActionResult(data={"playlist_item": response.data, "result": True}, cost_usd=0)
+            return ActionResult(
+                data={"playlist_item": response.data, "result": True}, cost_usd=0
+            )
 
         except Exception as e:
-            return ActionResult(data={"playlist_item": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"playlist_item": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("remove_video_from_playlist")
@@ -630,7 +766,9 @@ class RemoveVideoFromPlaylist(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             await context.fetch(
-                service_endpoint + "playlistItems", method="DELETE", params={"id": inputs["playlist_item_id"]}
+                service_endpoint + "playlistItems",
+                method="DELETE",
+                params={"id": inputs["playlist_item_id"]},
             )
 
             return ActionResult(data={"result": True}, cost_usd=0)
@@ -658,7 +796,9 @@ class ListComments(ActionHandler):
             if "page_token" in inputs:
                 params["pageToken"] = inputs["page_token"]
 
-            response = await context.fetch(service_endpoint + "commentThreads", method="GET", params=params)
+            response = await context.fetch(
+                service_endpoint + "commentThreads", method="GET", params=params
+            )
 
             comments = []
             for item in response.data.get("items", []):
@@ -672,7 +812,9 @@ class ListComments(ActionHandler):
             return result
 
         except Exception as e:
-            return ActionResult(data={"comments": [], "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"comments": [], "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("list_comment_replies")
@@ -689,7 +831,9 @@ class ListCommentReplies(ActionHandler):
             if "page_token" in inputs:
                 params["pageToken"] = inputs["page_token"]
 
-            response = await context.fetch(service_endpoint + "comments", method="GET", params=params)
+            response = await context.fetch(
+                service_endpoint + "comments", method="GET", params=params
+            )
 
             replies = []
             for item in response.data.get("items", []):
@@ -712,7 +856,9 @@ class ListCommentReplies(ActionHandler):
             return result
 
         except Exception as e:
-            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"replies": [], "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("post_comment")
@@ -727,37 +873,61 @@ class PostComment(ActionHandler):
             }
 
             response = await context.fetch(
-                service_endpoint + "commentThreads", method="POST", params={"part": "snippet"}, json=comment_data
+                service_endpoint + "commentThreads",
+                method="POST",
+                params={"part": "snippet"},
+                json=comment_data,
             )
 
-            return ActionResult(data={"comment": YouTubeParser.parse_comment(response.data), "result": True}, cost_usd=0)
+            return ActionResult(
+                data={
+                    "comment": YouTubeParser.parse_comment(response.data),
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("reply_to_comment")
 class ReplyToComment(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            reply_data = {"snippet": {"parentId": inputs["parent_comment_id"], "textOriginal": inputs["text"]}}
+            reply_data = {
+                "snippet": {
+                    "parentId": inputs["parent_comment_id"],
+                    "textOriginal": inputs["text"],
+                }
+            }
 
             response = await context.fetch(
-                service_endpoint + "comments", method="POST", params={"part": "snippet"}, json=reply_data
+                service_endpoint + "comments",
+                method="POST",
+                params={"part": "snippet"},
+                json=reply_data,
             )
 
             snippet = response.data.get("snippet", {})
-            return ActionResult(data={
-                "comment": {
-                    "id": response.data.get("id", ""),
-                    "text": snippet.get("textDisplay", ""),
-                    "author_display_name": snippet.get("authorDisplayName", ""),
+            return ActionResult(
+                data={
+                    "comment": {
+                        "id": response.data.get("id", ""),
+                        "text": snippet.get("textDisplay", ""),
+                        "author_display_name": snippet.get("authorDisplayName", ""),
+                    },
+                    "result": True,
                 },
-                "result": True,
-            }, cost_usd=0)
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("update_comment")
@@ -768,12 +938,17 @@ class UpdateComment(ActionHandler):
 
             # Get existing comment
             existing_response = await context.fetch(
-                service_endpoint + "comments", method="GET", params={"part": "snippet", "id": comment_id}
+                service_endpoint + "comments",
+                method="GET",
+                params={"part": "snippet", "id": comment_id},
             )
 
             items = existing_response.data.get("items", [])
             if not items:
-                return ActionResult(data={"comment": {}, "result": False, "error": "Comment not found"}, cost_usd=0)
+                return ActionResult(
+                    data={"comment": {}, "result": False, "error": "Comment not found"},
+                    cost_usd=0,
+                )
 
             existing_comment = items[0]
             snippet = existing_comment.get("snippet", {})
@@ -782,20 +957,31 @@ class UpdateComment(ActionHandler):
             update_data = {"id": comment_id, "snippet": snippet}
 
             response = await context.fetch(
-                service_endpoint + "comments", method="PUT", params={"part": "snippet"}, json=update_data
+                service_endpoint + "comments",
+                method="PUT",
+                params={"part": "snippet"},
+                json=update_data,
             )
 
-            return ActionResult(data={"comment": response.data, "result": True}, cost_usd=0)
+            return ActionResult(
+                data={"comment": response.data, "result": True}, cost_usd=0
+            )
 
         except Exception as e:
-            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0
+            )
 
 
 @youtube.action("delete_comment")
 class DeleteComment(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            await context.fetch(service_endpoint + "comments", method="DELETE", params={"id": inputs["comment_id"]})
+            await context.fetch(
+                service_endpoint + "comments",
+                method="DELETE",
+                params={"id": inputs["comment_id"]},
+            )
 
             return ActionResult(data={"result": True}, cost_usd=0)
 
@@ -807,12 +993,19 @@ class DeleteComment(ActionHandler):
 class ModerateComment(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
-            params = {"id": inputs["comment_id"], "moderationStatus": inputs["moderation_status"]}
+            params = {
+                "id": inputs["comment_id"],
+                "moderationStatus": inputs["moderation_status"],
+            }
 
             if inputs.get("ban_author", False):
                 params["banAuthor"] = "true"
 
-            await context.fetch(service_endpoint + "comments/setModerationStatus", method="POST", params=params)
+            await context.fetch(
+                service_endpoint + "comments/setModerationStatus",
+                method="POST",
+                params=params,
+            )
 
             return ActionResult(data={"result": True}, cost_usd=0)
 

--- a/youtube/youtube.py
+++ b/youtube/youtube.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import base64
 from io import BytesIO
@@ -187,22 +187,22 @@ class Search(ActionHandler):
             response = await context.fetch(service_endpoint + "search", method="GET", params=params)
 
             items = []
-            for item in response.get("items", []):
+            for item in response.data.get("items", []):
                 items.append(YouTubeParser.parse_search_result(item))
 
             result = {
                 "items": items,
-                "total_results": response.get("pageInfo", {}).get("totalResults", 0),
+                "total_results": response.data.get("pageInfo", {}).get("totalResults", 0),
                 "result": True,
             }
 
-            if "nextPageToken" in response:
-                result["next_page_token"] = response["nextPageToken"]
+            if "nextPageToken" in response.data:
+                result["next_page_token"] = response.data["nextPageToken"]
 
             return result
 
         except Exception as e:
-            return {"items": [], "total_results": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"items": [], "total_results": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Video Management ----
@@ -218,16 +218,16 @@ class GetVideo(ActionHandler):
                 params={"part": "snippet,statistics,contentDetails", "id": inputs["video_id"]},
             )
 
-            items = response.get("items", [])
+            items = response.data.get("items", [])
             if not items:
-                return {"video": {}, "result": False, "error": "Video not found"}
+                return ActionResult(data={"video": {}, "result": False, "error": "Video not found"}, cost_usd=0)
 
             video = YouTubeParser.parse_video(items[0])
 
-            return {"video": video, "result": True}
+            return ActionResult(data={"video": video, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"video": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"video": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("update_video")
@@ -241,9 +241,9 @@ class UpdateVideo(ActionHandler):
                 service_endpoint + "videos", method="GET", params={"part": "snippet,status", "id": video_id}
             )
 
-            items = existing_response.get("items", [])
+            items = existing_response.data.get("items", [])
             if not items:
-                return {"video": {}, "result": False, "error": "Video not found"}
+                return ActionResult(data={"video": {}, "result": False, "error": "Video not found"}, cost_usd=0)
 
             existing_video = items[0]
             snippet = existing_video.get("snippet", {})
@@ -270,10 +270,10 @@ class UpdateVideo(ActionHandler):
                 service_endpoint + "videos", method="PUT", params={"part": "snippet,status"}, json=update_data
             )
 
-            return {"video": YouTubeParser.parse_video(response), "result": True}
+            return ActionResult(data={"video": YouTubeParser.parse_video(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"video": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"video": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("upload_thumbnail")
@@ -358,18 +358,18 @@ class UploadThumbnail(ActionHandler):
                 if content_b64:
                     image_data = base64.b64decode(content_b64)
                 else:
-                    return {"thumbnail": {}, "result": False, "error": "File object missing 'content' field"}
+                    return ActionResult(data={"thumbnail": {}, "result": False, "error": "File object missing 'content' field"}, cost_usd=0)
             elif image_url:
                 # Fetch the image data from the URL (including conversation file:// URLs)
                 image_response = await context.fetch(image_url, method="GET")
 
                 # Get the image content as bytes
-                if isinstance(image_response, bytes):
-                    image_data = image_response
-                elif isinstance(image_response, dict) and "content" in image_response:
-                    image_data = image_response["content"]
+                if isinstance(image_response.data, bytes):
+                    image_data = image_response.data
+                elif isinstance(image_response, dict) and "content" in image_response.data:
+                    image_data = image_response.data["content"]
                 else:
-                    image_data = str(image_response).encode()
+                    image_data = str(image_response.data).encode()
             else:
                 return {
                     "thumbnail": {},
@@ -401,7 +401,7 @@ class UploadThumbnail(ActionHandler):
                 headers={"Content-Type": mimetype},
             )
 
-            result = {"thumbnail": response, "result": True}
+            result = {"thumbnail": response.data, "result": True}
 
             # Add compression info if compression occurred
             if compression_info:
@@ -410,7 +410,7 @@ class UploadThumbnail(ActionHandler):
             return result
 
         except Exception as e:
-            return {"thumbnail": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"thumbnail": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Channel Management ----
@@ -438,16 +438,16 @@ class GetChannel(ActionHandler):
 
             response = await context.fetch(service_endpoint + "channels", method="GET", params=params)
 
-            items = response.get("items", [])
+            items = response.data.get("items", [])
             if not items:
-                return {"channel": {}, "result": False, "error": "Channel not found"}
+                return ActionResult(data={"channel": {}, "result": False, "error": "Channel not found"}, cost_usd=0)
 
             channel = YouTubeParser.parse_channel(items[0])
 
-            return {"channel": channel, "result": True}
+            return ActionResult(data={"channel": channel, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"channel": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"channel": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Playlist Management ----
@@ -464,7 +464,7 @@ class ListPlaylists(ActionHandler):
             elif "channel_id" in inputs:
                 params["channelId"] = inputs["channel_id"]
             else:
-                return {"playlists": [], "result": False, "error": "Must provide channel_id or set mine=true"}
+                return ActionResult(data={"playlists": [], "result": False, "error": "Must provide channel_id or set mine=true"}, cost_usd=0)
 
             if "page_token" in inputs:
                 params["pageToken"] = inputs["page_token"]
@@ -472,18 +472,18 @@ class ListPlaylists(ActionHandler):
             response = await context.fetch(service_endpoint + "playlists", method="GET", params=params)
 
             playlists = []
-            for item in response.get("items", []):
+            for item in response.data.get("items", []):
                 playlists.append(YouTubeParser.parse_playlist(item))
 
             result = {"playlists": playlists, "result": True}
 
-            if "nextPageToken" in response:
-                result["next_page_token"] = response["nextPageToken"]
+            if "nextPageToken" in response.data:
+                result["next_page_token"] = response.data["nextPageToken"]
 
             return result
 
         except Exception as e:
-            return {"playlists": [], "result": False, "error": str(e)}
+            return ActionResult(data={"playlists": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("create_playlist")
@@ -502,10 +502,10 @@ class CreatePlaylist(ActionHandler):
                 service_endpoint + "playlists", method="POST", params={"part": "snippet,status"}, json=playlist_data
             )
 
-            return {"playlist": YouTubeParser.parse_playlist(response), "result": True}
+            return ActionResult(data={"playlist": YouTubeParser.parse_playlist(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"playlist": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"playlist": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("update_playlist")
@@ -519,9 +519,9 @@ class UpdatePlaylist(ActionHandler):
                 service_endpoint + "playlists", method="GET", params={"part": "snippet,status", "id": playlist_id}
             )
 
-            items = existing_response.get("items", [])
+            items = existing_response.data.get("items", [])
             if not items:
-                return {"playlist": {}, "result": False, "error": "Playlist not found"}
+                return ActionResult(data={"playlist": {}, "result": False, "error": "Playlist not found"}, cost_usd=0)
 
             existing_playlist = items[0]
             snippet = existing_playlist.get("snippet", {})
@@ -541,10 +541,10 @@ class UpdatePlaylist(ActionHandler):
                 service_endpoint + "playlists", method="PUT", params={"part": "snippet,status"}, json=update_data
             )
 
-            return {"playlist": YouTubeParser.parse_playlist(response), "result": True}
+            return ActionResult(data={"playlist": YouTubeParser.parse_playlist(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"playlist": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"playlist": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("delete_playlist")
@@ -553,10 +553,10 @@ class DeletePlaylist(ActionHandler):
         try:
             await context.fetch(service_endpoint + "playlists", method="DELETE", params={"id": inputs["playlist_id"]})
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("list_playlist_items")
@@ -575,7 +575,7 @@ class ListPlaylistItems(ActionHandler):
             response = await context.fetch(service_endpoint + "playlistItems", method="GET", params=params)
 
             items = []
-            for item in response.get("items", []):
+            for item in response.data.get("items", []):
                 snippet = item.get("snippet", {})
                 content_details = item.get("contentDetails", {})
                 items.append(
@@ -592,13 +592,13 @@ class ListPlaylistItems(ActionHandler):
 
             result = {"items": items, "result": True}
 
-            if "nextPageToken" in response:
-                result["next_page_token"] = response["nextPageToken"]
+            if "nextPageToken" in response.data:
+                result["next_page_token"] = response.data["nextPageToken"]
 
             return result
 
         except Exception as e:
-            return {"items": [], "result": False, "error": str(e)}
+            return ActionResult(data={"items": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("add_video_to_playlist")
@@ -619,10 +619,10 @@ class AddVideoToPlaylist(ActionHandler):
                 service_endpoint + "playlistItems", method="POST", params={"part": "snippet"}, json=playlist_item_data
             )
 
-            return {"playlist_item": response, "result": True}
+            return ActionResult(data={"playlist_item": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"playlist_item": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"playlist_item": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("remove_video_from_playlist")
@@ -633,10 +633,10 @@ class RemoveVideoFromPlaylist(ActionHandler):
                 service_endpoint + "playlistItems", method="DELETE", params={"id": inputs["playlist_item_id"]}
             )
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Comment Management ----
@@ -661,18 +661,18 @@ class ListComments(ActionHandler):
             response = await context.fetch(service_endpoint + "commentThreads", method="GET", params=params)
 
             comments = []
-            for item in response.get("items", []):
+            for item in response.data.get("items", []):
                 comments.append(YouTubeParser.parse_comment(item))
 
             result = {"comments": comments, "result": True}
 
-            if "nextPageToken" in response:
-                result["next_page_token"] = response["nextPageToken"]
+            if "nextPageToken" in response.data:
+                result["next_page_token"] = response.data["nextPageToken"]
 
             return result
 
         except Exception as e:
-            return {"comments": [], "result": False, "error": str(e)}
+            return ActionResult(data={"comments": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("list_comment_replies")
@@ -692,7 +692,7 @@ class ListCommentReplies(ActionHandler):
             response = await context.fetch(service_endpoint + "comments", method="GET", params=params)
 
             replies = []
-            for item in response.get("items", []):
+            for item in response.data.get("items", []):
                 snippet = item.get("snippet", {})
                 replies.append(
                     {
@@ -706,13 +706,13 @@ class ListCommentReplies(ActionHandler):
 
             result = {"replies": replies, "result": True}
 
-            if "nextPageToken" in response:
-                result["next_page_token"] = response["nextPageToken"]
+            if "nextPageToken" in response.data:
+                result["next_page_token"] = response.data["nextPageToken"]
 
             return result
 
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("post_comment")
@@ -730,10 +730,10 @@ class PostComment(ActionHandler):
                 service_endpoint + "commentThreads", method="POST", params={"part": "snippet"}, json=comment_data
             )
 
-            return {"comment": YouTubeParser.parse_comment(response), "result": True}
+            return ActionResult(data={"comment": YouTubeParser.parse_comment(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"comment": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("reply_to_comment")
@@ -746,18 +746,18 @@ class ReplyToComment(ActionHandler):
                 service_endpoint + "comments", method="POST", params={"part": "snippet"}, json=reply_data
             )
 
-            snippet = response.get("snippet", {})
-            return {
+            snippet = response.data.get("snippet", {})
+            return ActionResult(data={
                 "comment": {
-                    "id": response.get("id", ""),
+                    "id": response.data.get("id", ""),
                     "text": snippet.get("textDisplay", ""),
                     "author_display_name": snippet.get("authorDisplayName", ""),
                 },
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"comment": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("update_comment")
@@ -771,9 +771,9 @@ class UpdateComment(ActionHandler):
                 service_endpoint + "comments", method="GET", params={"part": "snippet", "id": comment_id}
             )
 
-            items = existing_response.get("items", [])
+            items = existing_response.data.get("items", [])
             if not items:
-                return {"comment": {}, "result": False, "error": "Comment not found"}
+                return ActionResult(data={"comment": {}, "result": False, "error": "Comment not found"}, cost_usd=0)
 
             existing_comment = items[0]
             snippet = existing_comment.get("snippet", {})
@@ -785,10 +785,10 @@ class UpdateComment(ActionHandler):
                 service_endpoint + "comments", method="PUT", params={"part": "snippet"}, json=update_data
             )
 
-            return {"comment": response, "result": True}
+            return ActionResult(data={"comment": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"comment": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("delete_comment")
@@ -797,10 +797,10 @@ class DeleteComment(ActionHandler):
         try:
             await context.fetch(service_endpoint + "comments", method="DELETE", params={"id": inputs["comment_id"]})
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @youtube.action("moderate_comment")
@@ -814,7 +814,7 @@ class ModerateComment(ActionHandler):
 
             await context.fetch(service_endpoint + "comments/setModerationStatus", method="POST", params=params)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)

--- a/zoho/requirements.txt
+++ b/zoho/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/zoho/zoho.py
+++ b/zoho/zoho.py
@@ -645,8 +645,8 @@ class CreateContact(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                contact_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                contact_result = response.data["data"][0]
 
                 if contact_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -696,8 +696,8 @@ class GetContact(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                contact_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                contact_data = response.data["data"][0]
                 return ActionResult(data={"contact": contact_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"contact": {}, "result": False, "error": "Contact not found"}, cost_usd=0)
@@ -727,8 +727,8 @@ class UpdateContact(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                contact_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                contact_result = response.data["data"][0]
 
                 if contact_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -773,8 +773,8 @@ class DeleteContact(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -818,8 +818,8 @@ class ListContacts(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            contacts = response.get("data", [])
-            info = response.get("info", {})
+            contacts = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"contacts": contacts, "info": info, "result": True}, cost_usd=0)
 
@@ -844,8 +844,8 @@ class SearchContacts(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            contacts = response.get("data", [])
-            info = response.get("info", {})
+            contacts = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"contacts": contacts, "info": info, "result": True}, cost_usd=0)
 
@@ -876,8 +876,8 @@ class CreateAccount(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                account_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                account_result = response.data["data"][0]
 
                 if account_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -942,8 +942,8 @@ class GetAccount(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                account_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                account_data = response.data["data"][0]
                 return ActionResult(data={"account": account_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"account": {}, "result": False, "error": "Account not found"}, cost_usd=0)
@@ -973,8 +973,8 @@ class UpdateAccount(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                account_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                account_result = response.data["data"][0]
 
                 if account_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1019,8 +1019,8 @@ class DeleteAccount(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1064,8 +1064,8 @@ class ListAccounts(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            accounts = response.get("data", [])
-            info = response.get("info", {})
+            accounts = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"accounts": accounts, "info": info, "result": True}, cost_usd=0)
 
@@ -1090,8 +1090,8 @@ class SearchAccounts(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            accounts = response.get("data", [])
-            info = response.get("info", {})
+            accounts = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"accounts": accounts, "info": info, "result": True}, cost_usd=0)
 
@@ -1122,8 +1122,8 @@ class CreateDeal(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                deal_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                deal_result = response.data["data"][0]
 
                 if deal_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1189,8 +1189,8 @@ class GetDeal(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                deal_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                deal_data = response.data["data"][0]
                 return ActionResult(data={"deal": deal_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"deal": {}, "result": False, "error": "Deal not found"}, cost_usd=0)
@@ -1220,8 +1220,8 @@ class UpdateDeal(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                deal_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                deal_result = response.data["data"][0]
 
                 if deal_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1266,8 +1266,8 @@ class DeleteDeal(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1308,8 +1308,8 @@ class ListDeals(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            deals = response.get("data", [])
-            info = response.get("info", {})
+            deals = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"deals": deals, "info": info, "result": True}, cost_usd=0)
 
@@ -1333,8 +1333,8 @@ class SearchDeals(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            deals = response.get("data", [])
-            info = response.get("info", {})
+            deals = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"deals": deals, "info": info, "result": True}, cost_usd=0)
 
@@ -1364,8 +1364,8 @@ class CreateLead(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                lead_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                lead_result = response.data["data"][0]
 
                 if lead_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1432,8 +1432,8 @@ class GetLead(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                lead_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                lead_data = response.data["data"][0]
                 return ActionResult(data={"lead": lead_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"lead": {}, "result": False, "error": "Lead not found"}, cost_usd=0)
@@ -1463,8 +1463,8 @@ class UpdateLead(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                lead_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                lead_result = response.data["data"][0]
 
                 if lead_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1509,8 +1509,8 @@ class DeleteLead(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1551,8 +1551,8 @@ class ListLeads(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            leads = response.get("data", [])
-            info = response.get("info", {})
+            leads = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"leads": leads, "info": info, "result": True}, cost_usd=0)
 
@@ -1576,8 +1576,8 @@ class SearchLeads(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            leads = response.get("data", [])
-            info = response.get("info", {})
+            leads = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"leads": leads, "info": info, "result": True}, cost_usd=0)
 
@@ -1631,8 +1631,8 @@ class ConvertLead(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                conversion_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                conversion_result = response.data["data"][0]
 
                 if conversion_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1686,8 +1686,8 @@ class CreateTask(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                task_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                task_result = response.data["data"][0]
 
                 if task_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1752,8 +1752,8 @@ class GetTask(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                task_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                task_data = response.data["data"][0]
                 return ActionResult(data={"task": task_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"task": {}, "result": False, "error": "Task not found"}, cost_usd=0)
@@ -1783,8 +1783,8 @@ class UpdateTask(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                task_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                task_result = response.data["data"][0]
 
                 if task_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1829,8 +1829,8 @@ class DeleteTask(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1871,8 +1871,8 @@ class ListTasks(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            tasks = response.get("data", [])
-            info = response.get("info", {})
+            tasks = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"tasks": tasks, "info": info, "result": True}, cost_usd=0)
 
@@ -1896,8 +1896,8 @@ class SearchTasks(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            tasks = response.get("data", [])
-            info = response.get("info", {})
+            tasks = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"tasks": tasks, "info": info, "result": True}, cost_usd=0)
 
@@ -1927,8 +1927,8 @@ class CreateEvent(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                event_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                event_result = response.data["data"][0]
 
                 if event_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -1994,8 +1994,8 @@ class GetEvent(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                event_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                event_data = response.data["data"][0]
                 return ActionResult(data={"event": event_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"event": {}, "result": False, "error": "Event not found"}, cost_usd=0)
@@ -2025,8 +2025,8 @@ class UpdateEvent(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                event_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                event_result = response.data["data"][0]
 
                 if event_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2071,8 +2071,8 @@ class DeleteEvent(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2113,8 +2113,8 @@ class ListEvents(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            events = response.get("data", [])
-            info = response.get("info", {})
+            events = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"events": events, "info": info, "result": True}, cost_usd=0)
 
@@ -2138,8 +2138,8 @@ class SearchEvents(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            events = response.get("data", [])
-            info = response.get("info", {})
+            events = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"events": events, "info": info, "result": True}, cost_usd=0)
 
@@ -2170,8 +2170,8 @@ class CreateCall(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                call_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                call_result = response.data["data"][0]
 
                 if call_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2237,8 +2237,8 @@ class GetCall(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                call_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                call_data = response.data["data"][0]
                 return ActionResult(data={"call": call_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"call": {}, "result": False, "error": "Call not found"}, cost_usd=0)
@@ -2268,8 +2268,8 @@ class UpdateCall(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                call_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                call_result = response.data["data"][0]
 
                 if call_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2314,8 +2314,8 @@ class DeleteCall(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2356,8 +2356,8 @@ class ListCalls(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            calls = response.get("data", [])
-            info = response.get("info", {})
+            calls = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"calls": calls, "info": info, "result": True}, cost_usd=0)
 
@@ -2381,8 +2381,8 @@ class SearchCalls(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            calls = response.get("data", [])
-            info = response.get("info", {})
+            calls = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"calls": calls, "info": info, "result": True}, cost_usd=0)
 
@@ -2418,8 +2418,8 @@ class GetRelatedRecords(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            related_records = response.get("data", [])
-            info = response.get("info", {})
+            related_records = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"related_records": related_records, "info": info, "result": True}, cost_usd=0)
 
@@ -2685,8 +2685,8 @@ class ExecuteCOQLQuery(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            data = response.get("data", [])
-            info = response.get("info", {})
+            data = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"data": data, "info": info, "result": True}, cost_usd=0)
 
@@ -2717,8 +2717,8 @@ class UpdateRelatedRecords(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                update_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                update_result = response.data["data"][0]
 
                 if update_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2767,8 +2767,8 @@ class CreateNote(ActionHandler):
             response = await context.fetch(url, method="POST", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                note_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                note_result = response.data["data"][0]
 
                 if note_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2817,8 +2817,8 @@ class GetContactNotes(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            notes_data = response.get("data", [])
-            info = response.get("info", {})
+            notes_data = response.data.get("data", [])
+            info = response.data.get("info", {})
 
             return ActionResult(data={"notes": notes_data, "info": info, "result": True}, cost_usd=0)
 
@@ -2849,8 +2849,8 @@ class GetNote(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                note_data = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                note_data = response.data["data"][0]
                 return ActionResult(data={"note": note_data, "result": True}, cost_usd=0)
             else:
                 return ActionResult(data={"note": {}, "result": False, "error": "Note not found"}, cost_usd=0)
@@ -2885,8 +2885,8 @@ class UpdateNote(ActionHandler):
             response = await context.fetch(url, method="PUT", headers=headers, json=payload)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                note_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                note_result = response.data["data"][0]
 
                 if note_result.get("code") == "SUCCESS":
                     return ActionResult(
@@ -2931,8 +2931,8 @@ class DeleteNote(ActionHandler):
             response = await context.fetch(url, method="DELETE", headers=headers)
 
             # Process response
-            if response.get("data") and len(response["data"]) > 0:
-                delete_result = response["data"][0]
+            if response.data.get("data") and len(response.data["data"]) > 0:
+                delete_result = response.data["data"][0]
 
                 if delete_result.get("code") == "SUCCESS":
                     return ActionResult(data={"result": True, "message": "Note deleted successfully"}, cost_usd=0)

--- a/zoho/zoho.py
+++ b/zoho/zoho.py
@@ -2452,7 +2452,7 @@ class GetAccountHierarchy(ActionHandler):
                 params={"fields": "Account_Name,Industry,Phone,Website,Owner"},
             )
 
-            account_data = account_response.get("data", [{}])[0] if account_response.get("data") else {}
+            account_data = account_response.data.get("data", [{}])[0] if account_response.data.get("data") else {}
 
             # Initialize hierarchy data
             hierarchy = {"account": account_data, "contacts": [], "deals": [], "tasks": [], "events": [], "calls": []}
@@ -2470,7 +2470,7 @@ class GetAccountHierarchy(ActionHandler):
                         params={"fields": ",".join(default_fields), "per_page": "50"},
                     )
 
-                    related_data = related_response.get("data", [])
+                    related_data = related_response.data.get("data", [])
                     hierarchy[module.lower()] = related_data
 
                 except Exception:
@@ -2512,7 +2512,7 @@ class GetContactActivities(ActionHandler):
                 params={"fields": "First_Name,Last_Name,Email,Phone,Account_Name"},
             )
 
-            contact_data = contact_response.get("data", [{}])[0] if contact_response.get("data") else {}
+            contact_data = contact_response.data.get("data", [{}])[0] if contact_response.data.get("data") else {}
 
             # Initialize activities data
             activities = {
@@ -2536,7 +2536,7 @@ class GetContactActivities(ActionHandler):
                         params={"fields": ",".join(default_fields), "per_page": "100"},
                     )
 
-                    related_data = related_response.get("data", [])
+                    related_data = related_response.data.get("data", [])
                     activities[module.lower()] = related_data
                     activities["activity_summary"][f"total_{module.lower()}"] = len(related_data)
 
@@ -2579,7 +2579,7 @@ class GetDealRelationships(ActionHandler):
                 params={"fields": "Deal_Name,Stage,Amount,Account_Name,Contact_Name,Owner"},
             )
 
-            deal_data = deal_response.get("data", [{}])[0] if deal_response.get("data") else {}
+            deal_data = deal_response.data.get("data", [{}])[0] if deal_response.data.get("data") else {}
 
             # Initialize relationship data
             relationships = {
@@ -2604,7 +2604,7 @@ class GetDealRelationships(ActionHandler):
                             headers=headers,
                             params={"fields": "Account_Name,Industry,Phone,Website"},
                         )
-                        relationships["account"] = account_response.get("data", [{}])[0]
+                        relationships["account"] = account_response.data.get("data", [{}])[0]
                         relationships["relationship_summary"]["has_account"] = True
                     except Exception:  # nosec B110
                         pass
@@ -2621,7 +2621,7 @@ class GetDealRelationships(ActionHandler):
                             headers=headers,
                             params={"fields": "First_Name,Last_Name,Email,Phone,Title"},
                         )
-                        relationships["contact"] = contact_response.get("data", [{}])[0]
+                        relationships["contact"] = contact_response.data.get("data", [{}])[0]
                         relationships["relationship_summary"]["has_contact"] = True
                     except Exception:  # nosec B110
                         pass
@@ -2643,7 +2643,7 @@ class GetDealRelationships(ActionHandler):
                             params={"fields": ",".join(default_fields), "per_page": "50"},
                         )
 
-                        activity_data = activity_response.get("data", [])
+                        activity_data = activity_response.data.get("data", [])
                         relationships[module.lower()] = activity_data
                         total_activities += len(activity_data)
 

--- a/zoom/requirements.txt
+++ b/zoom/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk==1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/zoom/zoom.py
+++ b/zoom/zoom.py
@@ -62,15 +62,18 @@ class ZoomAPIClient:
         headers = get_headers()
 
         if method == "GET":
-            return await self.context.fetch(url, params=params, headers=headers)
+            response = await self.context.fetch(url, params=params, headers=headers)
+            return response.data
         elif method == "POST":
-            return await self.context.fetch(url, method="POST", json=data, headers=headers)
+            response = await self.context.fetch(url, method="POST", json=data, headers=headers)
+            return response.data
         elif method == "PATCH":
-            return await self.context.fetch(url, method="PATCH", json=data, headers=headers)
+            response = await self.context.fetch(url, method="PATCH", json=data, headers=headers)
+            return response.data
         elif method == "DELETE":
             response = await self.context.fetch(url, method="DELETE", params=params, headers=headers)
             # DELETE typically returns empty response on success
-            return response if response else {"success": True}
+            return response.data if response.data else {"success": True}
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 


### PR DESCRIPTION
## Summary

- Bumps `autohive-integrations-sdk` to `~=2.0.0` in all `requirements.txt` files for integrations: shopify-admin, shopify-customer, shopify-storefront, slider, stripe, substack, supabase, supadata, tiktok, toggl, trello, typeform, uber, webcal, whatsapp, x, xero, youtube, zoho, zoom
- Updates all `context.fetch()` call sites to use `response.data` to access the JSON body (SDK 2.0.0 breaking change: fetch now returns a `FetchResponse` object)
- Wraps all `execute()` method return dicts in `ActionResult(data=..., cost_usd=0)`
- For integrations with central helper patterns (ZoomAPIClient, XeroRateLimiter, uber_fetch/uber_fetch_v1), applied the `.data` unwrap at the helper level so action handlers continue to receive plain dicts

## Test plan

- [ ] Verify each integration's requirements.txt shows `autohive-integrations-sdk~=2.0.0`
- [ ] Spot-check that `context.fetch()` return values are accessed via `.data` before any dict operations
- [ ] Confirm `execute()` methods return `ActionResult` instances
- [ ] Check integrations with helper wrappers (zoom, xero, uber) do not double-unwrap `.data`