### PR TITLE
chore: migrate api-call through fergus to SDK 2.0.0

### DIFF
--- a/api-call/api_call.py
+++ b/api-call/api_call.py
@@ -26,8 +26,8 @@ class GetRequest(ActionHandler):
             # Return success response
             return ActionResult(
                 data={
-                    "status_code": getattr(response, "status_code", 200),
-                    "response_data": response,
+                    "status_code": response.status,
+                    "response_data": response.data,
                     "headers": response_headers,
                     "success": True,
                 },
@@ -83,8 +83,8 @@ class PostRequest(ActionHandler):
             # Return success response
             return ActionResult(
                 data={
-                    "status_code": getattr(response, "status_code", 200),
-                    "response_data": response,
+                    "status_code": response.status,
+                    "response_data": response.data,
                     "headers": response_headers,
                     "success": True,
                 },

--- a/api-call/requirements.txt
+++ b/api-call/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/app-business-reviews/app_business_reviews.py
+++ b/app-business-reviews/app_business_reviews.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -29,7 +29,7 @@ class SearchAppsIOS(ActionHandler):
         response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
         # Extract apps from organic results
-        organic_results = response.get("organic_results", [])
+        organic_results = response.data.get("organic_results", [])
         limit = inputs.get("num", 10)
         apps = []
 
@@ -48,7 +48,7 @@ class SearchAppsIOS(ActionHandler):
             }
             apps.append(app)
 
-        return {"apps": apps, "total_results": len(apps)}
+        return ActionResult(data={"apps": apps, "total_results": len(apps)}, cost_usd=0)
 
 
 @app_business_reviews.action("get_reviews_app_store")
@@ -73,7 +73,7 @@ class GetReviewsAppStore(ActionHandler):
 
             search_response = await context.fetch("https://serpapi.com/search", method="GET", params=search_params)
 
-            organic_results = search_response.get("organic_results", [])
+            organic_results = search_response.data.get("organic_results", [])
             if not organic_results:
                 raise ValueError(f"No apps found for search term: {app_name}")
 
@@ -110,7 +110,7 @@ class GetReviewsAppStore(ActionHandler):
             response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
             # Extract reviews data from current page
-            page_reviews = response.get("reviews", [])
+            page_reviews = response.data.get("reviews", [])
             if not page_reviews:
                 break
 
@@ -139,16 +139,19 @@ class GetReviewsAppStore(ActionHandler):
             current_page += 1
 
             # Check if there are more pages using pagination info
-            pagination_info = response.get("serpapi_pagination", {})
+            pagination_info = response.data.get("serpapi_pagination", {})
             if not pagination_info.get("next"):
                 break
 
-        return {
-            "reviews": all_reviews,
-            "total_reviews": len(all_reviews),
-            "app_name": app_title,
-            "product_id": product_id,
-        }
+        return ActionResult(
+            data={
+                "reviews": all_reviews,
+                "total_reviews": len(all_reviews),
+                "app_name": app_title,
+                "product_id": product_id,
+            },
+            cost_usd=0,
+        )
 
 
 # ---- Google Play Store Actions ----
@@ -166,7 +169,7 @@ class SearchAppsAndroid(ActionHandler):
         response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
         # Extract apps from organic results
-        organic_results = response.get("organic_results", [])
+        organic_results = response.data.get("organic_results", [])
         limit = inputs.get("limit", 10)
         apps = []
 
@@ -189,7 +192,7 @@ class SearchAppsAndroid(ActionHandler):
             if len(apps) >= limit:
                 break
 
-        return {"apps": apps, "total_results": len(apps)}
+        return ActionResult(data={"apps": apps, "total_results": len(apps)}, cost_usd=0)
 
 
 @app_business_reviews.action("get_reviews_google_play")
@@ -210,7 +213,7 @@ class GetReviewsGooglePlay(ActionHandler):
 
             search_response = await context.fetch("https://serpapi.com/search", method="GET", params=search_params)
 
-            organic_results = search_response.get("organic_results", [])
+            organic_results = search_response.data.get("organic_results", [])
             if not organic_results:
                 raise ValueError(f"No apps found for search term: {app_name}")
 
@@ -265,7 +268,7 @@ class GetReviewsGooglePlay(ActionHandler):
             response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
             # Extract reviews data from current page
-            page_reviews = response.get("reviews", [])
+            page_reviews = response.data.get("reviews", [])
             if not page_reviews:
                 break
 
@@ -285,21 +288,24 @@ class GetReviewsGooglePlay(ActionHandler):
             pages_fetched += 1
 
             # Check if there's a next page
-            pagination_info = response.get("serpapi_pagination", {})
+            pagination_info = response.data.get("serpapi_pagination", {})
             next_page_token = pagination_info.get("next_page_token")
             if not next_page_token:
                 break
 
         # Extract app information from the response
-        app_info = response.get("product_info", {})
+        app_info = response.data.get("product_info", {})
 
-        return {
-            "reviews": all_reviews,
-            "total_reviews": len(all_reviews),
-            "app_name": app_info.get("title", ""),
-            "app_rating": app_info.get("rating") or 0.0,
-            "product_id": product_id,
-        }
+        return ActionResult(
+            data={
+                "reviews": all_reviews,
+                "total_reviews": len(all_reviews),
+                "app_name": app_info.get("title", ""),
+                "app_rating": app_info.get("rating") or 0.0,
+                "product_id": product_id,
+            },
+            cost_usd=0,
+        )
 
 
 # ---- Google Maps Actions ----
@@ -323,7 +329,7 @@ class SearchPlacesGoogleMaps(ActionHandler):
         response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
         # Extract places from local results
-        local_results = response.get("local_results", [])
+        local_results = response.data.get("local_results", [])
         limit = inputs.get("num_results", 5)
         places = []
 
@@ -340,7 +346,7 @@ class SearchPlacesGoogleMaps(ActionHandler):
             }
             places.append(place)
 
-        return {"places": places, "total_results": len(places)}
+        return ActionResult(data={"places": places, "total_results": len(places)}, cost_usd=0)
 
 
 @app_business_reviews.action("get_reviews_google_maps")
@@ -369,7 +375,7 @@ class GetReviewsGoogleMaps(ActionHandler):
             # Search for the place to get place_id and data_id
             search_response = await context.fetch("https://serpapi.com/search", method="GET", params=search_params)
 
-            local_results = search_response.get("local_results", [])
+            local_results = search_response.data.get("local_results", [])
             if not local_results:
                 # Provide helpful error message
                 suggestion = (
@@ -426,7 +432,7 @@ class GetReviewsGoogleMaps(ActionHandler):
             response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
             # Extract reviews data from current page
-            page_reviews = response.get("reviews", [])
+            page_reviews = response.data.get("reviews", [])
             if not page_reviews:
                 break
 
@@ -444,12 +450,12 @@ class GetReviewsGoogleMaps(ActionHandler):
             pages_fetched += 1
 
             # Check if there's a next page
-            next_page_token = response.get("serpapi_pagination", {}).get("next_page_token")
+            next_page_token = response.data.get("serpapi_pagination", {}).get("next_page_token")
             if not next_page_token:
                 break
 
         # Extract business information from the last response
-        place_info = response.get("place_info", {})
+        place_info = response.data.get("place_info", {})
 
         # Use business name from search result if we searched, otherwise from place_info
         business_name = place_info.get("title", "")
@@ -458,10 +464,13 @@ class GetReviewsGoogleMaps(ActionHandler):
             if local_results:
                 business_name = local_results[0].get("title", business_name)
 
-        return {
-            "reviews": all_reviews,
-            "total_reviews": len(all_reviews),
-            "average_rating": place_info.get("rating") or 0.0,
-            "business_name": business_name,
-            "place_id": place_id or place_info.get("place_id", inputs.get("place_id", "")),
-        }
+        return ActionResult(
+            data={
+                "reviews": all_reviews,
+                "total_reviews": len(all_reviews),
+                "average_rating": place_info.get("rating") or 0.0,
+                "business_name": business_name,
+                "place_id": place_id or place_info.get("place_id", inputs.get("place_id", "")),
+            },
+            cost_usd=0,
+        )

--- a/app-business-reviews/requirements.txt
+++ b/app-business-reviews/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/asana/asana.py
+++ b/asana/asana.py
@@ -44,7 +44,7 @@ class CreateTaskAction(ActionHandler):
 
             response = await context.fetch(f"{ASANA_API_BASE_URL}/tasks", method="POST", json={"data": data})
 
-            return ActionResult(data={"task": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -67,7 +67,7 @@ class GetTaskAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/tasks/{task_gid}", method="GET", params=params if params else None
             )
 
-            return ActionResult(data={"task": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -98,7 +98,7 @@ class UpdateTaskAction(ActionHandler):
 
             response = await context.fetch(f"{ASANA_API_BASE_URL}/tasks/{task_gid}", method="PUT", json={"data": data})
 
-            return ActionResult(data={"task": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -130,7 +130,7 @@ class ListTasksAction(ActionHandler):
 
             response = await context.fetch(f"{ASANA_API_BASE_URL}/tasks", method="GET", params=params)
 
-            tasks = response.get("data", [])
+            tasks = response.data.get("data", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -175,7 +175,7 @@ class ListProjectsAction(ActionHandler):
 
             response = await context.fetch(f"{ASANA_API_BASE_URL}/projects", method="GET", params=params)
 
-            projects = response.get("data", [])
+            projects = response.data.get("data", [])
             return ActionResult(data={"projects": projects, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -198,7 +198,7 @@ class GetProjectAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/projects/{project_gid}", method="GET", params=params if params else None
             )
 
-            return ActionResult(data={"project": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"project": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"project": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -223,7 +223,7 @@ class CreateProjectAction(ActionHandler):
 
             response = await context.fetch(f"{ASANA_API_BASE_URL}/projects", method="POST", json={"data": data})
 
-            return ActionResult(data={"project": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"project": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"project": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -253,7 +253,7 @@ class UpdateProjectAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/projects/{project_gid}", method="PUT", json={"data": data}
             )
 
-            return ActionResult(data={"project": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"project": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"project": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -305,7 +305,7 @@ class GetProjectByNameAction(ActionHandler):
                 response = await context.fetch(f"{ASANA_API_BASE_URL}/projects", method="GET", params=params)
 
                 # Check if response is successful
-                data = response.get("data", [])
+                data = response.data.get("data", [])
 
                 for project in data:
                     projects_checked += 1
@@ -326,7 +326,7 @@ class GetProjectByNameAction(ActionHandler):
                         )
 
                 # Check for next page
-                next_page = response.get("next_page")
+                next_page = response.data.get("next_page")
                 if next_page and next_page.get("offset"):
                     offset = next_page["offset"]
                 else:
@@ -385,7 +385,7 @@ class ListSectionsAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/projects/{project_gid}/sections", method="GET", params=params if params else None
             )
 
-            sections = response.get("data", [])
+            sections = response.data.get("data", [])
             return ActionResult(data={"sections": sections, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -405,7 +405,7 @@ class CreateSectionAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/projects/{project_gid}/sections", method="POST", json={"data": data}
             )
 
-            return ActionResult(data={"section": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"section": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"section": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -424,7 +424,7 @@ class UpdateSectionAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/sections/{section_gid}", method="PUT", json={"data": data}
             )
 
-            return ActionResult(data={"section": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"section": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"section": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -465,7 +465,7 @@ class CreateStoryAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/tasks/{task_gid}/stories", method="POST", json={"data": data}
             )
 
-            return ActionResult(data={"story": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"story": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"story": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -487,7 +487,7 @@ class ListStoriesAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/tasks/{task_gid}/stories", method="GET", params=params if params else None
             )
 
-            stories = response.get("data", [])
+            stories = response.data.get("data", [])
             return ActionResult(data={"stories": stories, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -517,7 +517,7 @@ class CreateSubtaskAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/tasks/{parent_task_gid}/subtasks", method="POST", json={"data": data}
             )
 
-            return ActionResult(data={"subtask": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"subtask": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"subtask": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -542,7 +542,7 @@ class ListWorkspacesAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/workspaces", method="GET", params=params if params else None
             )
 
-            workspaces = response.get("data", [])
+            workspaces = response.data.get("data", [])
             return ActionResult(data={"workspaces": workspaces, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -565,7 +565,7 @@ class GetWorkspaceAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/workspaces/{workspace_gid}", method="GET", params=params if params else None
             )
 
-            return ActionResult(data={"workspace": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"workspace": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -590,7 +590,7 @@ class GetUserAction(ActionHandler):
                 f"{ASANA_API_BASE_URL}/users/{user_gid}", method="GET", params=params if params else None
             )
 
-            return ActionResult(data={"user": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"user": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"subtask": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/asana/requirements.txt
+++ b/asana/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/aws/requirements.txt
+++ b/aws/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 boto3

--- a/bigquery/bigquery.py
+++ b/bigquery/bigquery.py
@@ -109,7 +109,7 @@ class RunQueryAction(ActionHandler):
                     data={
                         "rows": [],
                         "total_rows": 0,
-                        "total_bytes_processed": int(response.get("totalBytesProcessed", 0)),
+                        "total_bytes_processed": int(response.data.get("totalBytesProcessed", 0)),
                         "job_complete": True,
                         "dry_run": True,
                         "result": True,
@@ -118,27 +118,27 @@ class RunQueryAction(ActionHandler):
                 )
 
             # Parse the response
-            schema = response.get("schema", {})
-            rows = parse_rows(schema, response.get("rows", []))
-            job_complete = response.get("jobComplete", False)
-            job_reference = response.get("jobReference", {})
+            schema = response.data.get("schema", {})
+            rows = parse_rows(schema, response.data.get("rows", []))
+            job_complete = response.data.get("jobComplete", False)
+            job_reference = response.data.get("jobReference", {})
 
             result_data = {
                 "rows": rows,
-                "total_rows": int(response.get("totalRows", 0)) if response.get("totalRows") else len(rows),
+                "total_rows": int(response.data.get("totalRows", 0)) if response.data.get("totalRows") else len(rows),
                 "schema": format_schema(schema),
                 "job_id": job_reference.get("jobId"),
                 "job_complete": job_complete,
                 "total_bytes_processed": (
-                    int(response.get("totalBytesProcessed", 0)) if response.get("totalBytesProcessed") else None
+                    int(response.data.get("totalBytesProcessed", 0)) if response.data.get("totalBytesProcessed") else None
                 ),
-                "cache_hit": response.get("cacheHit"),
+                "cache_hit": response.data.get("cacheHit"),
                 "result": True,
             }
 
             # Add page token if more results available
-            if response.get("pageToken"):
-                result_data["page_token"] = response["pageToken"]
+            if response.data.get("pageToken"):
+                result_data["page_token"] = response.data["pageToken"]
 
             return ActionResult(data=result_data, cost_usd=0.0)
 
@@ -170,19 +170,19 @@ class GetQueryResultsAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params if params else None)
 
-            schema = response.get("schema", {})
-            rows = parse_rows(schema, response.get("rows", []))
+            schema = response.data.get("schema", {})
+            rows = parse_rows(schema, response.data.get("rows", []))
 
             result_data = {
                 "rows": rows,
-                "total_rows": int(response.get("totalRows", 0)) if response.get("totalRows") else len(rows),
+                "total_rows": int(response.data.get("totalRows", 0)) if response.data.get("totalRows") else len(rows),
                 "schema": format_schema(schema),
-                "job_complete": response.get("jobComplete", False),
+                "job_complete": response.data.get("jobComplete", False),
                 "result": True,
             }
 
-            if response.get("pageToken"):
-                result_data["page_token"] = response["pageToken"]
+            if response.data.get("pageToken"):
+                result_data["page_token"] = response.data["pageToken"]
 
             return ActionResult(data=result_data, cost_usd=0.0)
 
@@ -220,7 +220,7 @@ class ListDatasetsAction(ActionHandler):
             response = await context.fetch(url, method="GET", params=params if params else None)
 
             datasets = []
-            for ds in response.get("datasets", []):
+            for ds in response.data.get("datasets", []):
                 dataset_ref = ds.get("datasetReference", {})
                 datasets.append(
                     {
@@ -235,8 +235,8 @@ class ListDatasetsAction(ActionHandler):
 
             result_data = {"datasets": datasets, "result": True}
 
-            if response.get("nextPageToken"):
-                result_data["next_page_token"] = response["nextPageToken"]
+            if response.data.get("nextPageToken"):
+                result_data["next_page_token"] = response.data["nextPageToken"]
 
             return ActionResult(data=result_data, cost_usd=0.0)
 
@@ -257,20 +257,20 @@ class GetDatasetAction(ActionHandler):
 
             response = await context.fetch(url, method="GET")
 
-            dataset_ref = response.get("datasetReference", {})
+            dataset_ref = response.data.get("datasetReference", {})
             dataset = {
-                "id": response.get("id"),
+                "id": response.data.get("id"),
                 "dataset_id": dataset_ref.get("datasetId"),
                 "project_id": dataset_ref.get("projectId"),
-                "friendly_name": response.get("friendlyName"),
-                "description": response.get("description"),
-                "location": response.get("location"),
-                "creation_time": response.get("creationTime"),
-                "last_modified_time": response.get("lastModifiedTime"),
-                "default_table_expiration_ms": response.get("defaultTableExpirationMs"),
-                "default_partition_expiration_ms": response.get("defaultPartitionExpirationMs"),
-                "labels": response.get("labels", {}),
-                "access": response.get("access", []),
+                "friendly_name": response.data.get("friendlyName"),
+                "description": response.data.get("description"),
+                "location": response.data.get("location"),
+                "creation_time": response.data.get("creationTime"),
+                "last_modified_time": response.data.get("lastModifiedTime"),
+                "default_table_expiration_ms": response.data.get("defaultTableExpirationMs"),
+                "default_partition_expiration_ms": response.data.get("defaultPartitionExpirationMs"),
+                "labels": response.data.get("labels", {}),
+                "access": response.data.get("access", []),
             }
 
             return ActionResult(data={"dataset": dataset, "result": True}, cost_usd=0.0)
@@ -305,13 +305,13 @@ class CreateDatasetAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=payload)
 
-            dataset_ref = response.get("datasetReference", {})
+            dataset_ref = response.data.get("datasetReference", {})
             dataset = {
-                "id": response.get("id"),
+                "id": response.data.get("id"),
                 "dataset_id": dataset_ref.get("datasetId"),
                 "project_id": dataset_ref.get("projectId"),
-                "location": response.get("location"),
-                "creation_time": response.get("creationTime"),
+                "location": response.data.get("location"),
+                "creation_time": response.data.get("creationTime"),
             }
 
             return ActionResult(data={"dataset": dataset, "result": True}, cost_usd=0.0)
@@ -369,7 +369,7 @@ class ListTablesAction(ActionHandler):
             response = await context.fetch(url, method="GET", params=params if params else None)
 
             tables = []
-            for tbl in response.get("tables", []):
+            for tbl in response.data.get("tables", []):
                 table_ref = tbl.get("tableReference", {})
                 tables.append(
                     {
@@ -385,10 +385,10 @@ class ListTablesAction(ActionHandler):
                     }
                 )
 
-            result_data = {"tables": tables, "total_items": response.get("totalItems"), "result": True}
+            result_data = {"tables": tables, "total_items": response.data.get("totalItems"), "result": True}
 
-            if response.get("nextPageToken"):
-                result_data["next_page_token"] = response["nextPageToken"]
+            if response.data.get("nextPageToken"):
+                result_data["next_page_token"] = response.data["nextPageToken"]
 
             return ActionResult(data=result_data, cost_usd=0.0)
 
@@ -410,26 +410,26 @@ class GetTableAction(ActionHandler):
 
             response = await context.fetch(url, method="GET")
 
-            table_ref = response.get("tableReference", {})
+            table_ref = response.data.get("tableReference", {})
             table = {
-                "id": response.get("id"),
+                "id": response.data.get("id"),
                 "table_id": table_ref.get("tableId"),
                 "dataset_id": table_ref.get("datasetId"),
                 "project_id": table_ref.get("projectId"),
-                "type": response.get("type"),
-                "friendly_name": response.get("friendlyName"),
-                "description": response.get("description"),
-                "schema": format_schema(response.get("schema", {})),
-                "num_rows": response.get("numRows"),
-                "num_bytes": response.get("numBytes"),
-                "creation_time": response.get("creationTime"),
-                "last_modified_time": response.get("lastModifiedTime"),
-                "expiration_time": response.get("expirationTime"),
-                "location": response.get("location"),
-                "streaming_buffer": response.get("streamingBuffer"),
-                "time_partitioning": response.get("timePartitioning"),
-                "clustering": response.get("clustering"),
-                "labels": response.get("labels", {}),
+                "type": response.data.get("type"),
+                "friendly_name": response.data.get("friendlyName"),
+                "description": response.data.get("description"),
+                "schema": format_schema(response.data.get("schema", {})),
+                "num_rows": response.data.get("numRows"),
+                "num_bytes": response.data.get("numBytes"),
+                "creation_time": response.data.get("creationTime"),
+                "last_modified_time": response.data.get("lastModifiedTime"),
+                "expiration_time": response.data.get("expirationTime"),
+                "location": response.data.get("location"),
+                "streaming_buffer": response.data.get("streamingBuffer"),
+                "time_partitioning": response.data.get("timePartitioning"),
+                "clustering": response.data.get("clustering"),
+                "labels": response.data.get("labels", {}),
             }
 
             return ActionResult(data={"table": table, "result": True}, cost_usd=0.0)
@@ -482,14 +482,14 @@ class CreateTableAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=payload)
 
-            table_ref = response.get("tableReference", {})
+            table_ref = response.data.get("tableReference", {})
             table = {
-                "id": response.get("id"),
+                "id": response.data.get("id"),
                 "table_id": table_ref.get("tableId"),
                 "dataset_id": table_ref.get("datasetId"),
                 "project_id": table_ref.get("projectId"),
-                "schema": format_schema(response.get("schema", {})),
-                "creation_time": response.get("creationTime"),
+                "schema": format_schema(response.data.get("schema", {})),
+                "creation_time": response.data.get("creationTime"),
             }
 
             return ActionResult(data={"table": table, "result": True}, cost_usd=0.0)
@@ -544,7 +544,7 @@ class InsertRowsAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=payload)
 
-            insert_errors = response.get("insertErrors", [])
+            insert_errors = response.data.get("insertErrors", [])
 
             # Count unique failed row indices - a single row can have multiple errors
             # but should only be counted once as a failed insert
@@ -607,7 +607,7 @@ class ListJobsAction(ActionHandler):
             response = await context.fetch(url, method="GET", params=params if params else None)
 
             jobs = []
-            for job in response.get("jobs", []):
+            for job in response.data.get("jobs", []):
                 job_ref = job.get("jobReference", {})
                 status = job.get("status", {})
                 statistics = job.get("statistics", {})
@@ -631,8 +631,8 @@ class ListJobsAction(ActionHandler):
 
             result_data = {"jobs": jobs, "result": True}
 
-            if response.get("nextPageToken"):
-                result_data["next_page_token"] = response["nextPageToken"]
+            if response.data.get("nextPageToken"):
+                result_data["next_page_token"] = response.data["nextPageToken"]
 
             return ActionResult(data=result_data, cost_usd=0.0)
 
@@ -658,13 +658,13 @@ class GetJobAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params if params else None)
 
-            job_ref = response.get("jobReference", {})
-            status = response.get("status", {})
-            statistics = response.get("statistics", {})
-            configuration = response.get("configuration", {})
+            job_ref = response.data.get("jobReference", {})
+            status = response.data.get("status", {})
+            statistics = response.data.get("statistics", {})
+            configuration = response.data.get("configuration", {})
 
             job = {
-                "id": response.get("id"),
+                "id": response.data.get("id"),
                 "job_id": job_ref.get("jobId"),
                 "project_id": job_ref.get("projectId"),
                 "location": job_ref.get("location"),
@@ -679,7 +679,7 @@ class GetJobAction(ActionHandler):
                 "cache_hit": statistics.get("query", {}).get("cacheHit"),
                 "configuration": configuration,
                 # Note: user_email is snake_case in BigQuery API (exception to camelCase convention)
-                "user_email": response.get("user_email"),
+                "user_email": response.data.get("user_email"),
             }
 
             return ActionResult(data={"job": job, "result": True}, cost_usd=0.0)
@@ -711,7 +711,7 @@ class ListProjectsAction(ActionHandler):
             response = await context.fetch(url, method="GET", params=params if params else None)
 
             projects = []
-            for proj in response.get("projects", []):
+            for proj in response.data.get("projects", []):
                 project_ref = proj.get("projectReference", {})
                 projects.append(
                     {
@@ -724,8 +724,8 @@ class ListProjectsAction(ActionHandler):
 
             result_data = {"projects": projects, "result": True}
 
-            if response.get("nextPageToken"):
-                result_data["next_page_token"] = response["nextPageToken"]
+            if response.data.get("nextPageToken"):
+                result_data["next_page_token"] = response.data["nextPageToken"]
 
             return ActionResult(data=result_data, cost_usd=0.0)
 

--- a/bigquery/requirements.txt
+++ b/bigquery/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/bitly/bitly.py
+++ b/bitly/bitly.py
@@ -44,7 +44,7 @@ class GetUserAction(ActionHandler):
         try:
             response = await context.fetch(f"{BITLY_API_BASE_URL}/user", method="GET")
 
-            return ActionResult(data={"user": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"user": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -68,7 +68,7 @@ class ShortenUrlAction(ActionHandler):
 
             response = await context.fetch(f"{BITLY_API_BASE_URL}/shorten", method="POST", json=body)
 
-            return ActionResult(data={"bitlink": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bitlink": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bitlink": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -95,7 +95,7 @@ class CreateBitlinkAction(ActionHandler):
 
             response = await context.fetch(f"{BITLY_API_BASE_URL}/bitlinks", method="POST", json=body)
 
-            return ActionResult(data={"bitlink": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bitlink": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bitlink": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -112,7 +112,7 @@ class GetBitlinkAction(ActionHandler):
 
             response = await context.fetch(f"{BITLY_API_BASE_URL}/bitlinks/{encoded_bitlink}", method="GET")
 
-            return ActionResult(data={"bitlink": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bitlink": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bitlink": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -139,7 +139,7 @@ class UpdateBitlinkAction(ActionHandler):
                 f"{BITLY_API_BASE_URL}/bitlinks/{encoded_bitlink}", method="PATCH", json=body
             )
 
-            return ActionResult(data={"bitlink": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bitlink": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bitlink": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -155,7 +155,7 @@ class ExpandBitlinkAction(ActionHandler):
 
             response = await context.fetch(f"{BITLY_API_BASE_URL}/expand", method="POST", json={"bitlink_id": bitlink})
 
-            return ActionResult(data={"long_url": response.get("long_url", ""), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"long_url": response.data.get("long_url", ""), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"long_url": "", "result": False, "error": str(e)}, cost_usd=0.0)
@@ -182,7 +182,7 @@ class GetClicksAction(ActionHandler):
                 f"{BITLY_API_BASE_URL}/bitlinks/{encoded_bitlink}/clicks", method="GET", params=params
             )
 
-            clicks = response.get("link_clicks", [])
+            clicks = response.data.get("link_clicks", [])
 
             return ActionResult(data={"clicks": clicks, "result": True}, cost_usd=0.0)
 
@@ -210,9 +210,9 @@ class GetClicksSummaryAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "total_clicks": response.get("total_clicks", 0),
-                    "unit": response.get("unit", ""),
-                    "units": response.get("units", 0),
+                    "total_clicks": response.data.get("total_clicks", 0),
+                    "unit": response.data.get("unit", ""),
+                    "units": response.data.get("units", 0),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -235,7 +235,7 @@ class ListBitlinksAction(ActionHandler):
             if not group_guid:
                 # Get user's default group
                 user_response = await context.fetch(f"{BITLY_API_BASE_URL}/user", method="GET")
-                group_guid = user_response.get("default_group_guid")
+                group_guid = user_response.data.get("default_group_guid")
                 if not group_guid:
                     return ActionResult(
                         data={"bitlinks": [], "result": False, "error": "No default_group_guid found for user"},
@@ -261,8 +261,8 @@ class ListBitlinksAction(ActionHandler):
                 params=params if params else None,
             )
 
-            bitlinks = response.get("links", [])
-            pagination = response.get("pagination", {})
+            bitlinks = response.data.get("links", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(
                 data={
@@ -292,7 +292,7 @@ class ListGroupsAction(ActionHandler):
         try:
             response = await context.fetch(f"{BITLY_API_BASE_URL}/groups", method="GET")
 
-            groups = response.get("groups", [])
+            groups = response.data.get("groups", [])
 
             return ActionResult(data={"groups": groups, "result": True}, cost_usd=0.0)
 
@@ -310,7 +310,7 @@ class GetGroupAction(ActionHandler):
 
             response = await context.fetch(f"{BITLY_API_BASE_URL}/groups/{group_guid}", method="GET")
 
-            return ActionResult(data={"group": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"group": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"group": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -327,7 +327,7 @@ class ListOrganizationsAction(ActionHandler):
         try:
             response = await context.fetch(f"{BITLY_API_BASE_URL}/organizations", method="GET")
 
-            organizations = response.get("organizations", [])
+            organizations = response.data.get("organizations", [])
 
             return ActionResult(data={"organizations": organizations, "result": True}, cost_usd=0.0)
 

--- a/bitly/requirements.txt
+++ b/bitly/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/box/box.py
+++ b/box/box.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import json
 import base64
@@ -31,7 +31,7 @@ class ListSharedFolders(ActionHandler):
 
             # Filter for folders only
             folders = []
-            for item in data.get("entries", []):
+            for item in data.data.get("entries", []):
                 if item.get("type") == "folder":
                     folders.append(
                         {
@@ -47,15 +47,15 @@ class ListSharedFolders(ActionHandler):
             response_data = {"folders": folders, "result": True}
 
             # Add pagination token if there are more items
-            total_count = data.get("total_count", 0)
+            total_count = data.data.get("total_count", 0)
             current_offset = int(params.get("offset", 0))
             if current_offset + page_size < total_count:
                 response_data["nextPageToken"] = str(current_offset + page_size)
 
-            return response_data
+            return ActionResult(data=response_data, cost_usd=0)
 
         except Exception as e:
-            return {"folders": [], "result": False, "error": str(e)}
+            return ActionResult(data={"folders": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @box.action("list_files")
@@ -94,7 +94,7 @@ class ListFiles(ActionHandler):
 
             # Format the files response
             files = []
-            entries = data.get("entries", [])
+            entries = data.data.get("entries", [])
             for item in entries:
                 if item.get("type") == "file":
                     files.append(
@@ -111,13 +111,13 @@ class ListFiles(ActionHandler):
             response_data = {"files": files, "result": True}
 
             # Add pagination if available
-            if "next_marker" in data:
-                response_data["nextPageToken"] = data["next_marker"]
+            if "next_marker" in data.data:
+                response_data["nextPageToken"] = data.data["next_marker"]
 
-            return response_data
+            return ActionResult(data=response_data, cost_usd=0)
 
         except Exception as e:
-            return {"files": [], "result": False, "error": str(e)}
+            return ActionResult(data={"files": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @box.action("list_folder_contents")
@@ -135,7 +135,7 @@ class ListFolderContents(ActionHandler):
 
             # Format the items response
             items = []
-            for item in data.get("entries", []):
+            for item in data.data.get("entries", []):
                 formatted_item = {
                     "id": item.get("id"),
                     "name": item.get("name"),
@@ -156,7 +156,7 @@ class ListFolderContents(ActionHandler):
                         subfolder_url = f"{BOX_API_BASE}/folders/{item['id']}/items"
                         sub_data = await context.fetch(subfolder_url, method="GET", params=params)
 
-                        for sub_item in sub_data.get("entries", []):
+                        for sub_item in sub_data.data.get("entries", []):
                             sub_formatted_item = {
                                 "id": sub_item.get("id"),
                                 "name": f"{item['name']}/{sub_item.get('name')}",
@@ -173,13 +173,13 @@ class ListFolderContents(ActionHandler):
             response_data = {"items": items, "result": True}
 
             # Add pagination if available
-            if "next_marker" in data:
-                response_data["nextPageToken"] = data["next_marker"]
+            if "next_marker" in data.data:
+                response_data["nextPageToken"] = data.data["next_marker"]
 
-            return response_data
+            return ActionResult(data=response_data, cost_usd=0)
 
         except Exception as e:
-            return {"items": [], "result": False, "error": str(e)}
+            return ActionResult(data={"items": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @box.action("get_file")
@@ -212,45 +212,54 @@ class GetFile(ActionHandler):
                 async with session.get(content_url, headers=headers) as response:
                     if response.status != 200:
                         error_text = await response.text()
-                        return {
-                            "file": {"name": "", "content": "", "contentType": ""},
-                            "metadata": {"id": file_id},
-                            "result": False,
-                            "error": f"Box API error getting content: {response.status} - {error_text}",
-                        }
+                        return ActionResult(
+                            data={
+                                "file": {"name": "", "content": "", "contentType": ""},
+                                "metadata": {"id": file_id},
+                                "result": False,
+                                "error": f"Box API error getting content: {response.status} - {error_text}",
+                            },
+                            cost_usd=0,
+                        )
 
                     # Read binary content and encode as base64
                     file_content = await response.read()
                     content_base64 = base64.b64encode(file_content).decode("utf-8")
 
             # Extract information from metadata
-            file_name = metadata.get("name", f"file_{file_id}")
-            content_type = metadata.get("content_type") or "application/octet-stream"
+            file_name = metadata.data.get("name", f"file_{file_id}")
+            content_type = metadata.data.get("content_type") or "application/octet-stream"
 
             # Structure the metadata to match the required format
             structured_metadata = {
                 "id": file_id,
                 "name": file_name,
-                "size": str(metadata.get("size", 0)),
+                "size": str(metadata.data.get("size", 0)),
                 "mimeType": content_type,
-                "createdTime": metadata.get("created_at", ""),
-                "modifiedTime": metadata.get("modified_at", ""),
-                "parents": [metadata.get("parent", {}).get("id", "")] if metadata.get("parent") else [],
+                "createdTime": metadata.data.get("created_at", ""),
+                "modifiedTime": metadata.data.get("modified_at", ""),
+                "parents": [metadata.data.get("parent", {}).get("id", "")] if metadata.data.get("parent") else [],
             }
 
-            return {
-                "file": {"name": file_name, "content": content_base64, "contentType": content_type},
-                "metadata": structured_metadata,
-                "result": True,
-            }
+            return ActionResult(
+                data={
+                    "file": {"name": file_name, "content": content_base64, "contentType": content_type},
+                    "metadata": structured_metadata,
+                    "result": True,
+                },
+                cost_usd=0,
+            )
 
         except Exception as e:
-            return {
-                "file": {"name": "", "content": "", "contentType": ""},
-                "metadata": {"id": file_id},
-                "result": False,
-                "error": str(e),
-            }
+            return ActionResult(
+                data={
+                    "file": {"name": "", "content": "", "contentType": ""},
+                    "metadata": {"id": file_id},
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0,
+            )
 
 
 @box.action("upload_file")
@@ -300,7 +309,10 @@ class UploadFile(ActionHandler):
                 async with session.post(url, headers=headers, data=data) as response:
                     if response.status not in [200, 201]:
                         error_text = await response.text()
-                        return {"result": False, "error": f"Box upload error: {response.status} - {error_text}"}
+                        return ActionResult(
+                            data={"result": False, "error": f"Box upload error: {response.status} - {error_text}"},
+                            cost_usd=0,
+                        )
 
                     upload_result = await response.json()
 
@@ -308,23 +320,29 @@ class UploadFile(ActionHandler):
                     entries = upload_result.get("entries", [])
                     if entries:
                         uploaded_file = entries[0]
-                        return {
-                            "file_id": uploaded_file.get("id"),
-                            "file_name": uploaded_file.get("name"),
-                            "file_size": uploaded_file.get("size"),
-                            "content_type": content_type,
-                            "result": True,
-                        }
+                        return ActionResult(
+                            data={
+                                "file_id": uploaded_file.get("id"),
+                                "file_name": uploaded_file.get("name"),
+                                "file_size": uploaded_file.get("size"),
+                                "content_type": content_type,
+                                "result": True,
+                            },
+                            cost_usd=0,
+                        )
                     else:
-                        return {
-                            "file_name": file_name,
-                            "content_type": content_type,
-                            "result": True,
-                            "error": "Upload succeeded but no file details returned",
-                        }
+                        return ActionResult(
+                            data={
+                                "file_name": file_name,
+                                "content_type": content_type,
+                                "result": True,
+                                "error": "Upload succeeded but no file details returned",
+                            },
+                            cost_usd=0,
+                        )
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Polling Trigger Handlers ----

--- a/box/requirements.txt
+++ b/box/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp  # Required directly: SDK context.fetch() lacks binary download and multipart form upload support

--- a/calendly/calendly.py
+++ b/calendly/calendly.py
@@ -26,7 +26,7 @@ class GetCurrentUserAction(ActionHandler):
         try:
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/users/me", method="GET")
 
-            user = response.get("resource", response)
+            user = response.data.get("resource", response.data)
 
             return ActionResult(data={"user": user, "result": True}, cost_usd=0.0)
 
@@ -44,7 +44,7 @@ class GetUserAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/users/{user_uuid}", method="GET")
 
-            user = response.get("resource", response)
+            user = response.data.get("resource", response.data)
 
             return ActionResult(data={"user": user, "result": True}, cost_usd=0.0)
 
@@ -70,8 +70,8 @@ class ListEventTypesAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/event_types", method="GET", params=params if params else None
             )
 
-            event_types = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            event_types = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(
                 data={"event_types": event_types, "pagination": pagination, "result": True}, cost_usd=0.0
@@ -93,7 +93,7 @@ class GetEventTypeAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/event_types/{event_type_uuid}", method="GET")
 
-            event_type = response.get("resource", response)
+            event_type = response.data.get("resource", response.data)
 
             return ActionResult(data={"event_type": event_type, "result": True}, cost_usd=0.0)
 
@@ -129,8 +129,8 @@ class ListScheduledEventsAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/scheduled_events", method="GET", params=params if params else None
             )
 
-            events = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            events = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(data={"events": events, "pagination": pagination, "result": True}, cost_usd=0.0)
 
@@ -148,7 +148,7 @@ class GetScheduledEventAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/scheduled_events/{event_uuid}", method="GET")
 
-            event = response.get("resource", response)
+            event = response.data.get("resource", response.data)
 
             return ActionResult(data={"event": event, "result": True}, cost_usd=0.0)
 
@@ -202,8 +202,8 @@ class ListEventInviteesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            invitees = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            invitees = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(data={"invitees": invitees, "pagination": pagination, "result": True}, cost_usd=0.0)
 
@@ -225,7 +225,7 @@ class GetInviteeAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/scheduled_events/{event_uuid}/invitees/{invitee_uuid}", method="GET"
             )
 
-            invitee = response.get("resource", response)
+            invitee = response.data.get("resource", response.data)
 
             return ActionResult(data={"invitee": invitee, "result": True}, cost_usd=0.0)
 
@@ -252,7 +252,7 @@ class GetEventTypeAvailableTimesAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/event_type_available_times", method="GET", params=params
             )
 
-            available_times = response.get("collection", [])
+            available_times = response.data.get("collection", [])
 
             return ActionResult(data={"available_times": available_times, "result": True}, cost_usd=0.0)
 
@@ -270,7 +270,7 @@ class GetUserBusyTimesAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/user_busy_times", method="GET", params=params)
 
-            busy_times = response.get("collection", [])
+            busy_times = response.data.get("collection", [])
 
             return ActionResult(data={"busy_times": busy_times, "result": True}, cost_usd=0.0)
 
@@ -290,7 +290,7 @@ class ListUserAvailabilitySchedulesAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/user_availability_schedules", method="GET", params=params
             )
 
-            schedules = response.get("collection", [])
+            schedules = response.data.get("collection", [])
 
             return ActionResult(data={"availability_schedules": schedules, "result": True}, cost_usd=0.0)
 
@@ -316,8 +316,8 @@ class ListOrganizationMembershipsAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/organization_memberships", method="GET", params=params if params else None
             )
 
-            memberships = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            memberships = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(
                 data={"memberships": memberships, "pagination": pagination, "result": True}, cost_usd=0.0
@@ -347,8 +347,8 @@ class ListWebhooksAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/webhook_subscriptions", method="GET", params=params if params else None
             )
 
-            webhooks = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            webhooks = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(data={"webhooks": webhooks, "pagination": pagination, "result": True}, cost_usd=0.0)
 
@@ -368,7 +368,7 @@ class GetWebhookAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/webhook_subscriptions/{webhook_uuid}", method="GET"
             )
 
-            webhook = response.get("resource", response)
+            webhook = response.data.get("resource", response.data)
 
             return ActionResult(data={"webhook": webhook, "result": True}, cost_usd=0.0)
 
@@ -396,7 +396,7 @@ class CreateWebhookAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/webhook_subscriptions", method="POST", json=body)
 
-            webhook = response.get("resource", response)
+            webhook = response.data.get("resource", response.data)
 
             return ActionResult(data={"webhook": webhook, "result": True}, cost_usd=0.0)
 
@@ -437,8 +437,8 @@ class ListRoutingFormsAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/routing_forms", method="GET", params=params)
 
-            routing_forms = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            routing_forms = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(
                 data={"routing_forms": routing_forms, "pagination": pagination, "result": True}, cost_usd=0.0
@@ -460,7 +460,7 @@ class GetRoutingFormAction(ActionHandler):
 
             response = await context.fetch(f"{CALENDLY_API_BASE_URL}/routing_forms/{routing_form_uuid}", method="GET")
 
-            routing_form = response.get("resource", response)
+            routing_form = response.data.get("resource", response.data)
 
             return ActionResult(data={"routing_form": routing_form, "result": True}, cost_usd=0.0)
 
@@ -485,8 +485,8 @@ class ListRoutingFormSubmissionsAction(ActionHandler):
                 f"{CALENDLY_API_BASE_URL}/routing_form_submissions", method="GET", params=params
             )
 
-            submissions = response.get("collection", [])
-            pagination = response.get("pagination", {})
+            submissions = response.data.get("collection", [])
+            pagination = response.data.get("pagination", {})
 
             return ActionResult(
                 data={"submissions": submissions, "pagination": pagination, "result": True}, cost_usd=0.0

--- a/calendly/requirements.txt
+++ b/calendly/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/canva/canva.py
+++ b/canva/canva.py
@@ -27,8 +27,8 @@ class CanvaConnectedAccountHandler(ConnectedAccountHandler):
         user_response = await context.fetch(f"{service_endpoint}/v1/users/me", method="GET")
 
         # Extract information from responses
-        display_name = profile_response.get("profile", {}).get("display_name")
-        team_user = user_response.get("team_user", {})
+        display_name = profile_response.data.get("profile", {}).get("display_name")
+        team_user = user_response.data.get("team_user", {})
         user_id = team_user.get("user_id")
         team_id = team_user.get("team_id")
 
@@ -56,7 +56,7 @@ class GetUserCapabilities(ActionHandler):
         try:
             response = await context.fetch(f"{service_endpoint}/v1/users/me/capabilities", method="GET")
 
-            return ActionResult(data={"result": True, "capabilities": response.get("capabilities", [])}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "capabilities": response.data.get("capabilities", [])}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -102,7 +102,7 @@ class UploadAsset(ActionHandler):
             )
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("id"):
                 result["job_id"] = job_data["id"]
@@ -123,7 +123,7 @@ class GetAssetUploadStatus(ActionHandler):
             response = await context.fetch(f"{service_endpoint}/v1/asset-uploads/{job_id}", method="GET")
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("status"):
                 result["status"] = job_data["status"]
@@ -145,8 +145,8 @@ class GetAsset(ActionHandler):
 
             result = {"result": True}
 
-            if response.get("asset"):
-                result["asset"] = response["asset"]
+            if response.data.get("asset"):
+                result["asset"] = response.data["asset"]
 
             return ActionResult(data=result, cost_usd=0.0)
         except Exception as e:
@@ -206,7 +206,7 @@ class CreateDesign(ActionHandler):
 
             result = {"result": True}
 
-            if response.get("design"):
+            if response.data.get("design"):
                 result["design"] = response["design"]
 
             return ActionResult(data=result, cost_usd=0.0)
@@ -232,11 +232,11 @@ class ListDesigns(ActionHandler):
             response = await context.fetch(f"{service_endpoint}/v1/designs", method="GET", params=params)
 
             # Wrap response to match output schema
-            result = {"designs": response.get("items", []), "result": True}
+            result = {"designs": response.data.get("items", []), "result": True}
 
             # Only include continuation if it exists
-            if response.get("continuation"):
-                result["continuation"] = response["continuation"]
+            if response.data.get("continuation"):
+                result["continuation"] = response.data["continuation"]
 
             return ActionResult(data=result, cost_usd=0.0)
         except Exception as e:
@@ -253,7 +253,7 @@ class GetDesign(ActionHandler):
 
             result = {"result": True}
 
-            if response.get("design"):
+            if response.data.get("design"):
                 result["design"] = response["design"]
 
             return ActionResult(data=result, cost_usd=0.0)
@@ -333,7 +333,7 @@ class ExportDesign(ActionHandler):
 
             response = await context.fetch(f"{service_endpoint}/v1/exports", method="POST", json=export_data)
 
-            job_id = response.get("job", {}).get("id")
+            job_id = response.data.get("job", {}).get("id")
 
             return ActionResult(data={"result": True, "job_id": job_id} if job_id else {"result": True}, cost_usd=0.0)
         except Exception as e:
@@ -349,7 +349,7 @@ class GetExportStatus(ActionHandler):
             response = await context.fetch(f"{service_endpoint}/v1/exports/{export_id}", method="GET")
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("status"):
                 result["status"] = job_data["status"]
@@ -405,7 +405,7 @@ class ImportDesign(ActionHandler):
             )
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("id"):
                 result["job_id"] = job_data["id"]
@@ -426,7 +426,7 @@ class GetDesignImportStatus(ActionHandler):
             response = await context.fetch(f"{service_endpoint}/v1/imports/{job_id}", method="GET")
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("status"):
                 result["status"] = job_data["status"]
@@ -452,7 +452,7 @@ class ImportDesignFromUrl(ActionHandler):
             response = await context.fetch(f"{service_endpoint}/v1/url-imports", method="POST", json=import_data)
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("id"):
                 result["job_id"] = job_data["id"]
@@ -473,7 +473,7 @@ class GetUrlImportStatus(ActionHandler):
             response = await context.fetch(f"{service_endpoint}/v1/url-imports/{job_id}", method="GET")
 
             result = {"result": True}
-            job_data = response.get("job", {})
+            job_data = response.data.get("job", {})
 
             if job_data.get("status"):
                 result["status"] = job_data["status"]
@@ -498,7 +498,7 @@ class CreateFolder(ActionHandler):
 
             response = await context.fetch(f"{service_endpoint}/v1/folders", method="POST", json=folder_data)
 
-            return ActionResult(data={"result": True, "folder": response.get("folder")}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "folder": response.data.get("folder")}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -513,7 +513,7 @@ class GetFolder(ActionHandler):
 
             result = {"result": True}
 
-            if response.get("folder"):
+            if response.data.get("folder"):
                 result["folder"] = response["folder"]
 
             return ActionResult(data=result, cost_usd=0.0)
@@ -536,11 +536,11 @@ class ListFolderItems(ActionHandler):
                 f"{service_endpoint}/v1/folders/{folder_id}/items", method="GET", params=params
             )
 
-            result = {"items": response.get("items", []), "result": True}
+            result = {"items": response.data.get("items", []), "result": True}
 
             # Only include continuation if it exists
-            if response.get("continuation"):
-                result["continuation"] = response["continuation"]
+            if response.data.get("continuation"):
+                result["continuation"] = response.data["continuation"]
 
             return ActionResult(data=result, cost_usd=0.0)
         except Exception as e:

--- a/canva/requirements.txt
+++ b/canva/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/circle/circle.py
+++ b/circle/circle.py
@@ -314,13 +314,14 @@ def build_search_params(inputs: Dict[str, Any], allowed_params: List[str]) -> Di
     return params
 
 
-def handle_api_response(response: Dict[str, Any], default_return: Dict[str, Any]) -> Optional[ActionResult]:
+def handle_api_response(response, default_return: Dict[str, Any]) -> Optional[ActionResult]:
     """
     Check API response for errors and handle HTML responses.
     Returns ActionResult if there's an error, None if response is valid.
     """
-    if "error" in response:
-        error_msg = response.get("error", "Unknown error")
+    response_data = response.data if hasattr(response, "data") else response
+    if "error" in response_data:
+        error_msg = response_data.get("error", "Unknown error")
         # Truncate HTML error pages
         if isinstance(error_msg, str) and len(error_msg) > 500:
             error_msg = (
@@ -359,8 +360,8 @@ class SearchPostsAction(ActionHandler):
                 return error_response
 
             # Parse response - Circle API returns paginated data
-            posts = response.get("records", [])
-            count = response.get("count", 0)
+            posts = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"posts": posts, "count": count, "result": True}, cost_usd=0.0)
 
@@ -387,7 +388,7 @@ class GetPostAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"post": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"post": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -426,7 +427,7 @@ class CreatePostAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"post": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"post": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -463,7 +464,7 @@ class UpdatePostAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"post": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"post": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -493,7 +494,7 @@ class SearchMemberByEmailAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"member": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"member": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -524,8 +525,8 @@ class ListMembersAction(ActionHandler):
                 return error_response
 
             # Parse response
-            members = response.get("records", [])
-            count = response.get("count", 0)
+            members = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"members": members, "count": count, "result": True}, cost_usd=0.0)
 
@@ -552,7 +553,7 @@ class GetMemberAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"member": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"member": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -585,8 +586,8 @@ class SearchSpacesAction(ActionHandler):
                 return error_response
 
             # Parse response
-            spaces = response.get("records", [])
-            count = response.get("count", 0)
+            spaces = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"spaces": spaces, "count": count, "result": True}, cost_usd=0.0)
 
@@ -613,7 +614,7 @@ class GetSpaceAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"space": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"space": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -646,8 +647,8 @@ class SearchEventsAction(ActionHandler):
                 return error_response
 
             # Parse response
-            events = response.get("records", [])
-            count = response.get("count", 0)
+            events = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"events": events, "count": count, "result": True}, cost_usd=0.0)
 
@@ -674,7 +675,7 @@ class GetEventAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"event": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"event": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -706,7 +707,7 @@ class CreateCommentAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"comment": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"comment": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -734,8 +735,8 @@ class GetPostCommentsAction(ActionHandler):
                 return error_response
 
             # Parse response
-            comments = response.get("records", [])
-            count = response.get("count", 0)
+            comments = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"comments": comments, "count": count, "result": True}, cost_usd=0.0)
 
@@ -763,7 +764,7 @@ class GetCommunityInfoAction(ActionHandler):
             if error_response:
                 return error_response
 
-            return ActionResult(data={"community": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"community": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -935,8 +936,8 @@ class ListTagsAction(ActionHandler):
                 return error_response
 
             # Parse response
-            tags = response.get("records", [])
-            count = response.get("count", 0)
+            tags = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"tags": tags, "count": count, "result": True}, cost_usd=0.0)
 
@@ -968,8 +969,8 @@ class ListSpaceGroupsAction(ActionHandler):
                 return error_response
 
             # Parse response
-            space_groups = response.get("records", [])
-            count = response.get("count", 0)
+            space_groups = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"space_groups": space_groups, "count": count, "result": True}, cost_usd=0.0)
 
@@ -1007,8 +1008,8 @@ class ListAccessGroupsAction(ActionHandler):
                 return error_response
 
             # Parse response
-            access_groups = response.get("records", [])
-            count = response.get("count", 0)
+            access_groups = response.data.get("records", [])
+            count = response.data.get("count", 0)
 
             return ActionResult(data={"access_groups": access_groups, "count": count, "result": True}, cost_usd=0.0)
 

--- a/circle/requirements.txt
+++ b/circle/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 mistune>=3.0.0

--- a/clickup/clickup.py
+++ b/clickup/clickup.py
@@ -46,7 +46,7 @@ class CreateTaskAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/list/{list_id}/task", method="POST", json=data)
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -69,7 +69,7 @@ class GetTaskAction(ActionHandler):
                 f"{CLICKUP_API_BASE_URL}/task/{task_id}", method="GET", params=params if params else None
             )
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -100,7 +100,7 @@ class UpdateTaskAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/task/{task_id}", method="PUT", json=data)
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -151,7 +151,7 @@ class GetTasksAction(ActionHandler):
                 f"{CLICKUP_API_BASE_URL}/list/{list_id}/task", method="GET", params=params if params else None
             )
 
-            tasks = response.get("tasks", [])
+            tasks = response.data.get("tasks", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -199,7 +199,7 @@ class CreateListAction(ActionHandler):
                 f"{CLICKUP_API_BASE_URL}/{parent_type}/{parent_id}/list", method="POST", json=data
             )
 
-            return ActionResult(data={"list": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"list": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"list": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -215,7 +215,7 @@ class GetListAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/list/{list_id}", method="GET")
 
-            return ActionResult(data={"list": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"list": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"list": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -241,7 +241,7 @@ class UpdateListAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/list/{list_id}", method="PUT", json=data)
 
-            return ActionResult(data={"list": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"list": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"list": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -295,7 +295,7 @@ class GetListsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            lists = response.get("lists", [])
+            lists = response.data.get("lists", [])
             return ActionResult(data={"lists": lists, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -316,7 +316,7 @@ class CreateFolderAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/space/{space_id}/folder", method="POST", json=data)
 
-            return ActionResult(data={"folder": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"folder": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"folder": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -332,7 +332,7 @@ class GetFolderAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/folder/{folder_id}", method="GET")
 
-            return ActionResult(data={"folder": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"folder": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"folder": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -349,7 +349,7 @@ class UpdateFolderAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/folder/{folder_id}", method="PUT", json=data)
 
-            return ActionResult(data={"folder": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"folder": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"folder": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -387,7 +387,7 @@ class GetFoldersAction(ActionHandler):
                 f"{CLICKUP_API_BASE_URL}/space/{space_id}/folder", method="GET", params=params if params else None
             )
 
-            folders = response.get("folders", [])
+            folders = response.data.get("folders", [])
             return ActionResult(data={"folders": folders, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -407,7 +407,7 @@ class GetSpaceAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/space/{space_id}", method="GET")
 
-            return ActionResult(data={"space": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"space": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"space": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -429,7 +429,7 @@ class GetSpacesAction(ActionHandler):
                 f"{CLICKUP_API_BASE_URL}/team/{team_id}/space", method="GET", params=params if params else None
             )
 
-            spaces = response.get("spaces", [])
+            spaces = response.data.get("spaces", [])
             return ActionResult(data={"spaces": spaces, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -447,7 +447,7 @@ class GetAuthorizedTeamsAction(ActionHandler):
         try:
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/team", method="GET")
 
-            teams = response.get("teams", [])
+            teams = response.data.get("teams", [])
             return ActionResult(data={"teams": teams, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -474,7 +474,7 @@ class CreateTaskCommentAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/task/{task_id}/comment", method="POST", json=data)
 
-            return ActionResult(data={"comment": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"comment": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -490,7 +490,7 @@ class GetTaskCommentsAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/task/{task_id}/comment", method="GET")
 
-            comments = response.get("comments", [])
+            comments = response.data.get("comments", [])
             return ActionResult(data={"comments": comments, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -508,7 +508,7 @@ class UpdateCommentAction(ActionHandler):
 
             response = await context.fetch(f"{CLICKUP_API_BASE_URL}/comment/{comment_id}", method="PUT", json=data)
 
-            return ActionResult(data={"comment": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"comment": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/clickup/requirements.txt
+++ b/clickup/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/coda/coda.py
+++ b/coda/coda.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -68,12 +68,12 @@ class ListDocsAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract docs from response
-            docs = response.get("items", [])
+            docs = response.data.get("items", [])
 
-            return {"docs": docs, "result": True}
+            return ActionResult(data={"docs": docs, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"docs": [], "result": False, "error": str(e)}
+            return ActionResult(data={"docs": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("get_doc")
@@ -94,10 +94,10 @@ class GetDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("create_doc")
@@ -130,10 +130,10 @@ class CreateDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs"
             response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("update_doc")
@@ -164,10 +164,10 @@ class UpdateDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
             response = await context.fetch(url, method="PATCH", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("delete_doc")
@@ -190,10 +190,10 @@ class DeleteDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
             response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("list_pages")
@@ -225,8 +225,8 @@ class ListPagesAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract pages from response
-            pages = response.get("items", [])
-            next_page_token = response.get("nextPageToken")
+            pages = response.data.get("items", [])
+            next_page_token = response.data.get("nextPageToken")
 
             result = {"pages": pages, "result": True}
 
@@ -236,7 +236,7 @@ class ListPagesAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {"pages": [], "result": False, "error": str(e)}
+            return ActionResult(data={"pages": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("get_page")
@@ -258,10 +258,10 @@ class GetPageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("create_page")
@@ -309,10 +309,10 @@ class CreatePageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages"
             response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("update_page")
@@ -352,10 +352,10 @@ class UpdatePageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
             response = await context.fetch(url, method="PUT", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("delete_page")
@@ -379,10 +379,10 @@ class DeletePageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
             response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("list_tables")
@@ -420,8 +420,8 @@ class ListTablesAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract tables from response
-            tables = response.get("items", [])
-            next_page_token = response.get("nextPageToken")
+            tables = response.data.get("items", [])
+            next_page_token = response.data.get("nextPageToken")
 
             result = {"tables": tables, "result": True}
 
@@ -431,7 +431,7 @@ class ListTablesAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {"tables": [], "result": False, "error": str(e)}
+            return ActionResult(data={"tables": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("get_table")
@@ -453,10 +453,10 @@ class GetTableAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("list_columns")
@@ -492,8 +492,8 @@ class ListColumnsAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract columns from response
-            columns = response.get("items", [])
-            next_page_token = response.get("nextPageToken")
+            columns = response.data.get("items", [])
+            next_page_token = response.data.get("nextPageToken")
 
             result = {"columns": columns, "result": True}
 
@@ -503,7 +503,7 @@ class ListColumnsAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {"columns": [], "result": False, "error": str(e)}
+            return ActionResult(data={"columns": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("get_column")
@@ -526,10 +526,10 @@ class GetColumnAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/columns/{column_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("list_rows")
@@ -577,8 +577,8 @@ class ListRowsAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract rows from response
-            rows = response.get("items", [])
-            next_page_token = response.get("nextPageToken")
+            rows = response.data.get("items", [])
+            next_page_token = response.data.get("nextPageToken")
 
             result = {"rows": rows, "result": True}
 
@@ -588,7 +588,7 @@ class ListRowsAction(ActionHandler):
             return result
 
         except Exception as e:
-            return {"rows": [], "result": False, "error": str(e)}
+            return ActionResult(data={"rows": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("get_row")
@@ -620,10 +620,10 @@ class GetRowAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("upsert_rows")
@@ -660,10 +660,10 @@ class UpsertRowsAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
             response = await context.fetch(url, method="POST", headers=headers, params=params, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("update_row")
@@ -697,10 +697,10 @@ class UpdateRowAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
             response = await context.fetch(url, method="PUT", headers=headers, params=params, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("delete_row")
@@ -724,10 +724,10 @@ class DeleteRowAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
             response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @coda.action("delete_rows")
@@ -754,7 +754,7 @@ class DeleteRowsAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
             response = await context.fetch(url, method="DELETE", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0)

--- a/coda/requirements.txt
+++ b/coda/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/code-analysis/requirements.txt
+++ b/code-analysis/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 numpy
 Pillow
 PyPDF2

--- a/companies-register/companies_register.py
+++ b/companies-register/companies_register.py
@@ -451,7 +451,7 @@ class AddCompanyContactAction(ActionHandler):
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
             return ActionResult(
-                data={"contact": response, "result": True, "message": "Contact added successfully"}, cost_usd=None
+                data={"contact": response.data, "result": True, "message": "Contact added successfully"}, cost_usd=None
             )
 
         except Exception as e:
@@ -517,7 +517,7 @@ class SearchNZAddressAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params, headers=headers)
 
-            addresses = response.get("items", []) if isinstance(response, dict) else response
+            addresses = response.data.get("items", []) if isinstance(response.data, dict) else response.data
 
             return ActionResult(
                 data={
@@ -610,14 +610,14 @@ class FileAnnualReturnAction(ActionHandler):
             response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
             is_credit_card = payment_method == "creditCard"
-            payment_info_resp = response.get("paymentInfo", {}) if isinstance(response, dict) else {}
+            payment_info_resp = response.data.get("paymentInfo", {}) if isinstance(response.data, dict) else {}
 
             return ActionResult(
                 data={
-                    "documentId": response.get("documentId") if not is_credit_card else None,
-                    "documentType": response.get("documentType") if not is_credit_card else None,
-                    "status": response.get("status") if not is_credit_card else None,
-                    "startDate": response.get("startDate") if not is_credit_card else None,
+                    "documentId": response.data.get("documentId") if not is_credit_card else None,
+                    "documentType": response.data.get("documentType") if not is_credit_card else None,
+                    "status": response.data.get("status") if not is_credit_card else None,
+                    "startDate": response.data.get("startDate") if not is_credit_card else None,
                     "paymentUrl": payment_info_resp.get("paymentUrl") if is_credit_card else None,
                     "billingReference": payment_info_resp.get("billingReference"),
                     "paymentMethod": payment_method,

--- a/companies-register/requirements.txt
+++ b/companies-register/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp>=3.8.0

--- a/doc-maker/doc_maker.py
+++ b/doc-maker/doc_maker.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 from docx import Document
 from docx.shared import Inches
@@ -80,12 +80,13 @@ async def save_and_return_document(
     save_result = await save_action.execute(save_inputs, context)
 
     combined_result = original_result.copy()
+    save_data = save_result.data if hasattr(save_result, "data") else save_result
     combined_result.update(
         {
-            "saved": save_result["saved"],
-            "file_path": save_result["file_path"],
-            "file": save_result["file"],
-            "error": save_result.get("error", ""),
+            "saved": save_data["saved"],
+            "file_path": save_data["file_path"],
+            "file": save_data["file"],
+            "error": save_data.get("error", ""),
         }
     )
     return combined_result
@@ -667,20 +668,23 @@ class GetDocumentElementsAction(ActionHandler):
                         pattern = cell["pattern_type"]
                         pattern_counts[pattern] = pattern_counts.get(pattern, 0) + 1
 
-        return {
-            "template_summary": {
-                "structure": f"{analysis['paragraphs']}p,{analysis['tables']}t",
-                "fillable_total": int(analysis["fillable_paragraphs"] + analysis["fillable_cells"]),
-                "content_elements_hidden": int(
-                    analysis["total_elements"] - len(fillable_paragraphs) - len(fillable_cells)
-                ),
+        return ActionResult(
+            data={
+                "template_summary": {
+                    "structure": f"{analysis['paragraphs']}p,{analysis['tables']}t",
+                    "fillable_total": int(analysis["fillable_paragraphs"] + analysis["fillable_cells"]),
+                    "content_elements_hidden": int(
+                        analysis["total_elements"] - len(fillable_paragraphs) - len(fillable_cells)
+                    ),
+                },
+                "fillable_paragraphs": fillable_paragraphs,
+                "fillable_cells": fillable_cells,
+                "pattern_distribution": pattern_counts,
+                "recommended_strategy": "mixed" if len(pattern_counts) > 2 else "single_method",
+                "template_ready": True,
             },
-            "fillable_paragraphs": fillable_paragraphs,
-            "fillable_cells": fillable_cells,
-            "pattern_distribution": pattern_counts,
-            "recommended_strategy": "mixed" if len(pattern_counts) > 2 else "single_method",
-            "template_ready": True,
-        }
+            cost_usd=0,
+        )
 
 
 @doc_maker.action("create_document")
@@ -722,7 +726,7 @@ class CreateDocumentAction(ActionHandler):
             "markdown_processed": bool(markdown_content),
         }
 
-        return await save_and_return_document(result, document_id, context, custom_filename)
+        return ActionResult(data=await save_and_return_document(result, document_id, context, custom_filename), cost_usd=0)
 
 
 @doc_maker.action("add_table")
@@ -749,7 +753,7 @@ class AddTableAction(ActionHandler):
                 table.cell(row_idx, col_idx).text = str(cell_value)
 
         original_result = {"table_rows": rows, "table_cols": cols}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)
 
 
 @doc_maker.action("add_image")
@@ -798,7 +802,7 @@ class AddImageAction(ActionHandler):
             paragraph.add_run().add_picture(image_file)
 
         original_result = {"image_added": True}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)
 
 
 @doc_maker.action("add_markdown_content")
@@ -822,7 +826,7 @@ class AddMarkdownContentAction(ActionHandler):
         elements_added = len([p for p in doc.paragraphs if p.text.strip()])
 
         original_result = {"markdown_processed": True, "elements_added": elements_added}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)
 
 
 @doc_maker.action("update_by_position")
@@ -893,7 +897,7 @@ class UpdateByPositionAction(ActionHandler):
             + (f", {len(failed_updates)} failed" if failed_updates else ""),
             "failures": failed_updates[:3] if failed_updates else [],  # Limit failure details
         }
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)
 
 
 @doc_maker.action("find_and_replace")
@@ -1150,7 +1154,7 @@ class FindAndReplaceAction(ActionHandler):
             "alerts": warnings[:3] if warnings else [],
             "safety_active": True,
         }
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)
 
 
 @doc_maker.action("fill_template_fields")
@@ -1388,7 +1392,7 @@ class FillTemplateFieldsAction(ActionHandler):
             "template_status": "partially_complete" if blocked_operations > 0 else "complete",
             "action_required": "Review safety warnings and use more specific context" if safety_warnings else "none",
         }
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)
 
 
 @doc_maker.action("save_document")
@@ -1415,26 +1419,32 @@ class SaveDocumentAction(ActionHandler):
             # Get file name from path
             file_name = os.path.basename(file_path)
 
-            return {
-                "saved": True,
-                "file_path": file_path,
-                "file": {
-                    "content": content_base64,
-                    "name": file_name,
-                    "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            return ActionResult(
+                data={
+                    "saved": True,
+                    "file_path": file_path,
+                    "file": {
+                        "content": content_base64,
+                        "name": file_name,
+                        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    },
                 },
-            }
+                cost_usd=0,
+            )
         except Exception as e:
-            return {
-                "saved": False,
-                "file_path": file_path,
-                "file": {
-                    "content": "",
-                    "name": os.path.basename(file_path),
-                    "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            return ActionResult(
+                data={
+                    "saved": False,
+                    "file_path": file_path,
+                    "file": {
+                        "content": "",
+                        "name": os.path.basename(file_path),
+                        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    },
+                    "error": f"Could not generate document for streaming: {str(e)}",
                 },
-                "error": f"Could not generate document for streaming: {str(e)}",
-            }
+                cost_usd=0,
+            )
 
 
 @doc_maker.action("add_page_break")
@@ -1453,4 +1463,4 @@ class AddPageBreakAction(ActionHandler):
         paragraph.add_run().add_break(WD_BREAK.PAGE)
 
         original_result = {"page_break_added": True}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0)

--- a/doc-maker/requirements.txt
+++ b/doc-maker/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 python-docx
 markdown
 beautifulsoup4

--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -48,9 +48,9 @@ class ListFolderAction(ActionHandler):
 
                 response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/list_folder", method="POST", json=data)
 
-            entries = response.get("entries", [])
-            new_cursor = response.get("cursor")
-            has_more = response.get("has_more", False)
+            entries = response.data.get("entries", [])
+            new_cursor = response.data.get("cursor")
+            has_more = response.data.get("has_more", False)
 
             return ActionResult(
                 data={"entries": entries, "cursor": new_cursor, "has_more": has_more, "result": True}, cost_usd=0.0
@@ -79,7 +79,7 @@ class GetMetadataAction(ActionHandler):
 
             response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/get_metadata", method="POST", json=data)
 
-            return ActionResult(data={"metadata": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"metadata": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"metadata": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -98,8 +98,8 @@ class GetTemporaryLinkAction(ActionHandler):
 
             response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/get_temporary_link", method="POST", json=data)
 
-            link = response.get("link")
-            metadata = response.get("metadata", {})
+            link = response.data.get("link")
+            metadata = response.data.get("metadata", {})
 
             return ActionResult(data={"link": link, "metadata": metadata, "result": True}, cost_usd=0.0)
 
@@ -140,7 +140,7 @@ class UploadFileAction(ActionHandler):
                 f"{DROPBOX_CONTENT_BASE_URL}/files/upload", method="POST", headers=headers, data=content
             )
 
-            return ActionResult(data={"file": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"file": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"file": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -156,7 +156,7 @@ class CreateFolderAction(ActionHandler):
 
             response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/create_folder_v2", method="POST", json=data)
 
-            return ActionResult(data={"folder": response.get("metadata", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"folder": response.data.get("metadata", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"folder": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -172,7 +172,7 @@ class DeleteAction(ActionHandler):
 
             response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/delete_v2", method="POST", json=data)
 
-            return ActionResult(data={"metadata": response.get("metadata", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"metadata": response.data.get("metadata", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"metadata": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -193,7 +193,7 @@ class MoveAction(ActionHandler):
 
             response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/move_v2", method="POST", json=data)
 
-            return ActionResult(data={"metadata": response.get("metadata", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"metadata": response.data.get("metadata", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"metadata": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -213,7 +213,7 @@ class CopyAction(ActionHandler):
 
             response = await context.fetch(f"{DROPBOX_API_BASE_URL}/files/copy_v2", method="POST", json=data)
 
-            return ActionResult(data={"metadata": response.get("metadata", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"metadata": response.data.get("metadata", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"metadata": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/dropbox/requirements.txt
+++ b/dropbox/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/elevenlabs/elevenlabs.py
+++ b/elevenlabs/elevenlabs.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import base64
 import aiohttp
@@ -56,11 +56,11 @@ class ListVoicesAction(ActionHandler):
                 f"{ELEVENLABS_API_BASE_URL}/voices", method="GET", headers=headers, params=params if params else None
             )
 
-            voices = response.get("voices", [])
-            return {"voices": voices, "result": True}
+            voices = response.data.get("voices", [])
+            return ActionResult(data={"voices": voices, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"voices": [], "result": False, "error": str(e)}
+            return ActionResult(data={"voices": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @elevenlabs.action("get_voice")
@@ -84,10 +84,10 @@ class GetVoiceAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return {"voice": response, "result": True}
+            return ActionResult(data={"voice": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"voice": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"voice": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @elevenlabs.action("get_voice_settings")
@@ -104,10 +104,10 @@ class GetVoiceSettingsAction(ActionHandler):
                 f"{ELEVENLABS_API_BASE_URL}/voices/{voice_id}/settings", method="GET", headers=headers
             )
 
-            return {"settings": response, "result": True}
+            return ActionResult(data={"settings": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"settings": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"settings": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @elevenlabs.action("list_history")
@@ -129,11 +129,11 @@ class ListHistoryAction(ActionHandler):
                 f"{ELEVENLABS_API_BASE_URL}/history", method="GET", headers=headers, params=params if params else None
             )
 
-            history = response.get("history", [])
-            return {"history": history, "result": True}
+            history = response.data.get("history", [])
+            return ActionResult(data={"history": history, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"history": [], "result": False, "error": str(e)}
+            return ActionResult(data={"history": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @elevenlabs.action("download_history_audio")
@@ -158,20 +158,23 @@ class DownloadHistoryAudioAction(ActionHandler):
                         # Encode as base64 following Autohive pattern (see Slider integration)
                         audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
 
-                        return {
-                            "file": {
-                                "content": audio_base64,
-                                "name": "downloaded_audio.mp3",
-                                "contentType": "audio/mpeg",
+                        return ActionResult(
+                            data={
+                                "file": {
+                                    "content": audio_base64,
+                                    "name": "downloaded_audio.mp3",
+                                    "contentType": "audio/mpeg",
+                                },
+                                "result": True,
                             },
-                            "result": True,
-                        }
+                            cost_usd=0,
+                        )
                     else:
                         error_text = await resp.text()
-                        return {"audio": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}
+                        return ActionResult(data={"audio": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}, cost_usd=0)
 
         except Exception as e:
-            return {"audio": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"audio": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @elevenlabs.action("get_user_subscription")
@@ -186,10 +189,10 @@ class GetUserSubscriptionAction(ActionHandler):
                 f"{ELEVENLABS_API_BASE_URL}/user/subscription", method="GET", headers=headers
             )
 
-            return {"subscription": response, "result": True}
+            return ActionResult(data={"subscription": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"subscription": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"subscription": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @elevenlabs.action("text_to_speech")
@@ -227,17 +230,20 @@ class TextToSpeechAction(ActionHandler):
                         # Encode as base64 following Autohive pattern (see Slider integration)
                         audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
 
-                        return {
-                            "file": {
-                                "content": audio_base64,
-                                "name": "generated_audio.mp3",
-                                "contentType": "audio/mpeg",
+                        return ActionResult(
+                            data={
+                                "file": {
+                                    "content": audio_base64,
+                                    "name": "generated_audio.mp3",
+                                    "contentType": "audio/mpeg",
+                                },
+                                "result": True,
                             },
-                            "result": True,
-                        }
+                            cost_usd=0,
+                        )
                     else:
                         error_text = await resp.text()
-                        return {"audio": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}
+                        return ActionResult(data={"audio": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}, cost_usd=0)
 
         except Exception as e:
-            return {"audio": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"audio": {}, "result": False, "error": str(e)}, cost_usd=0)

--- a/elevenlabs/requirements.txt
+++ b/elevenlabs/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/eventbrite/eventbrite.py
+++ b/eventbrite/eventbrite.py
@@ -26,7 +26,7 @@ class GetCurrentUserAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "user": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "user": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -45,8 +45,8 @@ class ListOrganizationsAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "organizations": response.get("organizations", []),
-                    "pagination": response.get("pagination"),
+                    "organizations": response.data.get("organizations", []),
+                    "pagination": response.data.get("pagination"),
                 },
                 cost_usd=0.0,
             )
@@ -80,7 +80,7 @@ class GetEventAction(ActionHandler):
 
             response = await context.fetch(url, method="GET")
 
-            return ActionResult(data={"result": True, "event": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "event": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -112,7 +112,7 @@ class ListEventsAction(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             return ActionResult(
-                data={"result": True, "events": response.get("events", []), "pagination": response.get("pagination")},
+                data={"result": True, "events": response.data.get("events", []), "pagination": response.data.get("pagination")},
                 cost_usd=0.0,
             )
         except Exception as e:
@@ -174,7 +174,7 @@ class CreateEventAction(ActionHandler):
                 json=event_data,
             )
 
-            return ActionResult(data={"result": True, "event": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "event": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -219,7 +219,7 @@ class UpdateEventAction(ActionHandler):
                 json=event_data,
             )
 
-            return ActionResult(data={"result": True, "event": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "event": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -259,7 +259,7 @@ class PublishEventAction(ActionHandler):
                 method="POST",
             )
 
-            return ActionResult(data={"result": True, "published": response.get("published", True)}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "published": response.data.get("published", True)}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -279,7 +279,7 @@ class UnpublishEventAction(ActionHandler):
                 method="POST",
             )
 
-            return ActionResult(data={"result": True, "unpublished": response.get("unpublished", True)}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "unpublished": response.data.get("unpublished", True)}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -331,7 +331,7 @@ class CopyEventAction(ActionHandler):
                 json=copy_data if copy_data else None,
             )
 
-            return ActionResult(data={"result": True, "event": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "event": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -351,7 +351,7 @@ class GetEventDescriptionAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "description": response.get("description", "")}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "description": response.data.get("description", "")}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -376,7 +376,7 @@ class GetVenueAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "venue": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "venue": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -397,7 +397,7 @@ class ListVenuesAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"result": True, "venues": response.get("venues", []), "pagination": response.get("pagination")},
+                data={"result": True, "venues": response.data.get("venues", []), "pagination": response.data.get("pagination")},
                 cost_usd=0.0,
             )
         except Exception as e:
@@ -442,7 +442,7 @@ class CreateVenueAction(ActionHandler):
                 json=venue_data,
             )
 
-            return ActionResult(data={"result": True, "venue": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "venue": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -473,7 +473,7 @@ class GetOrderAction(ActionHandler):
 
             response = await context.fetch(url, method="GET")
 
-            return ActionResult(data={"result": True, "order": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "order": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -501,7 +501,7 @@ class ListOrdersByEventAction(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             return ActionResult(
-                data={"result": True, "orders": response.get("orders", []), "pagination": response.get("pagination")},
+                data={"result": True, "orders": response.data.get("orders", []), "pagination": response.data.get("pagination")},
                 cost_usd=0.0,
             )
         except Exception as e:
@@ -531,7 +531,7 @@ class ListOrdersByOrganizationAction(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             return ActionResult(
-                data={"result": True, "orders": response.get("orders", []), "pagination": response.get("pagination")},
+                data={"result": True, "orders": response.data.get("orders", []), "pagination": response.data.get("pagination")},
                 cost_usd=0.0,
             )
         except Exception as e:
@@ -560,7 +560,7 @@ class GetAttendeeAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "attendee": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "attendee": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -590,8 +590,8 @@ class ListAttendeesAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "attendees": response.get("attendees", []),
-                    "pagination": response.get("pagination"),
+                    "attendees": response.data.get("attendees", []),
+                    "pagination": response.data.get("pagination"),
                 },
                 cost_usd=0.0,
             )
@@ -623,7 +623,7 @@ class GetTicketClassAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "ticket_class": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "ticket_class": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -651,8 +651,8 @@ class ListTicketClassesAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "ticket_classes": response.get("ticket_classes", []),
-                    "pagination": response.get("pagination"),
+                    "ticket_classes": response.data.get("ticket_classes", []),
+                    "pagination": response.data.get("pagination"),
                 },
                 cost_usd=0.0,
             )
@@ -713,7 +713,7 @@ class CreateTicketClassAction(ActionHandler):
                 json=ticket_class_data,
             )
 
-            return ActionResult(data={"result": True, "ticket_class": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "ticket_class": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -760,7 +760,7 @@ class UpdateTicketClassAction(ActionHandler):
                 json=ticket_class_data,
             )
 
-            return ActionResult(data={"result": True, "ticket_class": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "ticket_class": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -805,7 +805,7 @@ class ListCategoriesAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "categories": response.get("categories", [])}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "categories": response.data.get("categories", [])}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
@@ -825,6 +825,6 @@ class GetCategoryAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"result": True, "category": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "category": response.data}, cost_usd=0.0)
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)

--- a/eventbrite/requirements.txt
+++ b/eventbrite/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/facebook/actions/comments.py
+++ b/facebook/actions/comments.py
@@ -49,8 +49,8 @@ class GetCommentsAction(ActionHandler):
 
         response = await context.fetch(f"{GRAPH_API_BASE}/{post_id}/comments", method="GET", params=params)
 
-        comments = [_build_comment_response(c) for c in response.get("data", [])]
-        total_count = response.get("summary", {}).get("total_count", len(comments))
+        comments = [_build_comment_response(c) for c in response.data.get("data", [])]
+        total_count = response.data.get("summary", {}).get("total_count", len(comments))
 
         return ActionResult(data={"comments": comments, "total_count": total_count})
 
@@ -85,7 +85,7 @@ class ManageCommentAction(ActionHandler):
                 method="POST",
                 data={"message": message, "access_token": page_token},
             )
-            return ActionResult(data={"success": True, "action_taken": "reply", "reply_id": response.get("id", "")})
+            return ActionResult(data={"success": True, "action_taken": "reply", "reply_id": response.data.get("id", "")})
 
         elif action in ("hide", "unhide"):
             is_hidden = action == "hide"

--- a/facebook/actions/insights.py
+++ b/facebook/actions/insights.py
@@ -62,7 +62,7 @@ class GetInsightsAction(ActionHandler):
         response = await context.fetch(endpoint, method="GET", params=params)
 
         metrics_data = {}
-        for item in response.get("data", []):
+        for item in response.data.get("data", []):
             metric_name = item.get("name", "")
             values = item.get("values", [])
             if values:

--- a/facebook/actions/pages.py
+++ b/facebook/actions/pages.py
@@ -30,7 +30,7 @@ class ListPagesAction(ActionHandler):
                 "category": page.get("category", ""),
                 "followers_count": page.get("followers_count", 0),
             }
-            for page in response.get("data", [])
+            for page in response.data.get("data", [])
         ]
 
         return ActionResult(data={"pages": pages})

--- a/facebook/actions/posts.py
+++ b/facebook/actions/posts.py
@@ -119,14 +119,14 @@ class GetPostsAction(ActionHandler):
             response = await context.fetch(
                 f"{GRAPH_API_BASE}/{post_id}", method="GET", params={"fields": fields, "access_token": page_token}
             )
-            posts = [_build_post_response(response)]
+            posts = [_build_post_response(response.data)]
         else:
             response = await context.fetch(
                 f"{GRAPH_API_BASE}/{page_id}/posts",
                 method="GET",
                 params={"fields": fields, "limit": limit, "access_token": page_token},
             )
-            posts = [_build_post_response(p) for p in response.get("data", [])]
+            posts = [_build_post_response(p) for p in response.data.get("data", [])]
 
         return ActionResult(data={"posts": posts})
 
@@ -192,7 +192,7 @@ class CreatePostAction(ActionHandler):
 
         response = await context.fetch(endpoint, method="POST", data=data)
 
-        post_id = response.get("id") or response.get("post_id", "")
+        post_id = response.data.get("id") or response.data.get("post_id", "")
 
         result = {
             "post_id": post_id,

--- a/facebook/requirements.txt
+++ b/facebook/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/fathom/fathom.py
+++ b/fathom/fathom.py
@@ -89,7 +89,7 @@ class ListMeetingsAction(ActionHandler):
             response = await client._make_request("meetings", params=params)
 
             # Process items to filter out null optional fields
-            items = response.get("items", [])
+            items = response.data.get("items", [])
             processed_items = []
 
             # Fields to exclude when they are null (not in output schema)
@@ -107,8 +107,8 @@ class ListMeetingsAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "limit": response.get("limit", 0),
-                    "next_cursor": response.get("next_cursor"),
+                    "limit": response.data.get("limit", 0),
+                    "next_cursor": response.data.get("next_cursor"),
                     "items": processed_items,
                 },
                 cost_usd=0.0,
@@ -127,7 +127,7 @@ class GetTranscriptAction(ActionHandler):
             response = await client._make_request(f"recordings/{recording_id}/transcript")
 
             transcript = []
-            for segment in response.get("transcript", []):
+            for segment in response.data.get("transcript", []):
                 # Extract speaker name from speaker object
                 speaker = segment.get("speaker", {})
                 speaker_name = speaker.get("display_name", "Unknown Speaker")
@@ -159,11 +159,11 @@ class ListTeamsAction(ActionHandler):
             response = await client._make_request("teams", params=params)
 
             teams = []
-            for team in response.get("items", []):
+            for team in response.data.get("items", []):
                 teams.append({"name": team.get("name", ""), "created_at": team.get("created_at", "")})
 
             return ActionResult(
-                data={"limit": response.get("limit"), "next_cursor": response.get("next_cursor"), "teams": teams},
+                data={"limit": response.data.get("limit"), "next_cursor": response.data.get("next_cursor"), "teams": teams},
                 cost_usd=0.0,
             )
         except Exception as e:
@@ -186,7 +186,7 @@ class ListTeamMembersAction(ActionHandler):
             response = await client._make_request("team_members", params=params)
 
             team_members = []
-            for member in response.get("items", []):
+            for member in response.data.get("items", []):
                 team_members.append(
                     {
                         "name": member.get("name", ""),
@@ -197,8 +197,8 @@ class ListTeamMembersAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "limit": response.get("limit"),
-                    "next_cursor": response.get("next_cursor"),
+                    "limit": response.data.get("limit"),
+                    "next_cursor": response.data.get("next_cursor"),
                     "team_members": team_members,
                 },
                 cost_usd=0.0,

--- a/fathom/requirements.txt
+++ b/fathom/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/fergus/fergus.py
+++ b/fergus/fergus.py
@@ -99,7 +99,7 @@ class CreateJob(ActionHandler):
                     body["customerReference"] = inputs["customer_reference"]
 
             resp = await context.fetch(f"{BASE_URL}/jobs", method="POST", headers=headers, json=body)
-            return _success({"job": resp})
+            return _success({"job": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -133,7 +133,7 @@ class UpdateJob(ActionHandler):
                 raise ValueError("At least one field must be provided to update a job.")
 
             resp = await context.fetch(f"{BASE_URL}/jobs/{job_id}", method="PUT", headers=headers, json=body)
-            return _success({"job": resp})
+            return _success({"job": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -154,7 +154,7 @@ class FinaliseJob(ActionHandler):
                 headers=headers,
                 json={},
             )
-            return _success({"job": resp})
+            return _success({"job": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -170,7 +170,7 @@ class GetJob(ActionHandler):
             job_id = int(inputs["job_id"])
 
             resp = await context.fetch(f"{BASE_URL}/jobs/{job_id}", method="GET", headers=headers)
-            return _success({"job": resp})
+            return _success({"job": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -203,7 +203,7 @@ class ListJobs(ActionHandler):
                 params["filterSearchText"] = inputs["search"]
 
             resp = await context.fetch(f"{BASE_URL}/jobs", method="GET", headers=headers, params=params)
-            return _success({"jobs": resp})
+            return _success({"jobs": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -226,7 +226,7 @@ class SearchCustomers(ActionHandler):
                 params["filterSearchText"] = inputs["search"]
 
             resp = await context.fetch(f"{BASE_URL}/customers", method="GET", headers=headers, params=params)
-            return _success({"customers": resp})
+            return _success({"customers": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -242,7 +242,7 @@ class GetCustomer(ActionHandler):
             customer_id = int(inputs["customer_id"])
 
             resp = await context.fetch(f"{BASE_URL}/customers/{customer_id}", method="GET", headers=headers)
-            return _success({"customer": resp})
+            return _success({"customer": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -265,7 +265,7 @@ class ListSites(ActionHandler):
                 params["filterSearchText"] = inputs["search"]
 
             resp = await context.fetch(f"{BASE_URL}/sites", method="GET", headers=headers, params=params)
-            return _success({"sites": resp})
+            return _success({"sites": resp.data})
         except Exception as e:
             return _error(e)
 
@@ -288,6 +288,6 @@ class ListUsers(ActionHandler):
                 params["filterSearchText"] = inputs["search"]
 
             resp = await context.fetch(f"{BASE_URL}/users", method="GET", headers=headers, params=params)
-            return _success({"users": resp})
+            return _success({"users": resp.data})
         except Exception as e:
             return _error(e)

--- a/fergus/requirements.txt
+++ b/fergus/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0


### PR DESCRIPTION
## Summary

Migrates 21 integrations (api-call through fergus alphabetically) from `autohive-integrations-sdk~=1.0.2` to `~=2.0.0`.

### Changes per integration

- **requirements.txt**: Updated SDK version from `~=1.0.2` to `~=2.0.0`
- **Fetch response handling**: `context.fetch()` now returns a `FetchResponse` object; all response access updated to use `.data` (e.g. `response.get("key")` → `response.data.get("key")`)
- **ActionResult wrapping**: All `execute()` returns wrapped in `ActionResult(data={...}, cost_usd=0)`; `ActionResult` import added where missing

### Integrations covered

api-call, app-business-reviews, asana, aws, bigquery, bitly, box, calendly, canva, circle, clickup, coda, code-analysis, companies-register, doc-maker, dropbox, elevenlabs, eventbrite, facebook, fathom, fergus

### Notes

- `aws` uses boto3 (no `context.fetch` calls) — only requirements.txt updated
- `code-analysis` already compliant — only requirements.txt updated
- `facebook/facebook.py` is an import-only entry point — only requirements.txt updated
- `elevenlabs` and `box` have aiohttp-based binary downloads that bypass `context.fetch` — handled correctly
- Helper functions updated: `circle.handle_api_response`, `doc-maker.save_and_return_document`, `fathom._make_request`