### PR TITLE
chore: migrate integrations (float → humanitix) to SDK 2.0.0

### DIFF
--- a/float/float.py
+++ b/float/float.py
@@ -100,7 +100,7 @@ class FloatConnectedAccountHandler(ConnectedAccountHandler):
 
             # Extract account information
             # Float typically returns account details including company name
-            account_data = response if isinstance(response, dict) else {}
+            account_data = response.data if isinstance(response.data, dict) else {}
 
             # Try to get the current user's information from the account endpoint
             # Float API typically returns the account owner's information
@@ -183,7 +183,7 @@ class ListPeopleHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/people", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list people: {str(e)}")
@@ -217,7 +217,7 @@ class GetPersonHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/people/{people_id}", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get person {people_id}: {str(e)}")
@@ -270,7 +270,7 @@ class CreatePersonHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/people", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to create person: {str(e)}")
@@ -334,7 +334,7 @@ class UpdatePersonHandler(ActionHandler):
                 params=params,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to update person {people_id}: {str(e)}")
@@ -419,7 +419,7 @@ class ListProjectsHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/projects", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list projects: {str(e)}")
@@ -448,7 +448,7 @@ class GetProjectHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/projects/{project_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get project {project_id}: {str(e)}")
@@ -502,7 +502,7 @@ class CreateProjectHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/projects", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to create project: {str(e)}")
@@ -558,7 +558,7 @@ class UpdateProjectHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/projects/{project_id}", method="PATCH", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to update project {project_id}: {str(e)}")
@@ -640,7 +640,7 @@ class ListTasksHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/tasks", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list tasks: {str(e)}")
@@ -667,7 +667,7 @@ class GetTaskHandler(ActionHandler):
         try:
             response = await context.fetch(url=f"{FLOAT_API_BASE_URL}/tasks/{task_id}", method="GET", headers=headers)
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get task {task_id}: {str(e)}")
@@ -719,7 +719,7 @@ class CreateTaskHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/tasks", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to create task: {str(e)}")
@@ -771,7 +771,7 @@ class UpdateTaskHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/tasks/{task_id}", method="PATCH", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to update task {task_id}: {str(e)}")
@@ -851,7 +851,7 @@ class ListTimeOffHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/timeoffs", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list time off: {str(e)}")
@@ -880,7 +880,7 @@ class GetTimeOffHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/timeoffs/{timeoff_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get time off {timeoff_id}: {str(e)}")
@@ -923,7 +923,7 @@ class CreateTimeOffHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/timeoffs", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to create time off: {str(e)}")
@@ -961,7 +961,7 @@ class UpdateTimeOffHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/timeoffs/{timeoff_id}", method="PATCH", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to update time off {timeoff_id}: {str(e)}")
@@ -1043,7 +1043,7 @@ class ListLoggedTimeHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/logged-time", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list logged time: {str(e)}")
@@ -1072,7 +1072,7 @@ class GetLoggedTimeHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/logged-time/{logged_time_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get logged time {logged_time_id}: {str(e)}")
@@ -1117,7 +1117,7 @@ class CreateLoggedTimeHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/logged-time", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to create logged time: {str(e)}")
@@ -1158,7 +1158,7 @@ class UpdateLoggedTimeHandler(ActionHandler):
                 json=request_body,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to update logged time {logged_time_id}: {str(e)}")
@@ -1234,7 +1234,7 @@ class ListClientsHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/clients", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list clients: {str(e)}")
@@ -1263,7 +1263,7 @@ class GetClientHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/clients/{client_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get client {client_id}: {str(e)}")
@@ -1300,7 +1300,7 @@ class CreateClientHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/clients", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to create client: {str(e)}")
@@ -1341,7 +1341,7 @@ class UpdateClientHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/clients/{client_id}", method="PATCH", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to update client {client_id}: {str(e)}")
@@ -1413,7 +1413,7 @@ class ListDepartmentsHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/departments", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list departments: {str(e)}")
@@ -1442,7 +1442,7 @@ class GetDepartmentHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/departments/{department_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get department {department_id}: {str(e)}")
@@ -1485,7 +1485,7 @@ class ListRolesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/roles", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list roles: {str(e)}")
@@ -1512,7 +1512,7 @@ class GetRoleHandler(ActionHandler):
         try:
             response = await context.fetch(url=f"{FLOAT_API_BASE_URL}/roles/{role_id}", method="GET", headers=headers)
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get role {role_id}: {str(e)}")
@@ -1555,7 +1555,7 @@ class ListTimeOffTypesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/timeoff-types", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list time off types: {str(e)}")
@@ -1584,7 +1584,7 @@ class GetTimeOffTypeHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/timeoff-types/{timeoff_type_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get time off type {timeoff_type_id}: {str(e)}")
@@ -1624,7 +1624,7 @@ class ListAccountsHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/accounts", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list accounts: {str(e)}")
@@ -1653,7 +1653,7 @@ class GetAccountHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/accounts/{account_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get account {account_id}: {str(e)}")
@@ -1692,7 +1692,7 @@ class ListStatusesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/status", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list statuses: {str(e)}")
@@ -1721,7 +1721,7 @@ class GetStatusHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/status/{status_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get status {status_id}: {str(e)}")
@@ -1760,7 +1760,7 @@ class ListPublicHolidaysHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/public-holidays", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list public holidays: {str(e)}")
@@ -1789,7 +1789,7 @@ class GetPublicHolidayHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/public-holidays/{public_holiday_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get public holiday {public_holiday_id}: {str(e)}")
@@ -1828,7 +1828,7 @@ class ListTeamHolidaysHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/holidays", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list team holidays: {str(e)}")
@@ -1857,7 +1857,7 @@ class GetTeamHolidayHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/holidays/{holiday_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get team holiday {holiday_id}: {str(e)}")
@@ -1896,7 +1896,7 @@ class ListProjectStagesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-stages", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list project stages: {str(e)}")
@@ -1925,7 +1925,7 @@ class GetProjectStageHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-stages/{project_stage_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get project stage {project_stage_id}: {str(e)}")
@@ -1967,7 +1967,7 @@ class ListProjectExpensesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-expenses", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list project expenses: {str(e)}")
@@ -1996,7 +1996,7 @@ class GetProjectExpenseHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-expenses/{project_expense_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get project expense {project_expense_id}: {str(e)}")
@@ -2038,7 +2038,7 @@ class ListPhasesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/phases", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list phases: {str(e)}")
@@ -2065,7 +2065,7 @@ class GetPhaseHandler(ActionHandler):
         try:
             response = await context.fetch(url=f"{FLOAT_API_BASE_URL}/phases/{phase_id}", method="GET", headers=headers)
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get phase {phase_id}: {str(e)}")
@@ -2107,7 +2107,7 @@ class ListProjectTasksHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-tasks", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list project tasks: {str(e)}")
@@ -2136,7 +2136,7 @@ class GetProjectTaskHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-tasks/{project_task_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get project task {project_task_id}: {str(e)}")
@@ -2166,7 +2166,7 @@ class MergeProjectTasksHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/project-tasks/merge", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to merge project tasks: {str(e)}")
@@ -2208,7 +2208,7 @@ class ListMilestonesHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/milestones", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to list milestones: {str(e)}")
@@ -2237,7 +2237,7 @@ class GetMilestoneHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/milestones/{milestone_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to get milestone {milestone_id}: {str(e)}")
@@ -2279,7 +2279,7 @@ class GetPeopleReportHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/reports/people", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to generate people report: {str(e)}")
@@ -2318,7 +2318,7 @@ class GetProjectsReportHandler(ActionHandler):
                 url=f"{FLOAT_API_BASE_URL}/reports/projects", method="GET", headers=headers, params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             raise Exception(f"Failed to generate projects report: {str(e)}")

--- a/float/requirements.txt
+++ b/float/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk==1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/freshdesk/freshdesk.py
+++ b/freshdesk/freshdesk.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import base64
 
@@ -78,12 +78,12 @@ class ListCompaniesAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Response is a list of companies
-            companies = response if isinstance(response, list) else []
+            companies = response.data if isinstance(response.data, list) else []
 
-            return {"companies": companies, "total": len(companies), "result": True}
+            return ActionResult(data={"companies": companies, "total": len(companies), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"companies": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"companies": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("create_company")
@@ -119,10 +119,10 @@ class CreateCompanyAction(ActionHandler):
             url = f"{base_url}/companies"
             response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {"company": response, "result": True}
+            return ActionResult(data={"company": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"company": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"company": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("get_company")
@@ -144,10 +144,10 @@ class GetCompanyAction(ActionHandler):
             url = f"{base_url}/companies/{company_id}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"company": response, "result": True}
+            return ActionResult(data={"company": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"company": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"company": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("update_company")
@@ -188,10 +188,10 @@ class UpdateCompanyAction(ActionHandler):
             url = f"{base_url}/companies/{company_id}"
             response = await context.fetch(url, method="PUT", headers=headers, json=body)
 
-            return {"company": response, "result": True}
+            return ActionResult(data={"company": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"company": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"company": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("delete_company")
@@ -214,10 +214,10 @@ class DeleteCompanyAction(ActionHandler):
             url = f"{base_url}/companies/{company_id}"
             await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("search_companies")
@@ -246,12 +246,12 @@ class SearchCompaniesAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Extract companies from response
-            companies = response.get("companies", []) if isinstance(response, dict) else []
+            companies = response.data.get("companies", []) if isinstance(response, dict) else []
 
-            return {"companies": companies, "total": len(companies), "result": True}
+            return ActionResult(data={"companies": companies, "total": len(companies), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"companies": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"companies": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Ticket Handlers ----
@@ -285,10 +285,10 @@ class CreateTicketAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets", method="POST", headers=headers, json=body)
 
-            return {"ticket": response, "result": True}
+            return ActionResult(data={"ticket": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"ticket": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"ticket": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("list_tickets")
@@ -304,12 +304,12 @@ class ListTicketsAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets", method="GET", headers=headers, params=params)
 
-            tickets = response if isinstance(response, list) else []
+            tickets = response.data if isinstance(response.data, list) else []
 
-            return {"tickets": tickets, "total": len(tickets), "result": True}
+            return ActionResult(data={"tickets": tickets, "total": len(tickets), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"tickets": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"tickets": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("get_ticket")
@@ -325,10 +325,10 @@ class GetTicketAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets/{ticket_id}", method="GET", headers=headers)
 
-            return {"ticket": response, "result": True}
+            return ActionResult(data={"ticket": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"ticket": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"ticket": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("update_ticket")
@@ -356,10 +356,10 @@ class UpdateTicketAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets/{ticket_id}", method="PUT", headers=headers, json=body)
 
-            return {"ticket": response, "result": True}
+            return ActionResult(data={"ticket": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"ticket": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"ticket": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("delete_ticket")
@@ -375,10 +375,10 @@ class DeleteTicketAction(ActionHandler):
 
             await context.fetch(f"{base_url}/tickets/{ticket_id}", method="DELETE", headers=headers)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Contact Handlers ----
@@ -410,10 +410,10 @@ class CreateContactAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/contacts", method="POST", headers=headers, json=body)
 
-            return {"contact": response, "result": True}
+            return ActionResult(data={"contact": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"contact": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"contact": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("list_contacts")
@@ -429,12 +429,12 @@ class ListContactsAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/contacts", method="GET", headers=headers, params=params)
 
-            contacts = response if isinstance(response, list) else []
+            contacts = response.data if isinstance(response.data, list) else []
 
-            return {"contacts": contacts, "total": len(contacts), "result": True}
+            return ActionResult(data={"contacts": contacts, "total": len(contacts), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"contacts": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"contacts": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("get_contact")
@@ -450,10 +450,10 @@ class GetContactAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/contacts/{contact_id}", method="GET", headers=headers)
 
-            return {"contact": response, "result": True}
+            return ActionResult(data={"contact": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"contact": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"contact": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("update_contact")
@@ -485,10 +485,10 @@ class UpdateContactAction(ActionHandler):
                 f"{base_url}/contacts/{contact_id}", method="PUT", headers=headers, json=body
             )
 
-            return {"contact": response, "result": True}
+            return ActionResult(data={"contact": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"contact": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"contact": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("delete_contact")
@@ -504,10 +504,10 @@ class DeleteContactAction(ActionHandler):
 
             await context.fetch(f"{base_url}/contacts/{contact_id}", method="DELETE", headers=headers)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("search_contacts")
@@ -536,12 +536,12 @@ class SearchContactsAction(ActionHandler):
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
             # Response is directly an array of contacts
-            contacts = response if isinstance(response, list) else []
+            contacts = response.data if isinstance(response.data, list) else []
 
-            return {"contacts": contacts, "total": len(contacts), "result": True}
+            return ActionResult(data={"contacts": contacts, "total": len(contacts), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"contacts": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"contacts": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Conversation Handlers ----
@@ -562,12 +562,12 @@ class ListConversationsAction(ActionHandler):
                 f"{base_url}/tickets/{ticket_id}/conversations", method="GET", headers=headers
             )
 
-            conversations = response if isinstance(response, list) else []
+            conversations = response.data if isinstance(response.data, list) else []
 
-            return {"conversations": conversations, "result": True}
+            return ActionResult(data={"conversations": conversations, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"conversations": [], "result": False, "error": str(e)}
+            return ActionResult(data={"conversations": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("create_note")
@@ -589,10 +589,10 @@ class CreateNoteAction(ActionHandler):
                 f"{base_url}/tickets/{ticket_id}/notes", method="POST", headers=headers, json=body
             )
 
-            return {"conversation": response, "result": True}
+            return ActionResult(data={"conversation": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"conversation": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @freshdesk.action("create_reply")
@@ -614,7 +614,7 @@ class CreateReplyAction(ActionHandler):
                 f"{base_url}/tickets/{ticket_id}/reply", method="POST", headers=headers, json=body
             )
 
-            return {"conversation": response, "result": True}
+            return ActionResult(data={"conversation": response.data, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"conversation": {}, "result": False, "error": str(e)}, cost_usd=0)

--- a/freshdesk/requirements.txt
+++ b/freshdesk/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/front/front.py
+++ b/front/front.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 import base64
 import aiohttp
@@ -86,32 +86,32 @@ class GetInboxAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/inboxes/{inbox_id}")
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "inbox": {},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse inbox
             inbox = {
-                "id": response.get("id", ""),
-                "name": response.get("name", ""),
-                "address": response.get("address", ""),
+                "id": response.data.get("id", ""),
+                "name": response.data.get("name", ""),
+                "address": response.data.get("address", ""),
             }
 
             # Add optional fields
-            if "type" in response:
-                inbox["type"] = response["type"]
-            if "send_as" in response:
-                inbox["send_as"] = response["send_as"]
-            if "is_private" in response:
-                inbox["is_private"] = response["is_private"]
+            if "type" in response.data:
+                inbox["type"] = response.data["type"]
+            if "send_as" in response.data:
+                inbox["send_as"] = response.data["send_as"]
+            if "is_private" in response.data:
+                inbox["is_private"] = response.data["is_private"]
 
-            return {"inbox": inbox, "result": True}
+            return ActionResult(data={"inbox": inbox, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"inbox": {}, "result": False, "error": f"Error getting inbox: {str(e)}"}
+            return ActionResult(data={"inbox": {}, "result": False, "error": f"Error getting inbox: {str(e)}"}, cost_usd=0)
 
 
 @front.action("list_inbox_conversations")
@@ -134,24 +134,24 @@ class ListInboxConversationsAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/inboxes/{inbox_id}/conversations", params=params)
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "conversations": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse conversations
             conversations = []
-            raw_conversations = response.get("_results", [])
+            raw_conversations = response.data.get("_results", [])
 
             for raw_conv in raw_conversations:
                 conversations.append(FrontDataParser.parse_conversation(raw_conv))
 
-            return {"conversations": conversations, "result": True}
+            return ActionResult(data={"conversations": conversations, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"conversations": [], "result": False, "error": f"Error listing inbox conversations: {str(e)}"}
+            return ActionResult(data={"conversations": [], "result": False, "error": f"Error listing inbox conversations: {str(e)}"}, cost_usd=0)
 
 
 @front.action("get_conversation")
@@ -164,20 +164,20 @@ class GetConversationAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/conversations/{conversation_id}")
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "conversation": {},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse conversation - Front returns conversation data directly
             conversation = FrontDataParser.parse_conversation(response)
 
-            return {"conversation": conversation, "result": True}
+            return ActionResult(data={"conversation": conversation, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": f"Error getting conversation: {str(e)}"}
+            return ActionResult(data={"conversation": {}, "result": False, "error": f"Error getting conversation: {str(e)}"}, cost_usd=0)
 
 
 @front.action("list_conversation_messages")
@@ -193,24 +193,24 @@ class ListConversationMessagesAction(ActionHandler):
             )
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "messages": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse messages
             messages = []
-            raw_messages = response.get("_results", [])
+            raw_messages = response.data.get("_results", [])
 
             for raw_msg in raw_messages:
                 messages.append(FrontDataParser.parse_message(raw_msg))
 
-            return {"messages": messages, "result": True}
+            return ActionResult(data={"messages": messages, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"messages": [], "result": False, "error": f"Error listing conversation messages: {str(e)}"}
+            return ActionResult(data={"messages": [], "result": False, "error": f"Error listing conversation messages: {str(e)}"}, cost_usd=0)
 
 
 @front.action("create_message_reply")
@@ -283,18 +283,18 @@ class CreateMessageReplyAction(ActionHandler):
                 )
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "message_uid": "",
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Front returns message_uid for async processing
-            return {"message_uid": response.get("message_uid", ""), "result": True}
+            return ActionResult(data={"message_uid": response.data.get("message_uid", ""), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"message_uid": "", "result": False, "error": f"Error creating message reply: {str(e)}"}
+            return ActionResult(data={"message_uid": "", "result": False, "error": f"Error creating message reply: {str(e)}"}, cost_usd=0)
 
     async def _send_reply_with_attachments(
         self,
@@ -419,7 +419,7 @@ class CreateMessageReplyAction(ActionHandler):
             async with session.post(url, data=form, headers=headers) as resp:
                 if resp.status >= 400:
                     error_text = await resp.text()
-                    return {"error": f"HTTP {resp.status}: {error_text}"}
+                    return ActionResult(data={"error": f"HTTP {resp.status}: {error_text}"}, cost_usd=0)
 
                 return await resp.json()
 
@@ -434,20 +434,20 @@ class GetMessageAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/messages/{message_id}")
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "message": {},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse message
             message = FrontDataParser.parse_message(response)
 
-            return {"message": message, "result": True}
+            return ActionResult(data={"message": message, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"message": {}, "result": False, "error": f"Error getting message: {str(e)}"}
+            return ActionResult(data={"message": {}, "result": False, "error": f"Error getting message: {str(e)}"}, cost_usd=0)
 
 
 @front.action("download_message_attachment")
@@ -477,7 +477,7 @@ class DownloadMessageAttachmentAction(ActionHandler):
                 async with session.get(attachment_url, headers=headers) as resp:
                     if resp.status >= 400:
                         error_text = await resp.text()
-                        return {"file": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}
+                        return ActionResult(data={"file": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}, cost_usd=0)
 
                     # Read complete file content as binary
                     file_bytes = await resp.read()
@@ -500,7 +500,7 @@ class DownloadMessageAttachmentAction(ActionHandler):
                     # Encode to base64 for JSON transport and attachment forwarding
                     content_b64 = base64.b64encode(file_bytes).decode("utf-8")
 
-                    return {
+                    return ActionResult(data={
                         "file": {
                             "content": content_b64,  # Use this in create_message attachments
                             "name": filename,
@@ -508,10 +508,10 @@ class DownloadMessageAttachmentAction(ActionHandler):
                             "size": len(file_bytes),
                         },
                         "result": True,
-                    }
+                    }, cost_usd=0)
 
         except Exception as e:
-            return {"file": {}, "result": False, "error": f"Error downloading attachment: {str(e)}"}
+            return ActionResult(data={"file": {}, "result": False, "error": f"Error downloading attachment: {str(e)}"}, cost_usd=0)
 
 
 @front.action("create_message")
@@ -578,18 +578,18 @@ class CreateMessageAction(ActionHandler):
                 )
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "message_uid": "",
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Front returns message_uid for async processing
-            return {"message_uid": response.get("message_uid", ""), "result": True}
+            return ActionResult(data={"message_uid": response.data.get("message_uid", ""), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"message_uid": "", "result": False, "error": f"Error creating message: {str(e)}"}
+            return ActionResult(data={"message_uid": "", "result": False, "error": f"Error creating message: {str(e)}"}, cost_usd=0)
 
     async def _send_with_attachments(
         self,
@@ -712,7 +712,7 @@ class CreateMessageAction(ActionHandler):
             async with session.post(url, data=form, headers=headers) as resp:
                 if resp.status >= 400:
                     error_text = await resp.text()
-                    return {"error": f"HTTP {resp.status}: {error_text}"}
+                    return ActionResult(data={"error": f"HTTP {resp.status}: {error_text}"}, cost_usd=0)
 
                 return await resp.json()
 
@@ -727,16 +727,16 @@ class ListChannelsAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/channels", params={"limit": min(limit, 100)})
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "channels": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse channels
             channels = []
-            raw_channels = response.get("_results", [])
+            raw_channels = response.data.get("_results", [])
 
             for raw_channel in raw_channels:
                 channel = {
@@ -754,10 +754,10 @@ class ListChannelsAction(ActionHandler):
 
                 channels.append(channel)
 
-            return {"channels": channels, "result": True}
+            return ActionResult(data={"channels": channels, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"channels": [], "result": False, "error": f"Error listing channels: {str(e)}"}
+            return ActionResult(data={"channels": [], "result": False, "error": f"Error listing channels: {str(e)}"}, cost_usd=0)
 
 
 @front.action("list_inbox_channels")
@@ -773,16 +773,16 @@ class ListInboxChannelsAction(ActionHandler):
             )
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "channels": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse channels
             channels = []
-            raw_channels = response.get("_results", [])
+            raw_channels = response.data.get("_results", [])
 
             for raw_channel in raw_channels:
                 channel = {
@@ -800,10 +800,10 @@ class ListInboxChannelsAction(ActionHandler):
 
                 channels.append(channel)
 
-            return {"channels": channels, "result": True}
+            return ActionResult(data={"channels": channels, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"channels": [], "result": False, "error": f"Error listing inbox channels: {str(e)}"}
+            return ActionResult(data={"channels": [], "result": False, "error": f"Error listing inbox channels: {str(e)}"}, cost_usd=0)
 
 
 @front.action("get_channel")
@@ -816,38 +816,38 @@ class GetChannelAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/channels/{channel_id}")
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "channel": {"id": "", "name": "", "type": ""},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse channel - Note: Front API returns "types" but we standardize to "type"
             channel = {
-                "id": response.get("id", ""),
-                "name": response.get("name", ""),
-                "type": response.get("types", response.get("type", "")),  # Front API uses "types" field
+                "id": response.data.get("id", ""),
+                "name": response.data.get("name", ""),
+                "type": response.data.get("types", response.data.get("type", "")),  # Front API uses "types" field
             }
 
             # Add optional fields
-            if "address" in response:
-                channel["address"] = response["address"]
-            if "send_as" in response:
-                channel["send_as"] = response["send_as"]
-            if "is_private" in response:
-                channel["is_private"] = response["is_private"]
-            if "settings" in response:
-                channel["settings"] = response["settings"]
+            if "address" in response.data:
+                channel["address"] = response.data["address"]
+            if "send_as" in response.data:
+                channel["send_as"] = response.data["send_as"]
+            if "is_private" in response.data:
+                channel["is_private"] = response.data["is_private"]
+            if "settings" in response.data:
+                channel["settings"] = response.data["settings"]
 
-            return {"channel": channel, "result": True}
+            return ActionResult(data={"channel": channel, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {
+            return ActionResult(data={
                 "channel": {"id": "", "name": "", "type": ""},
                 "result": False,
                 "error": f"Error getting channel: {str(e)}",
-            }
+            }, cost_usd=0)
 
 
 @front.action("list_message_templates")
@@ -860,16 +860,16 @@ class ListMessageTemplatesAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/message_templates", params={"limit": min(limit, 100)})
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "templates": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse templates
             templates = []
-            raw_templates = response.get("_results", [])
+            raw_templates = response.data.get("_results", [])
 
             for raw_template in raw_templates:
                 template = {
@@ -883,10 +883,10 @@ class ListMessageTemplatesAction(ActionHandler):
 
                 templates.append(template)
 
-            return {"templates": templates, "result": True}
+            return ActionResult(data={"templates": templates, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"templates": [], "result": False, "error": f"Error listing message templates: {str(e)}"}
+            return ActionResult(data={"templates": [], "result": False, "error": f"Error listing message templates: {str(e)}"}, cost_usd=0)
 
 
 @front.action("get_message_template")
@@ -899,27 +899,27 @@ class GetMessageTemplateAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/message_templates/{template_id}")
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "template": {},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse template
             template = {
-                "id": response.get("id", ""),
-                "name": response.get("name", ""),
-                "subject": response.get("subject", ""),
-                "body": response.get("body", ""),
-                "attachments": response.get("attachments", []),
-                "metadata": response.get("metadata", {}),
+                "id": response.data.get("id", ""),
+                "name": response.data.get("name", ""),
+                "subject": response.data.get("subject", ""),
+                "body": response.data.get("body", ""),
+                "attachments": response.data.get("attachments", []),
+                "metadata": response.data.get("metadata", {}),
             }
 
-            return {"template": template, "result": True}
+            return ActionResult(data={"template": template, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"template": {}, "result": False, "error": f"Error getting message template: {str(e)}"}
+            return ActionResult(data={"template": {}, "result": False, "error": f"Error getting message template: {str(e)}"}, cost_usd=0)
 
 
 @front.action("update_conversation")
@@ -946,7 +946,7 @@ class UpdateConversationAction(ActionHandler):
                 update_data["custom_fields"] = inputs["custom_fields"]
 
             if not update_data:
-                return {"conversation": {}, "result": False, "error": "No valid update fields provided"}
+                return ActionResult(data={"conversation": {}, "result": False, "error": "No valid update fields provided"}, cost_usd=0)
 
             # Update conversation
             response = await context.fetch(
@@ -960,33 +960,33 @@ class UpdateConversationAction(ActionHandler):
                 get_response = await context.fetch(f"{FRONT_API_BASE}/conversations/{conversation_id}")
 
                 if get_response is None or "error" in get_response:
-                    return {
+                    return ActionResult(data={
                         "conversation": {},
                         "result": False,
                         "error": (
                             f"Update may have succeeded but failed to fetch updated conversation: "
-                            f"{get_response.get('error', 'Unknown error') if get_response else 'No response'}"
+                            f"{get_response.data.get('error', 'Unknown error') if get_response else 'No response'}"
                         ),
-                    }
+                    }, cost_usd=0)
 
                 conversation = FrontDataParser.parse_conversation(get_response)
-                return {"conversation": conversation, "result": True}
+                return ActionResult(data={"conversation": conversation, "result": True}, cost_usd=0)
 
             # Check for API errors in response
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "conversation": {},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse response conversation
             conversation = FrontDataParser.parse_conversation(response)
 
-            return {"conversation": conversation, "result": True}
+            return ActionResult(data={"conversation": conversation, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": f"Error updating conversation: {str(e)}"}
+            return ActionResult(data={"conversation": {}, "result": False, "error": f"Error updating conversation: {str(e)}"}, cost_usd=0)
 
 
 @front.action("list_inboxes")
@@ -999,16 +999,16 @@ class ListInboxesAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/inboxes", params={"limit": min(limit, 100)})
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "inboxes": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse inboxes
             inboxes = []
-            raw_inboxes = response.get("_results", [])
+            raw_inboxes = response.data.get("_results", [])
 
             for raw_inbox in raw_inboxes:
                 inbox = {
@@ -1024,10 +1024,10 @@ class ListInboxesAction(ActionHandler):
 
                 inboxes.append(inbox)
 
-            return {"inboxes": inboxes, "result": True}
+            return ActionResult(data={"inboxes": inboxes, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"inboxes": [], "result": False, "error": f"Error listing inboxes: {str(e)}"}
+            return ActionResult(data={"inboxes": [], "result": False, "error": f"Error listing inboxes: {str(e)}"}, cost_usd=0)
 
 
 @front.action("list_teammates")
@@ -1040,16 +1040,16 @@ class ListTeammatesAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/teammates", params={"limit": min(limit, 100)})
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "teammates": [],
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse teammates
             teammates = []
-            raw_teammates = response.get("_results", [])
+            raw_teammates = response.data.get("_results", [])
 
             for raw_teammate in raw_teammates:
                 teammate = {
@@ -1067,10 +1067,10 @@ class ListTeammatesAction(ActionHandler):
 
                 teammates.append(teammate)
 
-            return {"teammates": teammates, "result": True}
+            return ActionResult(data={"teammates": teammates, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"teammates": [], "result": False, "error": f"Error listing teammates: {str(e)}"}
+            return ActionResult(data={"teammates": [], "result": False, "error": f"Error listing teammates: {str(e)}"}, cost_usd=0)
 
 
 @front.action("get_teammate")
@@ -1083,31 +1083,31 @@ class GetTeammateAction(ActionHandler):
             response = await context.fetch(f"{FRONT_API_BASE}/teammates/{teammate_id}")
 
             # Check for API errors
-            if "error" in response:
-                return {
+            if "error" in response.data:
+                return ActionResult(data={
                     "teammate": {},
                     "result": False,
-                    "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                    "error": f"API request failed: {response.data.get('error', 'Unknown error')}",
+                }, cost_usd=0)
 
             # Parse teammate
             teammate = {
-                "id": response.get("id", ""),
-                "email": response.get("email", ""),
-                "username": response.get("username", ""),
-                "first_name": response.get("first_name", ""),
-                "last_name": response.get("last_name", ""),
-                "is_admin": response.get("is_admin", False),
-                "is_available": response.get("is_available", True),
-                "is_blocked": response.get("is_blocked", False),
-                "type": response.get("type", "user"),
-                "custom_fields": response.get("custom_fields", {}),
+                "id": response.data.get("id", ""),
+                "email": response.data.get("email", ""),
+                "username": response.data.get("username", ""),
+                "first_name": response.data.get("first_name", ""),
+                "last_name": response.data.get("last_name", ""),
+                "is_admin": response.data.get("is_admin", False),
+                "is_available": response.data.get("is_available", True),
+                "is_blocked": response.data.get("is_blocked", False),
+                "type": response.data.get("type", "user"),
+                "custom_fields": response.data.get("custom_fields", {}),
             }
 
-            return {"teammate": teammate, "result": True}
+            return ActionResult(data={"teammate": teammate, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"teammate": {}, "result": False, "error": f"Error getting teammate: {str(e)}"}
+            return ActionResult(data={"teammate": {}, "result": False, "error": f"Error getting teammate: {str(e)}"}, cost_usd=0)
 
 
 # ---- Helper Actions for Name-Based Lookups ----
@@ -1128,11 +1128,11 @@ class FindTeammateAction(ActionHandler):
             list_result = await list_action.execute({"limit": 100}, context)
 
             if not list_result["result"]:
-                return {
+                return ActionResult(data={
                     "teammates": [],
                     "result": False,
                     "error": f"Failed to fetch teammates: {list_result.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0)
 
             # Filter teammates by search query (case-insensitive partial match)
             teammates = list_result["teammates"]
@@ -1156,10 +1156,10 @@ class FindTeammateAction(ActionHandler):
                 ):
                     matching_teammates.append(teammate)
 
-            return {"teammates": matching_teammates, "result": True, "count": len(matching_teammates)}
+            return ActionResult(data={"teammates": matching_teammates, "result": True, "count": len(matching_teammates)}, cost_usd=0)
 
         except Exception as e:
-            return {"teammates": [], "result": False, "error": f"Error finding teammate: {str(e)}"}
+            return ActionResult(data={"teammates": [], "result": False, "error": f"Error finding teammate: {str(e)}"}, cost_usd=0)
 
 
 @front.action("find_inbox")
@@ -1177,11 +1177,11 @@ class FindInboxAction(ActionHandler):
             list_result = await list_action.execute({"limit": 100}, context)
 
             if not list_result["result"]:
-                return {
+                return ActionResult(data={
                     "inboxes": [],
                     "result": False,
                     "error": f"Failed to fetch inboxes: {list_result.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0)
 
             # Filter inboxes by name (case-insensitive partial match)
             inboxes = list_result["inboxes"]
@@ -1194,10 +1194,10 @@ class FindInboxAction(ActionHandler):
                 if inbox_name in name:
                     matching_inboxes.append(inbox)
 
-            return {"inboxes": matching_inboxes, "result": True, "count": len(matching_inboxes)}
+            return ActionResult(data={"inboxes": matching_inboxes, "result": True, "count": len(matching_inboxes)}, cost_usd=0)
 
         except Exception as e:
-            return {"inboxes": [], "result": False, "error": f"Error finding inbox: {str(e)}"}
+            return ActionResult(data={"inboxes": [], "result": False, "error": f"Error finding inbox: {str(e)}"}, cost_usd=0)
 
 
 @front.action("find_conversation")
@@ -1216,11 +1216,11 @@ class FindConversationAction(ActionHandler):
             list_result = await list_action.execute({"inbox_id": inbox_id, "limit": 100}, context)
 
             if not list_result["result"]:
-                return {
+                return ActionResult(data={
                     "conversations": [],
                     "result": False,
                     "error": f"Failed to fetch conversations: {list_result.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0)
 
             # Filter conversations by search query (case-insensitive partial match)
             conversations = list_result["conversations"]
@@ -1246,7 +1246,7 @@ class FindConversationAction(ActionHandler):
                 ):
                     matching_conversations.append(conversation)
 
-            return {"conversations": matching_conversations, "result": True, "count": len(matching_conversations)}
+            return ActionResult(data={"conversations": matching_conversations, "result": True, "count": len(matching_conversations)}, cost_usd=0)
 
         except Exception as e:
-            return {"conversations": [], "result": False, "error": f"Error finding conversation: {str(e)}"}
+            return ActionResult(data={"conversations": [], "result": False, "error": f"Error finding conversation: {str(e)}"}, cost_usd=0)

--- a/front/requirements.txt
+++ b/front/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/ghost/requirements.txt
+++ b/ghost/requirements.txt
@@ -1,3 +1,3 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 requests
 PyJWT>=2.0,<3

--- a/github/github.py
+++ b/github/github.py
@@ -121,12 +121,12 @@ class GitHubAPI:
             response = await context.fetch(url, params=params, headers=headers)
 
             # Extract items from response
-            if data_key and isinstance(response, dict):
-                items = response.get(data_key, [])
-            elif isinstance(response, list):
-                items = response
+            if data_key and isinstance(response.data, dict):
+                items = response.data.get(data_key, [])
+            elif isinstance(response.data, list):
+                items = response.data
             else:
-                items = [response] if response else []
+                items = [response.data] if response.data else []
 
             if not items:
                 break
@@ -182,13 +182,13 @@ class GitHubAPI:
         if license_template:
             data["license_template"] = license_template
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def get_repository(context: ExecutionContext, owner: str, repo: str) -> Dict[str, Any]:
         """Get repository details"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def list_repositories(
@@ -245,7 +245,7 @@ class GitHubAPI:
         """Update repository settings"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}"
         data = {k: v for k, v in kwargs.items() if v is not None}
-        return await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def delete_repository(context: ExecutionContext, owner: str, repo: str) -> None:
@@ -284,7 +284,7 @@ class GitHubAPI:
     async def get_commit(context: ExecutionContext, owner: str, repo: str, sha: str) -> Dict[str, Any]:
         """Get a specific commit"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/commits/{sha}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def compare_branches(
@@ -292,7 +292,7 @@ class GitHubAPI:
     ) -> Dict[str, Any]:
         """Compare two branches"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/compare/{base}...{head}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Issue Operations ----
 
@@ -322,7 +322,7 @@ class GitHubAPI:
     async def get_issue(context: ExecutionContext, owner: str, repo: str, issue_number: int) -> Dict[str, Any]:
         """Get a specific issue"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/issues/{issue_number}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def create_issue(
@@ -348,7 +348,7 @@ class GitHubAPI:
         if milestone:
             data["milestone"] = milestone
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def update_issue(
@@ -380,7 +380,7 @@ class GitHubAPI:
         if milestone is not None:
             data["milestone"] = milestone
 
-        return await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def get_issue_comments(
@@ -397,7 +397,7 @@ class GitHubAPI:
         """Create a comment on an issue"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/issues/{issue_number}/comments"
         data = {"body": body}
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Pull Request Operations ----
 
@@ -448,7 +448,7 @@ class GitHubAPI:
 
         while True:
             response = await context.fetch(url, params=params, headers=headers)
-            items = response.get("items", [])
+            items = response.data.get("items", [])
             if not items:
                 break
 
@@ -468,7 +468,7 @@ class GitHubAPI:
     async def get_pull_request(context: ExecutionContext, owner: str, repo: str, pull_number: int) -> Dict[str, Any]:
         """Get detailed information about a pull request"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def create_pull_request(
@@ -495,7 +495,7 @@ class GitHubAPI:
         if body:
             data["body"] = body
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def update_pull_request(
@@ -504,7 +504,7 @@ class GitHubAPI:
         """Update a pull request"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}"
         data = {k: v for k, v in kwargs.items() if v is not None}
-        return await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def merge_pull_request(
@@ -525,7 +525,7 @@ class GitHubAPI:
         if commit_message:
             data["commit_message"] = commit_message
 
-        return await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def add_pull_request_reviewers(
@@ -545,7 +545,7 @@ class GitHubAPI:
         if team_reviewers:
             data["team_reviewers"] = team_reviewers
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def remove_pull_request_reviewers(
@@ -565,7 +565,7 @@ class GitHubAPI:
         if team_reviewers:
             data["team_reviewers"] = team_reviewers
 
-        return await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def list_pull_request_reviewers(
@@ -573,7 +573,7 @@ class GitHubAPI:
     ) -> Dict[str, Any]:
         """List reviewers for a pull request"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def create_pull_request_review(
@@ -596,7 +596,7 @@ class GitHubAPI:
         if comments:
             data["comments"] = comments
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Branch Operations ----
 
@@ -610,7 +610,7 @@ class GitHubAPI:
     async def get_branch(context: ExecutionContext, owner: str, repo: str, branch: str) -> Dict[str, Any]:
         """Get branch details"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/branches/{branch}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def create_branch(
@@ -619,7 +619,7 @@ class GitHubAPI:
         """Create a new branch"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/git/refs"
         data = {"ref": f"refs/heads/{branch_name}", "sha": sha}
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def delete_branch(context: ExecutionContext, owner: str, repo: str, branch: str) -> None:
@@ -631,7 +631,7 @@ class GitHubAPI:
     async def get_branch_protection(context: ExecutionContext, owner: str, repo: str, branch: str) -> Dict[str, Any]:
         """Get branch protection rules"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/branches/{branch}/protection"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Webhook Operations ----
 
@@ -656,11 +656,11 @@ class GitHubAPI:
 
         data = {"name": "web", "active": active, "events": events, "config": config}
 
-        return await context.fetch(
+        return (await context.fetch(
             webhook_url,
             method="POST",
             json=data,
-            headers=GitHubAPI.get_headers(context),
+            headers=GitHubAPI.get_headers(context)).data,
         )
 
     @staticmethod
@@ -673,7 +673,7 @@ class GitHubAPI:
     async def get_webhook(context: ExecutionContext, owner: str, repo: str, hook_id: int) -> Dict[str, Any]:
         """Get webhook details"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/hooks/{hook_id}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def delete_webhook(context: ExecutionContext, owner: str, repo: str, hook_id: int) -> None:
@@ -701,14 +701,14 @@ class GitHubAPI:
         )
 
         # Decode base64 content
-        content = base64.b64decode(response.get("content", "").replace("\n", "")).decode("utf-8")
+        content = base64.b64decode(response.data.get("content", "").replace("\n", "")).decode("utf-8")
 
         return {
             "content": content,
-            "sha": response.get("sha", ""),
-            "size": response.get("size", 0),
-            "name": response.get("name", ""),
-            "path": response.get("path", ""),
+            "sha": response.data.get("sha", ""),
+            "size": response.data.get("size", 0),
+            "name": response.data.get("name", ""),
+            "path": response.data.get("path", ""),
         }
 
     @staticmethod
@@ -733,7 +733,7 @@ class GitHubAPI:
         if branch:
             data["branch"] = branch
 
-        return await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def update_file(
@@ -758,7 +758,7 @@ class GitHubAPI:
         if branch:
             data["branch"] = branch
 
-        return await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def delete_file(
@@ -778,7 +778,7 @@ class GitHubAPI:
         if branch:
             data["branch"] = branch
 
-        return await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Gist Operations ----
 
@@ -792,13 +792,13 @@ class GitHubAPI:
         """Create a gist"""
         url = f"{GitHubAPI.BASE_URL}/gists"
         data = {"description": description, "public": public, "files": files}
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def get_gist(context: ExecutionContext, gist_id: str) -> Dict[str, Any]:
         """Get gist details"""
         url = f"{GitHubAPI.BASE_URL}/gists/{gist_id}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def list_gists(context: ExecutionContext, username: str = None) -> List[Dict[str, Any]]:
@@ -826,7 +826,7 @@ class GitHubAPI:
         else:
             url = f"{GitHubAPI.BASE_URL}/user"
 
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Organization Operations ----
 
@@ -892,7 +892,7 @@ class GitHubAPI:
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/tags"
         params = {"per_page": per_page, "page": page}
-        return await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context)).data)
 
     # -------------------------------------------------------------------------
     # Release Operations
@@ -921,7 +921,7 @@ class GitHubAPI:
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases"
         params = {"per_page": per_page, "page": page}
-        return await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def get_release(context: ExecutionContext, owner: str, repo: str, release_id: int) -> Dict[str, Any]:
@@ -937,7 +937,7 @@ class GitHubAPI:
             Release object with full details including assets
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases/{release_id}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def get_latest_release(context: ExecutionContext, owner: str, repo: str) -> Dict[str, Any]:
@@ -954,7 +954,7 @@ class GitHubAPI:
             Latest release object
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases/latest"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     @staticmethod
     async def get_release_by_tag(context: ExecutionContext, owner: str, repo: str, tag: str) -> Dict[str, Any]:
@@ -973,7 +973,7 @@ class GitHubAPI:
         """
         encoded_tag = quote(tag, safe="")
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases/tags/{encoded_tag}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
     # ---- Rate Limiting ----
 
@@ -981,7 +981,7 @@ class GitHubAPI:
     async def get_rate_limit(context: ExecutionContext) -> Dict[str, Any]:
         """Get current rate limit status"""
         url = f"{GitHubAPI.BASE_URL}/rate_limit"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context)).data)
 
 
 # ============================================================================

--- a/github/requirements.txt
+++ b/github/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk==1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -41,7 +41,7 @@ class GetCurrentUserAction(ActionHandler):
         try:
             response = await context.fetch(f"{GITLAB_API_BASE_URL}/user", method="GET")
 
-            return ActionResult(data={"user": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"user": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -77,7 +77,7 @@ class ListProjectsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            projects = response if isinstance(response, list) else []
+            projects = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"projects": projects, "result": True}, cost_usd=0.0)
 
@@ -103,7 +103,7 @@ class GetProjectAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return ActionResult(data={"project": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"project": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"project": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -147,7 +147,7 @@ class ListIssuesAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params if params else None)
 
-            issues = response if isinstance(response, list) else []
+            issues = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"issues": issues, "result": True}, cost_usd=0.0)
 
@@ -169,7 +169,7 @@ class GetIssueAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"issue": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"issue": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"issue": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -216,7 +216,7 @@ class ListMergeRequestsAction(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params if params else None)
 
-            merge_requests = response if isinstance(response, list) else []
+            merge_requests = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"merge_requests": merge_requests, "result": True}, cost_usd=0.0)
 
@@ -248,7 +248,7 @@ class GetMergeRequestAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return ActionResult(data={"merge_request": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"merge_request": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -271,7 +271,7 @@ class GetMergeRequestChangesAction(ActionHandler):
                 method="GET",
             )
 
-            changes = response.get("changes", []) if isinstance(response, dict) else []
+            changes = response.data.get("changes", []) if isinstance(response, dict) else []
 
             return ActionResult(data={"changes": changes, "result": True}, cost_usd=0.0)
 
@@ -299,7 +299,7 @@ class ListMergeRequestCommitsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            commits = response if isinstance(response, list) else []
+            commits = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"commits": commits, "result": True}, cost_usd=0.0)
 
@@ -329,7 +329,7 @@ class ListBranchesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            branches = response if isinstance(response, list) else []
+            branches = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"branches": branches, "result": True}, cost_usd=0.0)
 
@@ -351,7 +351,7 @@ class GetBranchAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"branch": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"branch": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"branch": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -390,7 +390,7 @@ class ListCommitsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            commits = response if isinstance(response, list) else []
+            commits = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"commits": commits, "result": True}, cost_usd=0.0)
 
@@ -417,7 +417,7 @@ class GetCommitAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return ActionResult(data={"commit": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"commit": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"commit": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -443,7 +443,7 @@ class GetCommitDiffAction(ActionHandler):
                 params=params if params else None,
             )
 
-            diffs = response if isinstance(response, list) else []
+            diffs = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"diffs": diffs, "result": True}, cost_usd=0.0)
 
@@ -485,7 +485,7 @@ class ListPipelinesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            pipelines = response if isinstance(response, list) else []
+            pipelines = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"pipelines": pipelines, "result": True}, cost_usd=0.0)
 
@@ -507,7 +507,7 @@ class GetPipelineAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"pipeline": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"pipeline": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"pipeline": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -533,7 +533,7 @@ class ListPipelineJobsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            jobs = response if isinstance(response, list) else []
+            jobs = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"jobs": jobs, "result": True}, cost_usd=0.0)
 
@@ -563,7 +563,7 @@ class ListRepositoryTreeAction(ActionHandler):
                 params=params if params else None,
             )
 
-            tree = response if isinstance(response, list) else []
+            tree = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"tree": tree, "result": True}, cost_usd=0.0)
 
@@ -587,7 +587,7 @@ class GetFileAction(ActionHandler):
                 params={"ref": ref},
             )
 
-            return ActionResult(data={"file": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"file": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"file": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -641,7 +641,7 @@ class CompareBranchesAction(ActionHandler):
                 params=params,
             )
 
-            return ActionResult(data={"comparison": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"comparison": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"comparison": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -669,7 +669,7 @@ class ListContainerRegistryRepositoriesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            repositories = response if isinstance(response, list) else []
+            repositories = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"repositories": repositories, "result": True}, cost_usd=0.0)
 
@@ -700,7 +700,7 @@ class GetContainerRegistryRepositoryAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return ActionResult(data={"repository": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"repository": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"repository": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -726,7 +726,7 @@ class ListContainerRegistryTagsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            tags = response if isinstance(response, list) else []
+            tags = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"tags": tags, "result": True}, cost_usd=0.0)
 
@@ -749,7 +749,7 @@ class GetContainerRegistryTagAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"tag": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"tag": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"tag": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/gitlab/requirements.txt
+++ b/gitlab/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/gong/gong.py
+++ b/gong/gong.py
@@ -36,13 +36,13 @@ class GongAPIClient:
 
         # Use the context's fetch method for authenticated requests (OAuth handled by SDK)
         if method == "GET":
-            return await self.context.fetch(url, params=params, headers=headers)
+            return (await self.context.fetch(url, params=params, headers=headers)).data
         elif method == "POST":
-            return await self.context.fetch(url, method="POST", json=data, headers=headers)
+            return (await self.context.fetch(url, method="POST", json=data, headers=headers)).data
         elif method == "PUT":
-            return await self.context.fetch(url, method="PUT", json=data, headers=headers)
+            return (await self.context.fetch(url, method="PUT", json=data, headers=headers)).data
         elif method == "DELETE":
-            return await self.context.fetch(url, method="DELETE", headers=headers)
+            return (await self.context.fetch(url, method="DELETE", headers=headers)).data
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 

--- a/gong/requirements.txt
+++ b/gong/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 python-dateutil

--- a/google-ads/requirements.txt
+++ b/google-ads/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 google-ads~=30.0
 python-dotenv
 proto-plus

--- a/google-analytics/requirements.txt
+++ b/google-analytics/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 google-analytics-data
 google-auth
 google-auth-oauthlib

--- a/google-business-profie/requirements.txt
+++ b/google-business-profie/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/google-business-profie/reviews.py
+++ b/google-business-profie/reviews.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -87,12 +87,12 @@ class ListAccounts(ActionHandler):
                     }
                 )
 
-            return {"accounts": accounts, "result": True}
+            return ActionResult(data={"accounts": accounts, "result": True}, cost_usd=0)
 
         except HttpError as e:
-            return {"accounts": [], "result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"accounts": [], "result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0)
         except Exception as e:
-            return {"accounts": [], "result": False, "error": str(e)}
+            return ActionResult(data={"accounts": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @reviews.action("list_locations")
@@ -138,12 +138,12 @@ class ListLocations(ActionHandler):
                     }
                 )
 
-            return {"locations": locations, "result": True}
+            return ActionResult(data={"locations": locations, "result": True}, cost_usd=0)
 
         except HttpError as e:
-            return {"locations": [], "result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"locations": [], "result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0)
         except Exception as e:
-            return {"locations": [], "result": False, "error": str(e)}
+            return ActionResult(data={"locations": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @reviews.action("list_reviews")
@@ -155,14 +155,14 @@ class ListReviews(ActionHandler):
 
             # Validate location_name format
             if not location_name.startswith("accounts/"):
-                return {
+                return ActionResult(data={
                     "reviews": [],
                     "result": False,
                     "error": (
                         f"Invalid location_name format: '{location_name}'. "
                         "Expected format: 'accounts/{account_id}/locations/{location_id}'"
                     ),
-                }
+                }, cost_usd=0)
 
             # List reviews for the location
             request = service.accounts().locations().reviews().list(parent=location_name)
@@ -194,12 +194,12 @@ class ListReviews(ActionHandler):
 
                 reviews.append(review_data)
 
-            return {"reviews": reviews, "result": True}
+            return ActionResult(data={"reviews": reviews, "result": True}, cost_usd=0)
 
         except HttpError as e:
-            return {"reviews": [], "result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"reviews": [], "result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0)
         except Exception as e:
-            return {"reviews": [], "result": False, "error": str(e)}
+            return ActionResult(data={"reviews": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @reviews.action("reply_to_review")
@@ -215,15 +215,15 @@ class ReplyToReview(ActionHandler):
             request = service.accounts().locations().reviews().updateReply(name=review_name, body=reply_body)
             response = request.execute()
 
-            return {
+            return ActionResult(data={
                 "reviewReply": {"comment": response.get("comment", ""), "updateTime": response.get("updateTime", "")},
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except HttpError as e:
-            return {"result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @reviews.action("delete_review_reply")
@@ -236,9 +236,9 @@ class DeleteReviewReply(ActionHandler):
             request = service.accounts().locations().reviews().deleteReply(name=review_name)
             request.execute()
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except HttpError as e:
-            return {"result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)

--- a/google-calendar/google_calendar.py
+++ b/google-calendar/google_calendar.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -64,13 +64,13 @@ class ListCalendars(ActionHandler):
             response = await context.fetch(service_endpoint + "users/me/calendarList", method="GET")
 
             calendars = []
-            for raw_calendar in response.get("items", []):
+            for raw_calendar in response.data.get("items", []):
                 calendars.append(CalendarEventParser.parse_calendar(raw_calendar))
 
-            return {"calendars": calendars, "result": True}
+            return ActionResult(data={"calendars": calendars, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"calendars": [], "result": False, "error": str(e)}
+            return ActionResult(data={"calendars": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_calendar.action("list_events")
@@ -95,20 +95,20 @@ class ListEvents(ActionHandler):
             )
 
             events = []
-            for raw_event in response.get("items", []):
+            for raw_event in response.data.get("items", []):
                 events.append(CalendarEventParser.parse_event(raw_event))
 
             # Prepare response with pagination support
             result = {"events": events, "result": True}
 
             # Add nextPageToken if present
-            if "nextPageToken" in response:
-                result["nextPageToken"] = response["nextPageToken"]
+            if "nextPageToken" in response.data:
+                result["nextPageToken"] = response.data["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0)
 
         except Exception as e:
-            return {"events": [], "result": False, "error": str(e)}
+            return ActionResult(data={"events": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_calendar.action("get_event")
@@ -122,10 +122,10 @@ class GetEvent(ActionHandler):
                 service_endpoint + f"calendars/{calendar_id}/events/{event_id}", method="GET"
             )
 
-            return {"event": CalendarEventParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": CalendarEventParser.parse_event(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_calendar.action("create_event")
@@ -159,10 +159,10 @@ class CreateEvent(ActionHandler):
                 service_endpoint + f"calendars/{calendar_id}/events", method="POST", json=event_data
             )
 
-            return {"event": CalendarEventParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": CalendarEventParser.parse_event(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_calendar.action("update_event")
@@ -178,7 +178,7 @@ class UpdateEvent(ActionHandler):
             )
 
             # Build updated event data, starting with existing event
-            event_data = existing_event.copy()
+            event_data = existing_event.data.copy()
 
             # Update fields that were provided in inputs
             if "summary" in inputs:
@@ -208,10 +208,10 @@ class UpdateEvent(ActionHandler):
                 service_endpoint + f"calendars/{calendar_id}/events/{event_id}", method="PUT", json=event_data
             )
 
-            return {"event": CalendarEventParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": CalendarEventParser.parse_event(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_calendar.action("delete_event")
@@ -223,10 +223,10 @@ class DeleteEvent(ActionHandler):
 
             await context.fetch(service_endpoint + f"calendars/{calendar_id}/events/{event_id}", method="DELETE")
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Polling Trigger Handlers ----

--- a/google-calendar/requirements.txt
+++ b/google-calendar/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/google-chat/google_chat.py
+++ b/google-chat/google_chat.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -145,10 +145,10 @@ class ListSpaces(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0)
 
         except Exception as e:
-            return {"spaces": [], **handle_api_error(e)}
+            return ActionResult(data={"spaces": [], **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("get_space")
@@ -161,10 +161,10 @@ class GetSpace(ActionHandler):
             request = service.spaces().get(name=space_name)
             response = request.execute()
 
-            return {"space": format_space(response), "result": True}
+            return ActionResult(data={"space": format_space(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"space": {}, **handle_api_error(e)}
+            return ActionResult(data={"space": {}, **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("create_space")
@@ -181,10 +181,10 @@ class CreateSpace(ActionHandler):
             request = service.spaces().create(body=space_body)
             response = request.execute()
 
-            return {"space": format_space(response), "result": True}
+            return ActionResult(data={"space": format_space(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"space": {}, **handle_api_error(e)}
+            return ActionResult(data={"space": {}, **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("send_message")
@@ -208,10 +208,10 @@ class SendMessage(ActionHandler):
             request = service.spaces().messages().create(**params)
             response = request.execute()
 
-            return {"message": format_message(response), "result": True}
+            return ActionResult(data={"message": format_message(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"message": {}, **handle_api_error(e)}
+            return ActionResult(data={"message": {}, **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("list_messages")
@@ -246,10 +246,10 @@ class ListMessages(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0)
 
         except Exception as e:
-            return {"messages": [], **handle_api_error(e)}
+            return ActionResult(data={"messages": [], **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("get_message")
@@ -262,10 +262,10 @@ class GetMessage(ActionHandler):
             request = service.spaces().messages().get(name=message_name)
             response = request.execute()
 
-            return {"message": format_message(response), "result": True}
+            return ActionResult(data={"message": format_message(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"message": {}, **handle_api_error(e)}
+            return ActionResult(data={"message": {}, **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("update_message")
@@ -282,10 +282,10 @@ class UpdateMessage(ActionHandler):
             request = service.spaces().messages().patch(**params)
             response = request.execute()
 
-            return {"message": format_message(response), "result": True}
+            return ActionResult(data={"message": format_message(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"message": {}, **handle_api_error(e)}
+            return ActionResult(data={"message": {}, **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("delete_message")
@@ -302,10 +302,10 @@ class DeleteMessage(ActionHandler):
             request = service.spaces().messages().delete(**params)
             request.execute()
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return handle_api_error(e)
+            return ActionResult(data=handle_api_error(e), cost_usd=0)
 
 
 @google_chat.action("list_members")
@@ -336,10 +336,10 @@ class ListMembers(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0)
 
         except Exception as e:
-            return {"members": [], **handle_api_error(e)}
+            return ActionResult(data={"members": [], **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("add_reaction")
@@ -354,10 +354,10 @@ class AddReaction(ActionHandler):
             request = service.spaces().messages().reactions().create(parent=message_name, body=reaction_body)
             response = request.execute()
 
-            return {"reaction": format_reaction(response), "result": True}
+            return ActionResult(data={"reaction": format_reaction(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"reaction": {}, **handle_api_error(e)}
+            return ActionResult(data={"reaction": {}, **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("list_reactions")
@@ -388,10 +388,10 @@ class ListReactions(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0)
 
         except Exception as e:
-            return {"reactions": [], **handle_api_error(e)}
+            return ActionResult(data={"reactions": [], **handle_api_error(e)}, cost_usd=0)
 
 
 @google_chat.action("remove_reaction")
@@ -404,10 +404,10 @@ class RemoveReaction(ActionHandler):
             request = service.spaces().messages().reactions().delete(name=reaction_name)
             request.execute()
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0)
 
         except Exception as e:
-            return handle_api_error(e)
+            return ActionResult(data=handle_api_error(e), cost_usd=0)
 
 
 @google_chat.action("find_direct_message")
@@ -420,7 +420,7 @@ class FindDirectMessage(ActionHandler):
             request = service.spaces().findDirectMessage(name=user_name)
             response = request.execute()
 
-            return {"space": format_space(response), "result": True}
+            return ActionResult(data={"space": format_space(response), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"space": {}, **handle_api_error(e)}
+            return ActionResult(data={"space": {}, **handle_api_error(e)}, cost_usd=0)

--- a/google-chat/requirements.txt
+++ b/google-chat/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/google-search-console/requirements.txt
+++ b/google-search-console/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 google-api-python-client
 google-auth
 google-auth-oauthlib

--- a/google-sheets/google_sheets.py
+++ b/google-sheets/google_sheets.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -58,15 +58,15 @@ class ListSpreadsheets(ActionHandler):
             next_page = result.get("nextPageToken")
             if isinstance(next_page, str) and next_page:
                 response["nextPageToken"] = next_page
-            return response
+            return ActionResult(data=response, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "files": [],
                 "result": False,
                 "error": f"Google Drive API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"files": [], "result": False, "error": str(e)}
+            return ActionResult(data={"files": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_get_spreadsheet")
@@ -78,15 +78,15 @@ class GetSpreadsheet(ActionHandler):
             include_grid = bool(inputs.get("include_grid_data", False))
             request = service.spreadsheets().get(spreadsheetId=spreadsheet_id, includeGridData=include_grid)
             spreadsheet = request.execute()
-            return {"spreadsheet": spreadsheet, "result": True}
+            return ActionResult(data={"spreadsheet": spreadsheet, "result": True}, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "spreadsheet": {},
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"spreadsheet": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"spreadsheet": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_list_sheets")
@@ -105,15 +105,15 @@ class ListSheets(ActionHandler):
                 .execute()
             )
             sheets_list = [s.get("properties", {}) for s in result.get("sheets", [])]
-            return {"sheets": sheets_list, "result": True}
+            return ActionResult(data={"sheets": sheets_list, "result": True}, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "sheets": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"sheets": [], "result": False, "error": str(e)}
+            return ActionResult(data={"sheets": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_read_range")
@@ -131,25 +131,25 @@ class ReadRange(ActionHandler):
             if dt_render:
                 params["dateTimeRenderOption"] = dt_render
             result = service.spreadsheets().values().get(**params).execute()
-            return {
+            return ActionResult(data={
                 "range": result.get("range", a1),
                 "values": result.get("values", []),
                 "result": True,
-            }
+            }, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "range": inputs.get("range"),
                 "values": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {
+            return ActionResult(data={
                 "range": inputs.get("range"),
                 "values": [],
                 "result": False,
                 "error": str(e),
-            }
+            }, cost_usd=0)
 
 
 @google_sheets.action("sheets_write_range")
@@ -169,14 +169,14 @@ class WriteRange(ActionHandler):
                 # Estimate cells
                 rows = len(values)
                 cols = max((len(r) for r in values), default=0)
-                return {
+                return ActionResult(data={
                     "updatedRange": a1,
                     "updatedRows": rows,
                     "updatedColumns": cols,
                     "updatedCells": rows * cols,
                     "dryRun": True,
                     "result": True,
-                }
+                }, cost_usd=0)
 
             service = build_sheets_service(context)
             body = {"values": values}
@@ -191,18 +191,18 @@ class WriteRange(ActionHandler):
                 )
                 .execute()
             )
-            return {
+            return ActionResult(data={
                 "updatedRange": result.get("updatedRange", a1),
                 "updatedRows": result.get("updatedRows", 0),
                 "updatedColumns": result.get("updatedColumns", 0),
                 "updatedCells": result.get("updatedCells", 0),
                 "dryRun": False,
                 "result": True,
-            }
+            }, cost_usd=0)
         except HttpError as e:
-            return {"result": False, "error": f"Google Sheets API error: {str(e)}"}
+            return ActionResult(data={"result": False, "error": f"Google Sheets API error: {str(e)}"}, cost_usd=0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_append_rows")
@@ -227,15 +227,15 @@ class AppendRows(ActionHandler):
                 )
                 .execute()
             )
-            return {"updates": result.get("updates", result), "result": True}
+            return ActionResult(data={"updates": result.get("updates", result), "result": True}, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "updates": {},
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"updates": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"updates": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_format_range")
@@ -260,15 +260,15 @@ class FormatRange(ActionHandler):
             result = (
                 service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
             )
-            return {"replies": result.get("replies", []), "result": True}
+            return ActionResult(data={"replies": result.get("replies", []), "result": True}, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "replies": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_freeze")
@@ -302,15 +302,15 @@ class FreezePanes(ActionHandler):
             result = (
                 service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
             )
-            return {"replies": result.get("replies", []), "result": True}
+            return ActionResult(data={"replies": result.get("replies", []), "result": True}, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "replies": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_batch_update")
@@ -323,34 +323,34 @@ class SheetsBatchUpdate(ActionHandler):
 
             # Basic validation: ensure it's a list of dicts
             if not isinstance(requests, list) or not all(isinstance(r, dict) for r in requests):
-                return {
+                return ActionResult(data={
                     "result": False,
                     "error": "requests must be an array of objects",
-                }
+                }, cost_usd=0)
 
             if dry_run:
                 # Validate by fetching spreadsheet metadata
                 service = build_sheets_service(context)
                 _ = service.spreadsheets().get(spreadsheetId=spreadsheet_id, includeGridData=False).execute()
-                return {"replies": [], "dryRun": True, "result": True}
+                return ActionResult(data={"replies": [], "dryRun": True, "result": True}, cost_usd=0)
 
             service = build_sheets_service(context)
             result = (
                 service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
             )
-            return {
+            return ActionResult(data={
                 "replies": result.get("replies", []),
                 "dryRun": False,
                 "result": True,
-            }
+            }, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "replies": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @google_sheets.action("sheets_duplicate_spreadsheet")
@@ -374,12 +374,12 @@ class DuplicateSpreadsheet(ActionHandler):
                 )
                 .execute()
             )
-            return {"file_metadata": result, "result": True}
+            return ActionResult(data={"file_metadata": result, "result": True}, cost_usd=0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "file_metadata": {},
                 "result": False,
                 "error": f"Google Drive API error: {str(e)}",
-            }
+            }, cost_usd=0)
         except Exception as e:
-            return {"file_metadata": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"file_metadata": {}, "result": False, "error": str(e)}, cost_usd=0)

--- a/google-sheets/requirements.txt
+++ b/google-sheets/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/grammarly/requirements.txt
+++ b/grammarly/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/hackernews/hackernews.py
+++ b/hackernews/hackernews.py
@@ -18,7 +18,7 @@ HN_USER_URL = "https://news.ycombinator.com/user?id="
 async def fetch_json(context: ExecutionContext, url: str) -> Optional[Any]:
     """Fetch JSON from a URL, returning None on error."""
     try:
-        return await context.fetch(url, method="GET")
+        return (await context.fetch(url, method="GET")).data
     except Exception:
         return None
 

--- a/hackernews/requirements.txt
+++ b/hackernews/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp>=3.9.0

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -43,10 +43,10 @@ class CreateTimeEntry(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/time_entries", method="POST", json=payload)
 
-            return {"success": True, "time_entry": response}
+            return ActionResult(data={"success": True, "time_entry": response.data}, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("stop_time_entry")
@@ -59,10 +59,10 @@ class StopTimeEntry(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/time_entries/{time_entry_id}/stop", method="PATCH")
 
-            return {"success": True, "time_entry": response}
+            return ActionResult(data={"success": True, "time_entry": response.data}, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("list_time_entries")
@@ -109,20 +109,20 @@ class ListTimeEntries(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/time_entries", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
-                "time_entries": response.get("time_entries", []),
-                "per_page": response.get("per_page"),
-                "total_pages": response.get("total_pages"),
-                "total_entries": response.get("total_entries"),
-                "next_page": response.get("next_page"),
-                "previous_page": response.get("previous_page"),
-                "page": response.get("page"),
-                "links": response.get("links"),
-            }
+                "time_entries": response.data.get("time_entries", []),
+                "per_page": response.data.get("per_page"),
+                "total_pages": response.data.get("total_pages"),
+                "total_entries": response.data.get("total_entries"),
+                "next_page": response.data.get("next_page"),
+                "previous_page": response.data.get("previous_page"),
+                "page": response.data.get("page"),
+                "links": response.data.get("links"),
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("update_time_entry")
@@ -166,10 +166,10 @@ class UpdateTimeEntry(ActionHandler):
                 json=payload,
             )
 
-            return {"success": True, "time_entry": response}
+            return ActionResult(data={"success": True, "time_entry": response.data}, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("delete_time_entry")
@@ -182,13 +182,13 @@ class DeleteTimeEntry(ActionHandler):
 
             await context.fetch(f"{HARVEST_API_BASE}/time_entries/{time_entry_id}", method="DELETE")
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "message": f"Time entry {time_entry_id} deleted successfully",
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("list_projects")
@@ -217,20 +217,20 @@ class ListProjects(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/projects", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
-                "projects": response.get("projects", []),
-                "per_page": response.get("per_page"),
-                "total_pages": response.get("total_pages"),
-                "total_entries": response.get("total_entries"),
-                "next_page": response.get("next_page"),
-                "previous_page": response.get("previous_page"),
-                "page": response.get("page"),
-                "links": response.get("links"),
-            }
+                "projects": response.data.get("projects", []),
+                "per_page": response.data.get("per_page"),
+                "total_pages": response.data.get("total_pages"),
+                "total_entries": response.data.get("total_entries"),
+                "next_page": response.data.get("next_page"),
+                "previous_page": response.data.get("previous_page"),
+                "page": response.data.get("page"),
+                "links": response.data.get("links"),
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("get_project")
@@ -243,10 +243,10 @@ class GetProject(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/projects/{project_id}", method="GET")
 
-            return {"success": True, "project": response}
+            return ActionResult(data={"success": True, "project": response.data}, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("list_clients")
@@ -272,20 +272,20 @@ class ListClients(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/clients", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
-                "clients": response.get("clients", []),
-                "per_page": response.get("per_page"),
-                "total_pages": response.get("total_pages"),
-                "total_entries": response.get("total_entries"),
-                "next_page": response.get("next_page"),
-                "previous_page": response.get("previous_page"),
-                "page": response.get("page"),
-                "links": response.get("links"),
-            }
+                "clients": response.data.get("clients", []),
+                "per_page": response.data.get("per_page"),
+                "total_pages": response.data.get("total_pages"),
+                "total_entries": response.data.get("total_entries"),
+                "next_page": response.data.get("next_page"),
+                "previous_page": response.data.get("previous_page"),
+                "page": response.data.get("page"),
+                "links": response.data.get("links"),
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("list_tasks")
@@ -311,20 +311,20 @@ class ListTasks(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/tasks", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
-                "tasks": response.get("tasks", []),
-                "per_page": response.get("per_page"),
-                "total_pages": response.get("total_pages"),
-                "total_entries": response.get("total_entries"),
-                "next_page": response.get("next_page"),
-                "previous_page": response.get("previous_page"),
-                "page": response.get("page"),
-                "links": response.get("links"),
-            }
+                "tasks": response.data.get("tasks", []),
+                "per_page": response.data.get("per_page"),
+                "total_pages": response.data.get("total_pages"),
+                "total_entries": response.data.get("total_entries"),
+                "next_page": response.data.get("next_page"),
+                "previous_page": response.data.get("previous_page"),
+                "page": response.data.get("page"),
+                "links": response.data.get("links"),
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)
 
 
 @harvest.action("list_users")
@@ -350,17 +350,17 @@ class ListUsers(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/users", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
-                "users": response.get("users", []),
-                "per_page": response.get("per_page"),
-                "total_pages": response.get("total_pages"),
-                "total_entries": response.get("total_entries"),
-                "next_page": response.get("next_page"),
-                "previous_page": response.get("previous_page"),
-                "page": response.get("page"),
-                "links": response.get("links"),
-            }
+                "users": response.data.get("users", []),
+                "per_page": response.data.get("per_page"),
+                "total_pages": response.data.get("total_pages"),
+                "total_entries": response.data.get("total_entries"),
+                "next_page": response.data.get("next_page"),
+                "previous_page": response.data.get("previous_page"),
+                "page": response.data.get("page"),
+                "links": response.data.get("links"),
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0)

--- a/harvest/requirements.txt
+++ b/harvest/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 urllib3>=2.6.3

--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -145,14 +145,14 @@ class GetChannels(ActionHandler):
 
             channels = []
             # Handle both array response and object with items property
-            items = response if isinstance(response, list) else response.get("items", response.get("channels", []))
+            items = response.data if isinstance(response.data, list) else response.data.get("items", response.data.get("channels", []))
             for raw_channel in items:
                 channels.append(HeartbeatDataParser.parse_channel(raw_channel))
 
-            return {"channels": channels, "result": True}
+            return ActionResult(data={"channels": channels, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"channels": [], "result": False, "error": str(e)}
+            return ActionResult(data={"channels": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_channel")
@@ -167,13 +167,13 @@ class GetChannel(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {
-                "channel": HeartbeatDataParser.parse_channel(response),
+            return ActionResult(data={
+                "channel": HeartbeatDataParser.parse_channel(response.data),
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"channel": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"channel": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_channel_threads")
@@ -190,14 +190,14 @@ class GetChannelThreads(ActionHandler):
 
             threads = []
             # Handle both array response and object with items property
-            items = response if isinstance(response, list) else response.get("items", response.get("threads", []))
+            items = response.data if isinstance(response.data, list) else response.data.get("items", response.data.get("threads", []))
             for raw_thread in items:
                 threads.append(HeartbeatDataParser.parse_thread(raw_thread))
 
-            return {"threads": threads, "result": True}
+            return ActionResult(data={"threads": threads, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"threads": [], "result": False, "error": str(e)}
+            return ActionResult(data={"threads": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_thread")
@@ -212,13 +212,13 @@ class GetThread(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {
-                "thread": HeartbeatDataParser.parse_thread(response),
+            return ActionResult(data={
+                "thread": HeartbeatDataParser.parse_thread(response.data),
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"thread": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"thread": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_users")
@@ -233,14 +233,14 @@ class GetUsers(ActionHandler):
 
             users = []
             # Handle both array response and object with items property
-            items = response if isinstance(response, list) else response.get("items", response.get("users", []))
+            items = response.data if isinstance(response.data, list) else response.data.get("items", response.data.get("users", []))
             for raw_user in items:
                 users.append(HeartbeatDataParser.parse_user(raw_user))
 
-            return {"users": users, "result": True}
+            return ActionResult(data={"users": users, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"users": [], "result": False, "error": str(e)}
+            return ActionResult(data={"users": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_user")
@@ -255,10 +255,10 @@ class GetUser(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {"user": HeartbeatDataParser.parse_user(response), "result": True}
+            return ActionResult(data={"user": HeartbeatDataParser.parse_user(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"user": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_events")
@@ -273,14 +273,14 @@ class GetEvents(ActionHandler):
 
             events = []
             # Handle both array response and object with items property
-            items = response if isinstance(response, list) else response.get("items", response.get("events", []))
+            items = response.data if isinstance(response.data, list) else response.data.get("items", response.data.get("events", []))
             for raw_event in items:
                 events.append(HeartbeatDataParser.parse_event(raw_event))
 
-            return {"events": events, "result": True}
+            return ActionResult(data={"events": events, "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"events": [], "result": False, "error": str(e)}
+            return ActionResult(data={"events": [], "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("get_heartbeat_event")
@@ -295,10 +295,10 @@ class GetEvent(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {"event": HeartbeatDataParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": HeartbeatDataParser.parse_event(response.data), "result": True}, cost_usd=0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("create_heartbeat_comment")
@@ -331,13 +331,13 @@ class CreateComment(ActionHandler):
                 json=request_body,
             )
 
-            return {
-                "comment": HeartbeatDataParser.parse_comment(response),
+            return ActionResult(data={
+                "comment": HeartbeatDataParser.parse_comment(response.data),
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"comment": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 @heartbeat.action("create_heartbeat_thread")
@@ -362,13 +362,13 @@ class CreateThread(ActionHandler):
                 json=request_body,
             )
 
-            return {
-                "thread": HeartbeatDataParser.parse_thread(response),
+            return ActionResult(data={
+                "thread": HeartbeatDataParser.parse_thread(response.data),
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"thread": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"thread": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 
 # ---- Polling Trigger Handlers ----

--- a/heartbeat/requirements.txt
+++ b/heartbeat/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/heygen/heygen.py
+++ b/heygen/heygen.py
@@ -77,7 +77,7 @@ class GeneratePhotoAvatarHandler(ActionHandler):
                 json=request_body,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -106,7 +106,7 @@ class CheckGenerationStatusHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/photo_avatar/generation/{generation_id}", headers=headers, method="GET"
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -143,7 +143,7 @@ class CreateAvatarGroupHandler(ActionHandler):
                 json=request_body,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -180,7 +180,7 @@ class AddLooksToGroupHandler(ActionHandler):
                 json=request_body,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -210,7 +210,7 @@ class TrainAvatarGroupHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/photo_avatar/train", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -239,7 +239,7 @@ class CheckTrainingStatusHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/photo_avatar/train/status/{group_id}", headers=headers, method="GET"
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -278,7 +278,7 @@ class GenerateAvatarLookHandler(ActionHandler):
                 json=request_body,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -315,7 +315,7 @@ class AddMotionToAvatarHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/photo_avatar/add_motion", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -348,7 +348,7 @@ class AddSoundEffectToAvatarHandler(ActionHandler):
                 json=request_body,
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -387,7 +387,7 @@ class ListAvatarGroupsHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/avatar_group.list", headers=headers, method="GET", params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -416,7 +416,7 @@ class ListAvatarsInGroupHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/avatar_group/{group_id}/avatars", headers=headers, method="GET"
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -445,7 +445,7 @@ class GetAvatarDetailsHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/avatar/{avatar_id}/details", headers=headers, method="GET"
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -474,7 +474,7 @@ class GetPhotoAvatarDetailsHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/photo_avatar/{photo_avatar_id}", headers=headers, method="GET"
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -500,7 +500,7 @@ class ListVoicesHandler(ActionHandler):
         try:
             response = await context.fetch(url=f"{HEYGEN_API_BASE_URL}/voices", headers=headers, method="GET")
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -532,7 +532,7 @@ class ListVoiceLocalesHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/voices/locales", headers=headers, method="GET", params=params
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -569,8 +569,8 @@ class ListAvatarsHandler(ActionHandler):
             )
 
             # Simplify response to reduce size - remove long URLs
-            if response.get("data"):
-                data = response["data"]
+            if response.data.get("data"):
+                data = response.data["data"]
 
                 # Simplify avatars list
                 if "avatars" in data and data["avatars"]:
@@ -600,7 +600,7 @@ class ListAvatarsHandler(ActionHandler):
                         )
                     data["talking_photos"] = simplified_photos
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -649,7 +649,7 @@ class CreateAvatarVideoHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/video/generate", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -706,7 +706,7 @@ class CreatePhotoAvatarVideoHandler(ActionHandler):
                 url=f"{HEYGEN_API_BASE_URL}/video/av4/generate", method="POST", headers=headers, json=request_body
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)
@@ -735,7 +735,7 @@ class GetVideoStatusHandler(ActionHandler):
                 url=f"https://api.heygen.com/v1/video_status.get?video_id={video_id}", headers=headers, method="GET"
             )
 
-            return ActionResult(data=response, cost_usd=0.0)
+            return ActionResult(data=response.data, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "data": None}, cost_usd=0.0)

--- a/heygen/requirements.txt
+++ b/heygen/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/humanitix/actions/checkin.py
+++ b/humanitix/actions/checkin.py
@@ -21,6 +21,7 @@ async def _toggle_check(inputs: Dict[str, Any], context: ExecutionContext, actio
     url = build_url(f"events/{event_id}/tickets/{ticket_id}/{action}", params)
 
     response = await context.fetch(url, method="POST", headers=headers)
+    response = response.data
 
     if error := build_error_result(response):
         return error

--- a/humanitix/actions/events.py
+++ b/humanitix/actions/events.py
@@ -50,6 +50,7 @@ class GetEventsAction(ActionHandler):
         url = build_url("events", params)
 
         response = await context.fetch(url, method="GET", headers=get_api_headers(context))
+        response = response.data
 
         if error := build_error_result(response):
             return error

--- a/humanitix/actions/orders.py
+++ b/humanitix/actions/orders.py
@@ -55,6 +55,7 @@ class GetOrdersAction(ActionHandler):
         url = build_url(f"events/{event_id}/orders", params)
 
         response = await context.fetch(url, method="GET", headers=get_api_headers(context))
+        response = response.data
 
         if error := build_error_result(response):
             return error

--- a/humanitix/actions/tags.py
+++ b/humanitix/actions/tags.py
@@ -41,6 +41,7 @@ class GetTagsAction(ActionHandler):
         url = build_url("tags", params)
 
         response = await context.fetch(url, method="GET", headers=get_api_headers(context))
+        response = response.data
 
         if error := build_error_result(response):
             return error

--- a/humanitix/actions/tickets.py
+++ b/humanitix/actions/tickets.py
@@ -58,6 +58,7 @@ class GetTicketsAction(ActionHandler):
         url = build_url(f"events/{event_id}/tickets", params)
 
         response = await context.fetch(url, method="GET", headers=get_api_headers(context))
+        response = response.data
 
         if error := build_error_result(response):
             return error

--- a/humanitix/helpers.py
+++ b/humanitix/helpers.py
@@ -42,7 +42,8 @@ async def fetch_single_resource(
     context: ExecutionContext, path: str, params: Dict[str, Any], result_key: str
 ) -> ActionResult:
     url = build_url(path, params or None)
-    response = await context.fetch(url, method="GET", headers=get_api_headers(context))
+    resp = await context.fetch(url, method="GET", headers=get_api_headers(context))
+    response = resp.data
     if error := build_error_result(response):
         return error
     return ActionResult(data={"result": True, result_key: response})

--- a/humanitix/requirements.txt
+++ b/humanitix/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/instagram/actions/account.py
+++ b/instagram/actions/account.py
@@ -37,14 +37,14 @@ class GetAccountAction(ActionHandler):
 
         return ActionResult(
             data={
-                "id": response.get("id", ""),
-                "username": response.get("username", ""),
-                "name": response.get("name", ""),
-                "biography": response.get("biography", ""),
-                "followers_count": response.get("followers_count", 0),
-                "following_count": response.get("follows_count", 0),
-                "media_count": response.get("media_count", 0),
-                "profile_picture_url": response.get("profile_picture_url", ""),
-                "website": response.get("website", ""),
+                "id": response.data.get("id", ""),
+                "username": response.data.get("username", ""),
+                "name": response.data.get("name", ""),
+                "biography": response.data.get("biography", ""),
+                "followers_count": response.data.get("followers_count", 0),
+                "following_count": response.data.get("follows_count", 0),
+                "media_count": response.data.get("media_count", 0),
+                "profile_picture_url": response.data.get("profile_picture_url", ""),
+                "website": response.data.get("website", ""),
             }
         )

--- a/instagram/actions/comments.py
+++ b/instagram/actions/comments.py
@@ -61,9 +61,9 @@ class GetCommentsAction(ActionHandler):
 
         response = await context.fetch(f"{INSTAGRAM_GRAPH_API_BASE}/{media_id}/comments", method="GET", params=params)
 
-        comments = [_build_comment_response(c) for c in response.get("data", [])]
+        comments = [_build_comment_response(c) for c in response.data.get("data", [])]
 
-        paging = response.get("paging", {})
+        paging = response.data.get("paging", {})
         cursors = paging.get("cursors", {})
         next_cursor = cursors.get("after") if paging.get("next") else None
 
@@ -93,7 +93,7 @@ class ManageCommentAction(ActionHandler):
             response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{comment_id}/replies", method="POST", data={"message": message}
             )
-            return ActionResult(data={"success": True, "action_taken": "reply", "reply_id": response.get("id", "")})
+            return ActionResult(data={"success": True, "action_taken": "reply", "reply_id": response.data.get("id", "")})
 
         elif action in ("hide", "unhide"):
             hide_value = action == "hide"

--- a/instagram/actions/insights.py
+++ b/instagram/actions/insights.py
@@ -81,7 +81,7 @@ class GetInsightsAction(ActionHandler):
             media_response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{target_id}", method="GET", params={"fields": "media_product_type"}
             )
-            media_product_type = media_response.get("media_product_type", "FEED")
+            media_product_type = media_response.data.get("media_product_type", "FEED")
 
             if media_product_type == "REELS":
                 metrics = custom_metrics or self.DEFAULT_MEDIA_METRICS_REELS
@@ -96,7 +96,7 @@ class GetInsightsAction(ActionHandler):
         response = await context.fetch(endpoint, method="GET", params=params)
 
         metrics_data = {}
-        for item in response.get("data", []):
+        for item in response.data.get("data", []):
             metric_name = item.get("name", "")
 
             total_value = item.get("total_value", {})

--- a/instagram/actions/media.py
+++ b/instagram/actions/media.py
@@ -62,7 +62,7 @@ class GetPostsAction(ActionHandler):
             response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{media_id}", method="GET", params={"fields": fields}
             )
-            media_list = [_build_media_response(response)]
+            media_list = [_build_media_response(response.data)]
             next_cursor = None
         else:
             account_id = await get_instagram_account_id(context)
@@ -73,9 +73,9 @@ class GetPostsAction(ActionHandler):
             response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="GET", params=params
             )
-            media_list = [_build_media_response(m) for m in response.get("data", [])]
+            media_list = [_build_media_response(m) for m in response.data.get("data", [])]
 
-            paging = response.get("paging", {})
+            paging = response.data.get("paging", {})
             cursors = paging.get("cursors", {})
             next_cursor = cursors.get("after") if paging.get("next") else None
 
@@ -127,7 +127,7 @@ class CreatePostAction(ActionHandler):
                 child_response = await context.fetch(
                     f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="POST", data=child_data
                 )
-                child_container_ids.append(child_response.get("id"))
+                child_container_ids.append(child_response.data.get("id"))
 
             for container_id in child_container_ids:
                 await wait_for_media_container(context, container_id)
@@ -137,7 +137,7 @@ class CreatePostAction(ActionHandler):
                 method="POST",
                 data={"media_type": "CAROUSEL", "caption": caption, "children": ",".join(child_container_ids)},
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         elif media_type == "REELS":
             if not media_url:
@@ -148,7 +148,7 @@ class CreatePostAction(ActionHandler):
                 method="POST",
                 data={"media_type": "REELS", "video_url": media_url, "caption": caption},
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         elif media_type == "VIDEO":
             if not media_url:
@@ -159,7 +159,7 @@ class CreatePostAction(ActionHandler):
                 method="POST",
                 data={"media_type": "VIDEO", "video_url": media_url, "caption": caption},
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         else:
             if not media_url:
@@ -172,7 +172,7 @@ class CreatePostAction(ActionHandler):
             container_response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="POST", data=data
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         await wait_for_media_container(context, container_id)
 
@@ -180,13 +180,13 @@ class CreatePostAction(ActionHandler):
             f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media_publish", method="POST", data={"creation_id": container_id}
         )
 
-        media_id = publish_response.get("id", "")
+        media_id = publish_response.data.get("id", "")
 
         media_details = await context.fetch(
             f"{INSTAGRAM_GRAPH_API_BASE}/{media_id}", method="GET", params={"fields": "permalink"}
         )
 
-        return ActionResult(data={"media_id": media_id, "permalink": media_details.get("permalink", "")})
+        return ActionResult(data={"media_id": media_id, "permalink": media_details.data.get("permalink", "")})
 
 
 @instagram.action("create_story")
@@ -222,4 +222,4 @@ class CreateStoryAction(ActionHandler):
             f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media_publish", method="POST", data={"creation_id": container_id}
         )
 
-        return ActionResult(data={"media_id": publish_response.get("id", "")})
+        return ActionResult(data={"media_id": publish_response.data.get("id", "")})

--- a/instagram/helpers.py
+++ b/instagram/helpers.py
@@ -28,7 +28,7 @@ async def get_instagram_account_id(context: ExecutionContext) -> str:
     """
     response = await context.fetch(f"{INSTAGRAM_GRAPH_API_BASE}/me", method="GET", params={"fields": "id,username"})
 
-    account_id = response.get("id")
+    account_id = response.data.get("id")
     if not account_id:
         raise Exception(
             "Failed to retrieve Instagram account ID. "
@@ -66,15 +66,15 @@ async def wait_for_media_container(
             f"{INSTAGRAM_GRAPH_API_BASE}/{container_id}", method="GET", params={"fields": "status_code,status"}
         )
 
-        status_code = response.get("status_code", "").upper()
+        status_code = response.data.get("status_code", "").upper()
 
         if status_code == "FINISHED":
-            return response
+            return response.data
         elif status_code == "ERROR":
-            error_msg = response.get("status", "Unknown error during media processing")
+            error_msg = response.data.get("status", "Unknown error during media processing")
             raise Exception(f"Media container processing failed: {error_msg}")
         elif status_code in ("EXPIRED", "FAILED"):
-            raise Exception(f"Media container {status_code.lower()}: {response.get('status', 'Unknown error')}")
+            raise Exception(f"Media container {status_code.lower()}: {response.data.get('status', 'Unknown error')}")
 
         await asyncio.sleep(delay)
 

--- a/instagram/instagram.py
+++ b/instagram/instagram.py
@@ -43,13 +43,13 @@ class InstagramConnectedAccountHandler(ConnectedAccountHandler):
 
         response = await context.fetch(f"{INSTAGRAM_GRAPH_API_BASE}/me", method="GET", params={"fields": fields})
 
-        name = response.get("name", "")
+        name = response.data.get("name", "")
         name_parts = name.split(maxsplit=1) if name else []
 
         return ConnectedAccountInfo(
-            username=response.get("username"),
+            username=response.data.get("username"),
             first_name=name_parts[0] if len(name_parts) > 0 else None,
             last_name=name_parts[1] if len(name_parts) > 1 else None,
-            avatar_url=response.get("profile_picture_url"),
-            user_id=response.get("id"),
+            avatar_url=response.data.get("profile_picture_url"),
+            user_id=response.data.get("id"),
         )

--- a/instagram/requirements.txt
+++ b/instagram/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/jira/jira.py
+++ b/jira/jira.py
@@ -51,7 +51,8 @@ async def get_cloud_id(access_token: str, context: ExecutionContext) -> str:
         "Accept": "application/json",
     }
     try:
-        resources = await context.fetch(ACCESSIBLE_RESOURCES_URL, headers=headers)
+        resources_resp = await context.fetch(ACCESSIBLE_RESOURCES_URL, headers=headers)
+        resources = resources_resp.data
     except Exception as e:
         raise Exception(f"Failed to discover Jira Cloud ID: {e}")
 
@@ -168,7 +169,7 @@ async def jira_request(
         body = await context.fetch(url, method=method, params=params, data=raw_body, headers=headers)
     else:
         body = await context.fetch(url, method=method, params=params, json=payload, headers=headers)
-    return body
+    return body.data
 
 
 # ---- Action Handlers ----

--- a/jira/requirements.txt
+++ b/jira/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/linkedin-ads/linkedin_ads.py
+++ b/linkedin-ads/linkedin_ads.py
@@ -77,7 +77,7 @@ async def make_request(
         else:
             return {"success": False, "error": f"Unsupported HTTP method: {method}"}
 
-        return {"success": True, "data": response}
+        return {"success": True, "data": response.data}
     except Exception as e:
         error_message = str(e)
         error_details = {"raw_error": error_message}

--- a/linkedin-ads/requirements.txt
+++ b/linkedin-ads/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -48,8 +48,8 @@ async def get_current_user_urn(context: ExecutionContext) -> str:
     user_info_url = "https://api.linkedin.com/v2/userinfo"
     user_response = await context.fetch(user_info_url, method="GET")
 
-    if isinstance(user_response, dict) and user_response.get("sub"):
-        return f"urn:li:person:{user_response.get('sub')}"
+    if isinstance(user_response.data, dict) and user_response.data.get("sub"):
+        return f"urn:li:person:{user_response.data.get('sub')}"
     raise ValueError("Could not determine current user. Please ensure proper authentication.")
 
 
@@ -104,11 +104,11 @@ async def initialize_image_upload(context: ExecutionContext, owner_urn: str) -> 
 
     response = await context.fetch(url, method="POST", json=payload, headers=get_linkedin_headers())
 
-    if isinstance(response, dict) and "value" in response:
-        value = response["value"]
+    if isinstance(response.data, dict) and "value" in response.data:
+        value = response.data["value"]
         return {"upload_url": value.get("uploadUrl"), "image_urn": value.get("image")}
 
-    raise ValueError(f"Failed to initialize image upload: {response}")
+    raise ValueError(f"Failed to initialize image upload: {response.data}")
 
 
 async def upload_image_binary(context: ExecutionContext, upload_url: str, image_data: bytes, content_type: str) -> None:
@@ -211,15 +211,15 @@ class UserInfoActionHandler(ActionHandler):
 
         response = await context.fetch(url, method="GET")
 
-        if isinstance(response, dict) and response.get("sub"):
+        if isinstance(response.data, dict) and response.data.get("sub"):
             return ActionResult(
                 data={
                     "result": "User information retrieved successfully.",
-                    "user_info": response,
+                    "user_info": response.data,
                 }
             )
         else:
-            error_details = response.get("error", "Unknown error") if isinstance(response, dict) else "Unknown error"
+            error_details = response.data.get("error", "Unknown error") if isinstance(response.data, dict) else "Unknown error"
             return ActionResult(
                 data={
                     "result": "Failed to retrieve user information.",
@@ -582,7 +582,7 @@ class GetPostActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=get_linkedin_headers())
 
-            return ActionResult(data={"result": "Post retrieved successfully.", "post": response})
+            return ActionResult(data={"result": "Post retrieved successfully.", "post": response.data})
         except Exception as e:
             error_message = str(e)
             error_details = getattr(e, "response_data", str(e))
@@ -629,8 +629,8 @@ class GetPostsActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=headers)
 
-            posts = response.get("elements", []) if isinstance(response, dict) else []
-            paging = response.get("paging") if isinstance(response, dict) else None
+            posts = response.data.get("elements", []) if isinstance(response.data, dict) else []
+            paging = response.data.get("paging") if isinstance(response.data, dict) else None
 
             return ActionResult(
                 data={
@@ -728,8 +728,8 @@ class GetCommentsActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=get_linkedin_headers())
 
-            comments = response.get("elements", []) if isinstance(response, dict) else []
-            paging = response.get("paging") if isinstance(response, dict) else None
+            comments = response.data.get("elements", []) if isinstance(response.data, dict) else []
+            paging = response.data.get("paging") if isinstance(response.data, dict) else None
 
             return ActionResult(
                 data={
@@ -783,13 +783,13 @@ class CreateCommentActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="POST", json=payload, headers=get_linkedin_headers())
 
-            comment_id = response.get("id") if isinstance(response, dict) else None
+            comment_id = response.data.get("id") if isinstance(response.data, dict) else None
 
             return ActionResult(
                 data={
                     "result": "Comment created successfully.",
                     "comment_id": comment_id,
-                    "comment": response,
+                    "comment": response.data,
                 }
             )
         except Exception as e:
@@ -871,8 +871,8 @@ class GetReactionsActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=get_linkedin_headers())
 
-            reactions = response.get("elements", []) if isinstance(response, dict) else []
-            paging = response.get("paging") if isinstance(response, dict) else None
+            reactions = response.data.get("elements", []) if isinstance(response.data, dict) else []
+            paging = response.data.get("paging") if isinstance(response.data, dict) else None
 
             return ActionResult(
                 data={
@@ -925,7 +925,7 @@ class CreateReactionActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="POST", json=payload, headers=get_linkedin_headers())
 
-            return ActionResult(data={"result": "Reaction created successfully.", "reaction": response})
+            return ActionResult(data={"result": "Reaction created successfully.", "reaction": response.data})
         except Exception as e:
             error_message = str(e)
             error_details = getattr(e, "response_data", str(e))

--- a/linkedin/requirements.txt
+++ b/linkedin/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/mailchimp/mailchimp.py
+++ b/mailchimp/mailchimp.py
@@ -55,7 +55,7 @@ class MailchimpRateLimiter:
         for attempt in range(self.max_retries + 1):
             try:
                 response = await context.fetch(url, **kwargs)
-                return response
+                return response.data
 
             except Exception as e:
                 last_error = e

--- a/mailchimp/requirements.txt
+++ b/mailchimp/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/microsoft-excel/microsoft_excel.py
+++ b/microsoft-excel/microsoft_excel.py
@@ -55,7 +55,7 @@ class ListWorkbooks(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params)
 
-            items = response.get("value", [])
+            items = response.data.get("value", [])
 
             workbooks = []
             for item in items:
@@ -73,7 +73,7 @@ class ListWorkbooks(ActionHandler):
                     )
 
             result_data = {"workbooks": workbooks, "result": True}
-            next_link = response.get("@odata.nextLink")
+            next_link = response.data.get("@odata.nextLink")
             if next_link:
                 result_data["next_page_token"] = next_link
 
@@ -105,7 +105,7 @@ class GetWorkbook(ActionHandler):
             worksheets = []
             try:
                 ws_data = await context.fetch(worksheets_url, method="GET")
-                for ws in ws_data.get("value", []):
+                for ws in ws_data.data.get("value", []):
                     worksheets.append(
                         {
                             "id": ws.get("id"),
@@ -123,7 +123,7 @@ class GetWorkbook(ActionHandler):
             tables = []
             try:
                 tables_data = await context.fetch(tables_url, method="GET")
-                for table in tables_data.get("value", []):
+                for table in tables_data.data.get("value", []):
                     tables.append(
                         {
                             "id": table.get("id"),
@@ -142,7 +142,7 @@ class GetWorkbook(ActionHandler):
             named_ranges = []
             try:
                 names_data = await context.fetch(names_url, method="GET")
-                for name in names_data.get("value", []):
+                for name in names_data.data.get("value", []):
                     named_ranges.append(
                         {
                             "name": name.get("name"),
@@ -157,10 +157,10 @@ class GetWorkbook(ActionHandler):
             return ActionResult(
                 data={
                     "workbook": {
-                        "id": file_data.get("id"),
-                        "name": file_data.get("name"),
-                        "webUrl": file_data.get("webUrl"),
-                        "lastModifiedDateTime": file_data.get("lastModifiedDateTime"),
+                        "id": file_data.data.get("id"),
+                        "name": file_data.data.get("name"),
+                        "webUrl": file_data.data.get("webUrl"),
+                        "lastModifiedDateTime": file_data.data.get("lastModifiedDateTime"),
                     },
                     "worksheets": worksheets,
                     "tables": tables,
@@ -190,7 +190,7 @@ class ListWorksheets(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             worksheets = []
-            for ws in response.get("value", []):
+            for ws in response.data.get("value", []):
                 worksheets.append(
                     {
                         "id": ws.get("id"),
@@ -230,16 +230,16 @@ class ReadRange(ActionHandler):
             )
             response = await context.fetch(url, method="GET")
 
-            values = response.get("values", [])
-            formulas = response.get("formulas", []) if value_render_option == "FORMULA" else []
-            number_format = response.get("numberFormat", [])
+            values = response.data.get("values", [])
+            formulas = response.data.get("formulas", []) if value_render_option == "FORMULA" else []
+            number_format = response.data.get("numberFormat", [])
 
             row_count = len(values)
             column_count = len(values[0]) if values else 0
 
             return ActionResult(
                 data={
-                    "range": response.get("address", range_address),
+                    "range": response.data.get("address", range_address),
                     "values": values,
                     "formulas": formulas,
                     "number_format": number_format,
@@ -284,7 +284,7 @@ class WriteRange(ActionHandler):
 
             return ActionResult(
                 data={
-                    "updated_range": response.get("address", range_address),
+                    "updated_range": response.data.get("address", range_address),
                     "updated_rows": row_count,
                     "updated_columns": column_count,
                     "updated_cells": row_count * column_count,
@@ -319,7 +319,7 @@ class ListTables(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             tables = []
-            for table in response.get("value", []):
+            for table in response.data.get("value", []):
                 tables.append(
                     {
                         "id": table.get("id"),
@@ -359,7 +359,7 @@ class GetTableData(ActionHandler):
             # Get headers
             header_url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/tables/{encoded_table}/headerRowRange"
             header_data = await context.fetch(header_url, method="GET")
-            all_headers = header_data.get("values", [[]])[0]
+            all_headers = header_data.data.get("values", [[]])[0]
 
             # Validate select_columns if specified
             if select_columns:
@@ -376,7 +376,7 @@ class GetTableData(ActionHandler):
             # Get rows
             rows_url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/tables/{encoded_table}/dataBodyRange"
             rows_data = await context.fetch(rows_url, method="GET")
-            all_rows = rows_data.get("values", [])
+            all_rows = rows_data.data.get("values", [])
 
             # Check max_rows safety limit
             if max_rows and len(all_rows) > max_rows:
@@ -457,7 +457,7 @@ class AddTableRow(ActionHandler):
             table_range = ""
             try:
                 range_data = await context.fetch(range_url, method="GET")
-                table_range = range_data.get("address", "")
+                table_range = range_data.data.get("address", "")
             except Exception:  # nosec B110
                 # API error handled - rows were added, range info is optional
                 pass
@@ -500,9 +500,9 @@ class GetUsedRange(ActionHandler):
                 url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/worksheets/{encoded_ws}/usedRange"
 
             response = await context.fetch(url, method="GET")
-            values = response.get("values", [])
-            row_count = response.get("rowCount", len(values))
-            column_count = response.get("columnCount", len(values[0]) if values else 0)
+            values = response.data.get("values", [])
+            row_count = response.data.get("rowCount", len(values))
+            column_count = response.data.get("columnCount", len(values[0]) if values else 0)
             cell_count = row_count * column_count
 
             # Check max_cells safety limit
@@ -521,7 +521,7 @@ class GetUsedRange(ActionHandler):
 
             return ActionResult(
                 data={
-                    "range": response.get("address", ""),
+                    "range": response.data.get("address", ""),
                     "row_count": row_count,
                     "column_count": column_count,
                     "values": values,
@@ -555,10 +555,10 @@ class CreateWorksheet(ActionHandler):
             return ActionResult(
                 data={
                     "worksheet": {
-                        "id": response.get("id"),
-                        "name": response.get("name"),
-                        "position": response.get("position"),
-                        "visibility": response.get("visibility"),
+                        "id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "position": response.data.get("position"),
+                        "visibility": response.data.get("visibility"),
                     },
                     "result": True,
                 },
@@ -617,9 +617,9 @@ class CreateTable(ActionHandler):
             return ActionResult(
                 data={
                     "table": {
-                        "id": response.get("id"),
-                        "name": response.get("name"),
-                        "showHeaders": response.get("showHeaders"),
+                        "id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "showHeaders": response.data.get("showHeaders"),
                     },
                     "result": True,
                 },
@@ -654,7 +654,7 @@ class UpdateTableRow(ActionHandler):
             body = {"values": [values]}
             response = await context.fetch(url, method="PATCH", json=body)
 
-            return ActionResult(data={"updated_row": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"updated_row": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -751,7 +751,7 @@ class ApplyFilter(ActionHandler):
             columns_url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/tables/{encoded_table}/columns"
             columns_data = await context.fetch(columns_url, method="GET")
 
-            columns = columns_data.get("value", [])
+            columns = columns_data.data.get("value", [])
             if column_index < 0 or column_index >= len(columns):
                 return ActionResult(
                     data={

--- a/microsoft-excel/requirements.txt
+++ b/microsoft-excel/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/microsoft-planner/microsoft_planner.py
+++ b/microsoft-planner/microsoft_planner.py
@@ -34,7 +34,7 @@ async def get_etag(context: ExecutionContext, resource_url: str) -> Optional[str
     try:
         response = await context.fetch(resource_url, method="GET")
         # ETag is returned in the response with @odata.etag key
-        return response.get("@odata.etag")
+        return response.data.get("@odata.etag")
     except Exception:
         return None
 
@@ -63,7 +63,7 @@ class ListGroupsAction(ActionHandler):
                 params=params,
             )
 
-            groups = response.get("value", [])
+            groups = response.data.get("value", [])
             return ActionResult(data={"groups": groups, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -86,7 +86,7 @@ class GetUserByEmailAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/users", method="GET", params=params)
 
-            users = response.get("value", [])
+            users = response.data.get("value", [])
 
             if users:
                 user = users[0]
@@ -139,7 +139,7 @@ class SearchUsersAction(ActionHandler):
                 headers=headers,
             )
 
-            users = response.get("value", [])
+            users = response.data.get("value", [])
 
             # Format users for easier consumption
             formatted_users = [
@@ -168,10 +168,10 @@ class GetCurrentUserAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "user": response,
-                    "user_id": response.get("id"),
-                    "display_name": response.get("displayName"),
-                    "email": response.get("mail") or response.get("userPrincipalName"),
+                    "user": response.data,
+                    "user_id": response.data.get("id"),
+                    "display_name": response.data.get("displayName"),
+                    "email": response.data.get("mail") or response.data.get("userPrincipalName"),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -191,7 +191,7 @@ class ListUserTasksAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/users/{user_id}/planner/tasks", method="GET")
 
-            tasks = response.get("value", [])
+            tasks = response.data.get("value", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -208,7 +208,7 @@ class ListUserPlansAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/users/{user_id}/planner/plans", method="GET")
 
-            plans = response.get("value", [])
+            plans = response.data.get("value", [])
             return ActionResult(data={"plans": plans, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -228,7 +228,7 @@ class ListPlansAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/groups/{group_id}/planner/plans", method="GET")
 
-            plans = response.get("value", [])
+            plans = response.data.get("value", [])
             return ActionResult(data={"plans": plans, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -245,7 +245,7 @@ class GetPlanAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans/{plan_id}", method="GET")
 
-            return ActionResult(data={"plan": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"plan": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"plan": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -281,7 +281,7 @@ class CreatePlanAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans", method="POST", json=body)
 
-            return ActionResult(data={"plan": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"plan": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"plan": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -322,7 +322,7 @@ class UpdatePlanAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"plan": response if response else {}, "result": True},
+                data={"plan": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -375,7 +375,7 @@ class GetPlanDetailsAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans/{plan_id}/details", method="GET")
 
-            return ActionResult(data={"plan_details": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"plan_details": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -428,7 +428,7 @@ class UpdatePlanDetailsAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"plan_details": response if response else {}, "result": True},
+                data={"plan_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -455,7 +455,7 @@ class ListBucketsAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets", method="GET", params=params)
 
-            buckets = response.get("value", [])
+            buckets = response.data.get("value", [])
             return ActionResult(data={"buckets": buckets, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -472,7 +472,7 @@ class GetBucketAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets/{bucket_id}", method="GET")
 
-            return ActionResult(data={"bucket": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bucket": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bucket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -493,7 +493,7 @@ class CreateBucketAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets", method="POST", json=body)
 
-            return ActionResult(data={"bucket": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bucket": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bucket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -534,7 +534,7 @@ class UpdateBucketAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"bucket": response if response else {}, "result": True},
+                data={"bucket": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -584,7 +584,7 @@ class ListBucketTasksAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets/{bucket_id}/tasks", method="GET")
 
-            tasks = response.get("value", [])
+            tasks = response.data.get("value", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -604,7 +604,7 @@ class ListTasksAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans/{plan_id}/tasks", method="GET")
 
-            tasks = response.get("value", [])
+            tasks = response.data.get("value", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -621,7 +621,7 @@ class GetTaskAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}", method="GET")
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -677,7 +677,7 @@ class CreateTaskAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks", method="POST", json=body)
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -775,7 +775,7 @@ class UpdateTaskAction(ActionHandler):
 
             # Ensure we always return an object for task, even if response is None
             return ActionResult(
-                data={"task": response if response else {}, "result": True},
+                data={"task": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -828,7 +828,7 @@ class GetTaskDetailsAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
-            return ActionResult(data={"task_details": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task_details": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -887,7 +887,7 @@ class UpdateTaskDetailsAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"task_details": response if response else {}, "result": True},
+                data={"task_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -913,7 +913,7 @@ class AddChecklistItemAction(ActionHandler):
             current_details = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
             # Get current ETag (required for updates)
-            etag = current_details.get("@odata.etag")
+            etag = current_details.data.get("@odata.etag")
             if not etag:
                 return ActionResult(
                     data={
@@ -924,7 +924,7 @@ class AddChecklistItemAction(ActionHandler):
                 )
 
             # Get existing checklist or initialize empty dict
-            existing_checklist = current_details.get("checklist", {})
+            existing_checklist = current_details.data.get("checklist", {})
 
             # Clean existing checklist items by removing read-only fields
             # Don't include orderHint for existing items since we're not reordering them
@@ -961,7 +961,7 @@ class AddChecklistItemAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "task_details": response if response else {},
+                    "task_details": response.data if response else {},
                     "item_id": item_id,
                     "result": True,
                 },
@@ -985,7 +985,7 @@ class UpdateChecklistItemAction(ActionHandler):
             current_details = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
             # Get current ETag (required for updates)
-            etag = current_details.get("@odata.etag")
+            etag = current_details.data.get("@odata.etag")
             if not etag:
                 return ActionResult(
                     data={
@@ -996,7 +996,7 @@ class UpdateChecklistItemAction(ActionHandler):
                 )
 
             # Get existing checklist
-            existing_checklist = current_details.get("checklist", {})
+            existing_checklist = current_details.data.get("checklist", {})
 
             if item_id not in existing_checklist:
                 return ActionResult(
@@ -1036,7 +1036,7 @@ class UpdateChecklistItemAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"task_details": response if response else {}, "result": True},
+                data={"task_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1057,7 +1057,7 @@ class RemoveChecklistItemAction(ActionHandler):
             current_details = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
             # Get current ETag (required for updates)
-            etag = current_details.get("@odata.etag")
+            etag = current_details.data.get("@odata.etag")
             if not etag:
                 return ActionResult(
                     data={
@@ -1068,7 +1068,7 @@ class RemoveChecklistItemAction(ActionHandler):
                 )
 
             # Get existing checklist
-            existing_checklist = current_details.get("checklist", {})
+            existing_checklist = current_details.data.get("checklist", {})
 
             if item_id not in existing_checklist:
                 return ActionResult(
@@ -1103,7 +1103,7 @@ class RemoveChecklistItemAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"task_details": response if response else {}, "result": True},
+                data={"task_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1127,7 +1127,7 @@ class GetTaskAssignedToBoardFormatAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"board_format": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board_format": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -1181,7 +1181,7 @@ class UpdateTaskAssignedToBoardFormatAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"board_format": response if response else {}, "result": True},
+                data={"board_format": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1205,7 +1205,7 @@ class GetTaskBucketBoardFormatAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"board_format": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board_format": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -1255,7 +1255,7 @@ class UpdateTaskBucketBoardFormatAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"board_format": response if response else {}, "result": True},
+                data={"board_format": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1279,7 +1279,7 @@ class GetTaskProgressBoardFormatAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"board_format": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board_format": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -1329,7 +1329,7 @@ class UpdateTaskProgressBoardFormatAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"board_format": response if response else {}, "result": True},
+                data={"board_format": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 

--- a/microsoft-planner/requirements.txt
+++ b/microsoft-planner/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/microsoft-powerpoint/microsoft_powerpoint.py
+++ b/microsoft-powerpoint/microsoft_powerpoint.py
@@ -31,9 +31,7 @@ async def download_file_content(context: ExecutionContext, item_id: str) -> byte
         method="GET",
         raw_response=True,
     )
-    return response
-
-
+    return response.data
 async def overwrite_file_content(context: ExecutionContext, item_id: str, content: bytes) -> Dict[str, Any]:
     """Overwrite file content by item ID (simpler and more reliable than path-based upload)."""
     if len(content) > MAX_SIMPLE_UPLOAD_SIZE:
@@ -48,9 +46,7 @@ async def overwrite_file_content(context: ExecutionContext, item_id: str, conten
         headers={"Content-Type": "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
         data=content,
     )
-    return response
-
-
+    return response.data
 async def upload_file_content(
     context: ExecutionContext, folder_path: str, file_name: str, content: bytes
 ) -> Dict[str, Any]:
@@ -72,9 +68,7 @@ async def upload_file_content(
         headers={"Content-Type": "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
         data=content,
     )
-    return response
-
-
+    return response.data
 def create_blank_pptx() -> bytes:
     try:
         from pptx import Presentation
@@ -121,7 +115,7 @@ class ListPresentationsAction(ActionHandler):
             else:
                 response = await context.fetch(base_url, method="GET", params=params)
 
-            items = response.get("value", [])
+            items = response.data.get("value", [])
             presentations = [
                 {
                     "id": item.get("id"),
@@ -133,7 +127,7 @@ class ListPresentationsAction(ActionHandler):
                 for item in items
             ]
 
-            next_page_token = response.get("@odata.nextLink")
+            next_page_token = response.data.get("@odata.nextLink")
 
             return ActionResult(
                 data={
@@ -172,15 +166,15 @@ class GetPresentationAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response.get("id"),
-                    "name": response.get("name"),
-                    "size": response.get("size"),
-                    "webUrl": response.get("webUrl"),
-                    "createdDateTime": response.get("createdDateTime"),
-                    "lastModifiedDateTime": response.get("lastModifiedDateTime"),
-                    "createdBy": response.get("createdBy"),
-                    "lastModifiedBy": response.get("lastModifiedBy"),
-                    "parentReference": response.get("parentReference"),
+                    "id": response.data.get("id"),
+                    "name": response.data.get("name"),
+                    "size": response.data.get("size"),
+                    "webUrl": response.data.get("webUrl"),
+                    "createdDateTime": response.data.get("createdDateTime"),
+                    "lastModifiedDateTime": response.data.get("lastModifiedDateTime"),
+                    "createdBy": response.data.get("createdBy"),
+                    "lastModifiedBy": response.data.get("lastModifiedBy"),
+                    "parentReference": response.data.get("parentReference"),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -214,7 +208,7 @@ class GetSlidesAction(ActionHandler):
                         f"{GRAPH_API_BASE_URL}/me/drive/items/{presentation_id}/thumbnails",
                         method="GET",
                     )
-                    thumbnail_sets = thumbnails_response.get("value", [])
+                    thumbnail_sets = thumbnails_response.data.get("value", [])
                     if thumbnail_sets:
                         size_data = thumbnail_sets[0].get(thumbnail_size, thumbnail_sets[0].get("medium", {}))
                         thumbnail_data = {
@@ -305,7 +299,7 @@ class GetSlideAction(ActionHandler):
                         f"{GRAPH_API_BASE_URL}/me/drive/items/{presentation_id}/thumbnails",
                         method="GET",
                     )
-                    thumbnail_sets = thumbnails_response.get("value", [])
+                    thumbnail_sets = thumbnails_response.data.get("value", [])
                     if thumbnail_sets:
                         size_data = thumbnail_sets[0].get(thumbnail_size, thumbnail_sets[0].get("large", {}))
                         result_data["thumbnailUrl"] = size_data.get("url")
@@ -361,13 +355,13 @@ class CreatePresentationAction(ActionHandler):
                     json=copy_body,
                 )
 
-                if response.get("id"):
+                if response.data.get("id"):
                     return ActionResult(
                         data={
-                            "id": response.get("id"),
-                            "name": response.get("name"),
-                            "webUrl": response.get("webUrl"),
-                            "createdDateTime": response.get("createdDateTime"),
+                            "id": response.data.get("id"),
+                            "name": response.data.get("name"),
+                            "webUrl": response.data.get("webUrl"),
+                            "createdDateTime": response.data.get("createdDateTime"),
                             "result": True,
                         },
                         cost_usd=0.0,
@@ -387,10 +381,10 @@ class CreatePresentationAction(ActionHandler):
 
                 return ActionResult(
                     data={
-                        "id": response.get("id"),
-                        "name": response.get("name"),
-                        "webUrl": response.get("webUrl"),
-                        "createdDateTime": response.get("createdDateTime"),
+                        "id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "webUrl": response.data.get("webUrl"),
+                        "createdDateTime": response.data.get("createdDateTime"),
                         "result": True,
                     },
                     cost_usd=0.0,
@@ -671,8 +665,8 @@ class ExportPdfAction(ActionHandler):
                 params={"$select": "name,parentReference"},
             )
 
-            original_name = file_info.get("name", "presentation.pptx")
-            parent_path = file_info.get("parentReference", {}).get("path", "/drive/root:").replace("/drive/root:", "")
+            original_name = file_info.data.get("name", "presentation.pptx")
+            parent_path = file_info.data.get("parentReference", {}).get("path", "/drive/root:").replace("/drive/root:", "")
 
             if output_name:
                 pdf_name = output_name if output_name.endswith(".pdf") else f"{output_name}.pdf"
@@ -700,17 +694,17 @@ class ExportPdfAction(ActionHandler):
             )
 
             download_response = await context.fetch(
-                f"{GRAPH_API_BASE_URL}/me/drive/items/{response.get('id')}",
+                f"{GRAPH_API_BASE_URL}/me/drive/items/{response.data.get('id')}",
                 method="GET",
             )
 
             return ActionResult(
                 data={
-                    "pdf_id": response.get("id"),
-                    "pdf_name": response.get("name"),
-                    "pdf_webUrl": response.get("webUrl"),
-                    "pdf_size": response.get("size"),
-                    "download_url": download_response.get("@microsoft.graph.downloadUrl"),
+                    "pdf_id": response.data.get("id"),
+                    "pdf_name": response.data.get("name"),
+                    "pdf_webUrl": response.data.get("webUrl"),
+                    "pdf_size": response.data.get("size"),
+                    "download_url": download_response.data.get("@microsoft.graph.downloadUrl"),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -761,7 +755,7 @@ class GetSlideImageAction(ActionHandler):
                 method="GET",
             )
 
-            thumbnail_sets = thumbnails_response.get("value", [])
+            thumbnail_sets = thumbnails_response.data.get("value", [])
 
             if not thumbnail_sets:
                 return ActionResult(

--- a/microsoft-powerpoint/requirements.txt
+++ b/microsoft-powerpoint/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 python-pptx>=0.6.21

--- a/microsoft-word/microsoft_word.py
+++ b/microsoft-word/microsoft_word.py
@@ -350,7 +350,7 @@ class ListDocuments(ActionHandler):
             response = await context.fetch(url, method="GET", params=params)
 
             documents = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 if item.get("name", "").lower().endswith(".docx"):
                     documents.append(
                         {
@@ -363,7 +363,7 @@ class ListDocuments(ActionHandler):
                         }
                     )
 
-            next_link = response.get("@odata.nextLink")
+            next_link = response.data.get("@odata.nextLink")
 
             return ActionResult(
                 data={"documents": documents, "next_page_token": next_link if next_link else None, "result": True},
@@ -392,7 +392,7 @@ class GetDocument(ActionHandler):
 
             document = await context.fetch(url, method="GET", params=params)
 
-            return ActionResult(data={"document": document, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"document": document.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
@@ -420,12 +420,12 @@ class GetContent(ActionHandler):
                 response = await context.fetch(content_url, method="GET")
                 metadata = None
 
-            if not isinstance(response, bytes):
+            if not isinstance(response.data, bytes):
                 return ActionResult(
                     data={"result": False, "error": "Failed to download document content"}, cost_usd=0.0
                 )
 
-            docx_bytes = response
+            docx_bytes = response.data
 
             parsed = parse_docx_content(docx_bytes)
 
@@ -444,7 +444,7 @@ class GetContent(ActionHandler):
             }
 
             if metadata is not None:
-                result_data["metadata"] = metadata
+                result_data["metadata"] = metadata.data
 
             result_data["result"] = True
             return ActionResult(data=result_data, cost_usd=0.0)
@@ -474,8 +474,8 @@ class CreateDocument(ActionHandler):
                     folder_url = f"{GRAPH_API_BASE}/me/drive/root:/{encoded_path}"
                     folder_info = await context.fetch(folder_url, method="GET")
                     copy_body["parentReference"] = {
-                        "driveId": folder_info.get("parentReference", {}).get("driveId"),
-                        "id": folder_info.get("id"),
+                        "driveId": folder_info.data.get("parentReference", {}).get("driveId"),
+                        "id": folder_info.data.get("id"),
                     }
 
                 await context.fetch(copy_url, method="POST", json=copy_body)
@@ -514,9 +514,9 @@ class CreateDocument(ActionHandler):
 
                 return ActionResult(
                     data={
-                        "document_id": response.get("id"),
-                        "name": response.get("name"),
-                        "webUrl": response.get("webUrl"),
+                        "document_id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "webUrl": response.data.get("webUrl"),
                         "result": True,
                     },
                     cost_usd=0.0,
@@ -544,7 +544,8 @@ async def _wait_for_copy(
             else:
                 check_url = f"{GRAPH_API_BASE}/me/drive/root:/{encoded_name}"
 
-            return await context.fetch(check_url, method="GET")
+            resp = await context.fetch(check_url, method="GET")
+            return resp.data
         except Exception:
             await asyncio.sleep(delay)
             delay = min(delay * 1.5, 5.0)  # Cap at 5 seconds
@@ -564,14 +565,14 @@ class UpdateContent(ActionHandler):
 
             if preserve_formatting:
                 content_url = f"{GRAPH_API_BASE}/me/drive/items/{document_id}/content"
-                existing_bytes = await context.fetch(content_url, method="GET")
+                existing_bytes_resp = await context.fetch(content_url, method="GET")
 
-                if not isinstance(existing_bytes, bytes):
+                if not isinstance(existing_bytes_resp.data, bytes):
                     return ActionResult(
                         data={"result": False, "error": "Failed to download document content"}, cost_usd=0.0
                     )
 
-                docx_bytes, _ = modify_docx_content(existing_bytes, {"replace_all": content})
+                docx_bytes, _ = modify_docx_content(existing_bytes_resp.data, {"replace_all": content})
             else:
                 docx_bytes = create_docx_from_text(content)
 
@@ -610,14 +611,14 @@ class InsertText(ActionHandler):
                 )
 
             content_url = f"{GRAPH_API_BASE}/me/drive/items/{document_id}/content"
-            existing_bytes = await context.fetch(content_url, method="GET")
+            existing_bytes_resp = await context.fetch(content_url, method="GET")
 
-            if not isinstance(existing_bytes, bytes):
+            if not isinstance(existing_bytes_resp.data, bytes):
                 return ActionResult(
                     data={"result": False, "error": "Failed to download document content"}, cost_usd=0.0
                 )
 
-            parsed = parse_docx_content(existing_bytes)
+            parsed = parse_docx_content(existing_bytes_resp.data)
             paragraphs = parsed["paragraphs"]
 
             texts = [p["text"] for p in paragraphs]
@@ -668,14 +669,14 @@ class GetParagraphs(ActionHandler):
                 return ActionResult(data={"result": False, "error": "start_index must be non-negative"}, cost_usd=0.0)
 
             content_url = f"{GRAPH_API_BASE}/me/drive/items/{document_id}/content"
-            docx_bytes = await context.fetch(content_url, method="GET")
+            docx_bytes_resp = await context.fetch(content_url, method="GET")
 
-            if not isinstance(docx_bytes, bytes):
+            if not isinstance(docx_bytes_resp.data, bytes):
                 return ActionResult(
                     data={"result": False, "error": "Failed to download document content"}, cost_usd=0.0
                 )
 
-            parsed = parse_docx_content(docx_bytes)
+            parsed = parse_docx_content(docx_bytes_resp.data)
             paragraphs = parsed["paragraphs"]
 
             if start_index > 0:
@@ -712,9 +713,9 @@ class SearchReplace(ActionHandler):
                 return ActionResult(data={"result": False, "error": "search_text cannot be empty"}, cost_usd=0.0)
 
             content_url = f"{GRAPH_API_BASE}/me/drive/items/{document_id}/content"
-            docx_bytes = await context.fetch(content_url, method="GET")
+            docx_bytes_resp = await context.fetch(content_url, method="GET")
 
-            if not isinstance(docx_bytes, bytes):
+            if not isinstance(docx_bytes_resp.data, bytes):
                 return ActionResult(
                     data={"result": False, "error": "Failed to download document content"}, cost_usd=0.0
                 )
@@ -722,7 +723,7 @@ class SearchReplace(ActionHandler):
             # For match_whole_word, we need to handle it differently
             # since modify_docx_content doesn't support word boundaries
             if match_whole_word:
-                parsed = parse_docx_content(docx_bytes)
+                parsed = parse_docx_content(docx_bytes_resp.data)
                 text = parsed["full_text"]
                 pattern = re.compile(r"\b" + re.escape(search_text) + r"\b", 0 if match_case else re.IGNORECASE)
                 count_before = len(pattern.findall(text))
@@ -743,7 +744,7 @@ class SearchReplace(ActionHandler):
             }
 
             # modify_docx_content now returns (bytes, replacement_count)
-            modified_bytes, replacement_count = modify_docx_content(docx_bytes, modifications)
+            modified_bytes, replacement_count = modify_docx_content(docx_bytes_resp.data, modifications)
 
             if replacement_count == 0:
                 return ActionResult(
@@ -785,15 +786,15 @@ class ExportPdf(ActionHandler):
 
             pdf_response = await context.fetch(pdf_url, method="GET")
 
-            if not isinstance(pdf_response, bytes):
+            if not isinstance(pdf_response.data, bytes):
                 return ActionResult(data={"result": False, "error": "Failed to convert document to PDF"}, cost_usd=0.0)
 
-            pdf_bytes = pdf_response
+            pdf_bytes = pdf_response.data
 
             if save_to_drive:
                 if not output_name:
                     doc_info = await context.fetch(f"{GRAPH_API_BASE}/me/drive/items/{document_id}", method="GET")
-                    original_name = doc_info.get("name", "document.docx")
+                    original_name = doc_info.data.get("name", "document.docx")
                     output_name = original_name.rsplit(".", 1)[0] + ".pdf"
 
                 if not output_name.lower().endswith(".pdf"):
@@ -814,9 +815,9 @@ class ExportPdf(ActionHandler):
 
                 return ActionResult(
                     data={
-                        "pdf_url": uploaded.get("webUrl"),
-                        "pdf_id": uploaded.get("id"),
-                        "size": uploaded.get("size"),
+                        "pdf_url": uploaded.data.get("webUrl"),
+                        "pdf_id": uploaded.data.get("id"),
+                        "size": uploaded.data.get("size"),
                         "result": True,
                     },
                     cost_usd=0.0,
@@ -854,14 +855,14 @@ class GetTables(ActionHandler):
             table_index = inputs.get("table_index")
 
             content_url = f"{GRAPH_API_BASE}/me/drive/items/{document_id}/content"
-            docx_bytes = await context.fetch(content_url, method="GET")
+            docx_bytes_resp = await context.fetch(content_url, method="GET")
 
-            if not isinstance(docx_bytes, bytes):
+            if not isinstance(docx_bytes_resp.data, bytes):
                 return ActionResult(
                     data={"result": False, "error": "Failed to download document content"}, cost_usd=0.0
                 )
 
-            parsed = parse_docx_content(docx_bytes)
+            parsed = parse_docx_content(docx_bytes_resp.data)
             tables = parsed["tables"]
 
             if table_index is not None:

--- a/microsoft-word/requirements.txt
+++ b/microsoft-word/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 defusedxml~=0.7.1

--- a/microsoft365/microsoft365.py
+++ b/microsoft365/microsoft365.py
@@ -99,8 +99,8 @@ class CreateCalendarEventAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "webLink": response["webLink"],
+                    "id": response.data["id"],
+                    "webLink": response.data["webLink"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -138,9 +138,9 @@ class UploadFileAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "webUrl": response["webUrl"],
-                    "size": response["size"],
+                    "id": response.data["id"],
+                    "webUrl": response.data["webUrl"],
+                    "size": response.data["size"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -173,7 +173,7 @@ class ListFilesAction(ActionHandler):
 
             # Format files
             files = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 file_item = {
                     "id": item["id"],
                     "name": item["name"],
@@ -237,8 +237,8 @@ class UpdateCalendarEventAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "webLink": response["webLink"],
+                    "id": response.data["id"],
+                    "webLink": response.data["webLink"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -290,7 +290,7 @@ class ListCalendarEventsAction(ActionHandler):
 
             # Format events
             events = []
-            for event in response.get("value", []):
+            for event in response.data.get("value", []):
                 # Process attendees
                 attendees = []
                 for attendee in event.get("attendees", []):
@@ -368,7 +368,7 @@ class ListEmailsAction(ActionHandler):
 
             # Format emails
             emails = []
-            for email in response.get("value", []):
+            for email in response.data.get("value", []):
                 emails.append(
                     {
                         "id": email["id"],
@@ -411,7 +411,7 @@ class ListEmailsFromContactAction(ActionHandler):
 
             # Format emails
             emails = []
-            for email in response.get("value", []):
+            for email in response.data.get("value", []):
                 emails.append(
                     {
                         "id": email["id"],
@@ -461,9 +461,9 @@ class MarkEmailReadAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "isRead": response["isRead"],
-                    "lastModifiedDateTime": response["lastModifiedDateTime"],
+                    "id": response.data["id"],
+                    "isRead": response.data["isRead"],
+                    "lastModifiedDateTime": response.data["lastModifiedDateTime"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -514,8 +514,8 @@ class ListMailFoldersAction(ActionHandler):
                     # nextLink already contains query params, don't pass params again
                     response = await context.fetch(next_url)
 
-                all_folder_items.extend(response.get("value", []))
-                next_url = response.get("@odata.nextLink")
+                all_folder_items.extend(response.data.get("value", []))
+                next_url = response.data.get("@odata.nextLink")
 
             # Format folders
             folders = []
@@ -577,8 +577,8 @@ class ListMailFoldersAction(ActionHandler):
                     # nextLink already contains query params, don't pass params again
                     response = await context.fetch(next_url)
 
-                all_folder_items.extend(response.get("value", []))
-                next_url = response.get("@odata.nextLink")
+                all_folder_items.extend(response.data.get("value", []))
+                next_url = response.data.get("@odata.nextLink")
 
             folders = []
             for folder in all_folder_items:
@@ -626,13 +626,13 @@ class GetMailFolderAction(ActionHandler):
             response = await context.fetch(api_url, params=params)
 
             folder_data = {
-                "id": response["id"],
-                "displayName": response.get("displayName", ""),
-                "parentFolderId": response.get("parentFolderId", ""),
-                "childFolderCount": response.get("childFolderCount", 0),
-                "unreadItemCount": response.get("unreadItemCount", 0),
-                "totalItemCount": response.get("totalItemCount", 0),
-                "isHidden": response.get("isHidden", False),
+                "id": response.data["id"],
+                "displayName": response.data.get("displayName", ""),
+                "parentFolderId": response.data.get("parentFolderId", ""),
+                "childFolderCount": response.data.get("childFolderCount", 0),
+                "unreadItemCount": response.data.get("unreadItemCount", 0),
+                "totalItemCount": response.data.get("totalItemCount", 0),
+                "isHidden": response.data.get("isHidden", False),
             }
 
             return ActionResult(data={"folder": folder_data, "result": True}, cost_usd=0.0)
@@ -669,9 +669,9 @@ class MoveEmailAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "parentFolderId": response["parentFolderId"],
-                    "subject": response.get("subject", ""),
+                    "id": response.data["id"],
+                    "parentFolderId": response.data["parentFolderId"],
+                    "subject": response.data.get("subject", ""),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -696,12 +696,12 @@ class ReadEmailAction(ActionHandler):
 
             # Format email details
             email_details = {
-                "id": email_response["id"],
-                "subject": email_response.get("subject") or "",
-                "sender": email_response["sender"],
-                "receivedDateTime": email_response["receivedDateTime"],
-                "body": email_response.get("body", {}),
-                "hasAttachments": email_response.get("hasAttachments", False),
+                "id": email_response.data["id"],
+                "subject": email_response.data.get("subject") or "",
+                "sender": email_response.data["sender"],
+                "receivedDateTime": email_response.data["receivedDateTime"],
+                "body": email_response.data.get("body", {}),
+                "hasAttachments": email_response.data.get("hasAttachments", False),
             }
 
             attachments = []
@@ -710,7 +710,7 @@ class ReadEmailAction(ActionHandler):
                 # Get attachments
                 attachments_response = await context.fetch(f"{GRAPH_API_BASE}/me/messages/{email_id}/attachments")
 
-                for attachment in attachments_response.get("value", []):
+                for attachment in attachments_response.data.get("value", []):
                     attachment_id = attachment["id"]
                     attachment_name = attachment["name"]
                     attachment_size = attachment.get("size", 0)
@@ -765,7 +765,7 @@ class ReadContactsAction(ActionHandler):
             response = await context.fetch(api_url, params=params)
 
             # Format and filter contacts
-            all_contacts = response.get("value", [])
+            all_contacts = response.data.get("value", [])
             contacts = []
 
             for contact in all_contacts:
@@ -880,7 +880,7 @@ class SearchOneDriveFilesAction(ActionHandler):
 
             # Format search results
             files = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 file_item = {
                     "id": item["id"],
                     "name": item["name"],
@@ -917,10 +917,10 @@ class ReadOneDriveFileContentAction(ActionHandler):
                 f"{GRAPH_API_BASE}/me/drive/items/{file_id}", params=metadata_params
             )
 
-            file_name = metadata_response["name"]
-            file_size = metadata_response.get("size", 0)
-            mime_type = metadata_response.get("mimeType", "")
-            web_url = metadata_response.get("webUrl", "")
+            file_name = metadata_response.data["name"]
+            file_size = metadata_response.data.get("size", 0)
+            mime_type = metadata_response.data.get("mimeType", "")
+            web_url = metadata_response.data.get("webUrl", "")
 
             # Try to get file content
             content = None
@@ -1116,10 +1116,10 @@ class CreateDraftEmailAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "draft_id": response["id"],
-                    "subject": response.get("subject") or "",
-                    "created_datetime": response.get("createdDateTime") or "",
-                    "is_draft": response.get("isDraft", True),
+                    "draft_id": response.data["id"],
+                    "subject": response.data.get("subject") or "",
+                    "created_datetime": response.data.get("createdDateTime") or "",
+                    "is_draft": response.data.get("isDraft", True),
                 },
                 cost_usd=0.0,
             )
@@ -1271,11 +1271,11 @@ class DownloadEmailAttachmentAction(ActionHandler):
             )
 
             # Extract metadata
-            attachment_id_val = attachment_response["id"]
-            attachment_name = attachment_response.get("name") or ""
-            content_type = attachment_response.get("contentType") or "application/octet-stream"
-            size = attachment_response.get("size", 0)
-            is_inline = attachment_response.get("isInline", False)
+            attachment_id_val = attachment_response.data["id"]
+            attachment_name = attachment_response.data.get("name") or ""
+            content_type = attachment_response.data.get("contentType") or "application/octet-stream"
+            size = attachment_response.data.get("size", 0)
+            is_inline = attachment_response.data.get("isInline", False)
 
             # Get attachment content if requested
             content = ""
@@ -1295,8 +1295,8 @@ class DownloadEmailAttachmentAction(ActionHandler):
 
                 except Exception as content_error:
                     # If binary content fails, try getting contentBytes from attachment object
-                    if "contentBytes" in attachment_response:
-                        content = attachment_response["contentBytes"]
+                    if "contentBytes" in attachment_response.data:
+                        content = attachment_response.data["contentBytes"]
                         content_available = True
                     else:
                         content = ""
@@ -1399,8 +1399,8 @@ class SearchEmailsAction(ActionHandler):
             messages = []
             total_results = 0
 
-            if response.get("value") and len(response["value"]) > 0:
-                search_result = response["value"][0]
+            if response.data.get("value") and len(response.data["value"]) > 0:
+                search_result = response.data["value"][0]
                 hits = search_result.get("hitsContainers", [])
 
                 if hits:
@@ -1470,7 +1470,7 @@ class SearchSharePointSitesAction(ActionHandler):
 
             # Process search results according to API response format
             sites = []
-            for site in response.get("value", []):
+            for site in response.data.get("value", []):
                 sites.append(
                     {
                         "id": site.get("id") or "",
@@ -1518,19 +1518,19 @@ class GetSharePointSiteDetailsAction(ActionHandler):
 
             # Process response according to API documentation
             site_details = {
-                "id": response.get("id") or "",
-                "display_name": response.get("displayName") or "",
-                "name": response.get("name") or "",
-                "description": response.get("description") or "",
-                "web_url": response.get("webUrl") or "",
-                "created_datetime": response.get("createdDateTime") or "",
-                "last_modified_datetime": response.get("lastModifiedDateTime") or "",
-                "is_personal_site": response.get("isPersonalSite", False),
+                "id": response.data.get("id") or "",
+                "display_name": response.data.get("displayName") or "",
+                "name": response.data.get("name") or "",
+                "description": response.data.get("description") or "",
+                "web_url": response.data.get("webUrl") or "",
+                "created_datetime": response.data.get("createdDateTime") or "",
+                "last_modified_datetime": response.data.get("lastModifiedDateTime") or "",
+                "is_personal_site": response.data.get("isPersonalSite", False),
             }
 
             # Add additional metadata if available
-            if "siteCollection" in response:
-                site_details["site_collection"] = response["siteCollection"]
+            if "siteCollection" in response.data:
+                site_details["site_collection"] = response.data["siteCollection"]
 
             return ActionResult(data={"result": True, "site": site_details}, cost_usd=0.0)
 
@@ -1577,7 +1577,7 @@ class ListSharePointLibrariesAction(ActionHandler):
 
             # Process response according to API documentation
             libraries = []
-            for drive in response.get("value", []):
+            for drive in response.data.get("value", []):
                 library_data = {
                     "id": drive.get("id", ""),
                     "name": drive.get("name", ""),
@@ -1642,7 +1642,7 @@ class SearchSharePointDocumentsAction(ActionHandler):
             # GET /sites/{site-id}/drives
             drives_response = await context.fetch(f"{GRAPH_API_BASE}/sites/{site_id}/drives")
 
-            drives = drives_response.get("value", [])
+            drives = drives_response.data.get("value", [])
             if not drives:
                 return ActionResult(
                     data={
@@ -1679,7 +1679,7 @@ class SearchSharePointDocumentsAction(ActionHandler):
                     drive_response = await context.fetch(api_url, params=params)
 
                     # Process files from this drive
-                    for item in drive_response.get("value", []):
+                    for item in drive_response.data.get("value", []):
                         file_item = {
                             "id": item["id"],
                             "name": item["name"],
@@ -1763,10 +1763,10 @@ class ReadSharePointDocumentAction(ActionHandler):
 
             metadata_response = await context.fetch(metadata_url, params=metadata_params)
 
-            file_name = metadata_response["name"]
-            file_size = metadata_response.get("size", 0)
-            mime_type = metadata_response.get("mimeType", "")
-            web_url = metadata_response.get("webUrl", "")
+            file_name = metadata_response.data["name"]
+            file_size = metadata_response.data.get("size", 0)
+            mime_type = metadata_response.data.get("mimeType", "")
+            web_url = metadata_response.data.get("webUrl", "")
 
             # Try to get file content (reuse OneDrive logic)
             content = None
@@ -1939,7 +1939,7 @@ class ListSharePointPagesAction(ActionHandler):
 
             # Process response according to API documentation
             pages = []
-            for page in response.get("value", []):
+            for page in response.data.get("value", []):
                 page_data = {
                     "id": page.get("id", ""),
                     "name": page.get("name", ""),
@@ -2016,25 +2016,25 @@ class ReadSharePointPageContentAction(ActionHandler):
 
             # Process response according to API documentation
             page_data = {
-                "id": response.get("id", ""),
-                "name": response.get("name", ""),
-                "title": response.get("title", ""),
-                "web_url": response.get("webUrl", ""),
-                "page_layout": response.get("pageLayout", ""),
-                "created_datetime": response.get("createdDateTime", ""),
-                "last_modified_datetime": response.get("lastModifiedDateTime", ""),
+                "id": response.data.get("id", ""),
+                "name": response.data.get("name", ""),
+                "title": response.data.get("title", ""),
+                "web_url": response.data.get("webUrl", ""),
+                "page_layout": response.data.get("pageLayout", ""),
+                "created_datetime": response.data.get("createdDateTime", ""),
+                "last_modified_datetime": response.data.get("lastModifiedDateTime", ""),
             }
 
             # Add creator information if available
-            if "createdBy" in response and "user" in response["createdBy"]:
+            if "createdBy" in response.data and "user" in response.data["createdBy"]:
                 page_data["created_by"] = {
-                    "display_name": response["createdBy"]["user"].get("displayName", ""),
-                    "email": response["createdBy"]["user"].get("email", ""),
+                    "display_name": response.data["createdBy"]["user"].get("displayName", ""),
+                    "email": response.data["createdBy"]["user"].get("email", ""),
                 }
 
             # Add page content if available
-            if include_content and "canvasLayout" in response:
-                page_data["content"] = response["canvasLayout"]
+            if include_content and "canvasLayout" in response.data:
+                page_data["content"] = response.data["canvasLayout"]
 
             return ActionResult(
                 data={"result": True, "site_id": site_id, "page": page_data},
@@ -2068,7 +2068,7 @@ class ListSharePointSubsitesAction(ActionHandler):
 
             # Process response
             subsites = []
-            for site in response.get("value", []):
+            for site in response.data.get("value", []):
                 subsites.append(
                     {
                         "id": site.get("id", ""),
@@ -2088,7 +2088,7 @@ class ListSharePointSubsitesAction(ActionHandler):
                     "site_id": site_id,
                     "subsites": subsites,
                     "total_subsites": len(subsites),
-                    "has_more": "@odata.nextLink" in response,
+                    "has_more": "@odata.nextLink" in response.data,
                 },
                 cost_usd=0.0,
             )
@@ -2134,7 +2134,7 @@ class ListSharePointFolderContentsAction(ActionHandler):
 
             # Process response
             items = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 item_data = {
                     "id": item.get("id", ""),
                     "name": item.get("name", ""),
@@ -2173,7 +2173,7 @@ class ListSharePointFolderContentsAction(ActionHandler):
             }
 
             # Include pagination indicator
-            result["has_more"] = "@odata.nextLink" in response
+            result["has_more"] = "@odata.nextLink" in response.data
 
             return ActionResult(data=result, cost_usd=0.0)
 
@@ -2286,7 +2286,7 @@ class FindMeetingTimesAction(ActionHandler):
 
             # Process meeting time suggestions
             suggestions = []
-            for suggestion in response.get("meetingTimeSuggestions", []):
+            for suggestion in response.data.get("meetingTimeSuggestions", []):
                 time_slot = suggestion.get("meetingTimeSlot", {})
                 start_info = time_slot.get("start", {})
                 end_info = time_slot.get("end", {})
@@ -2326,7 +2326,7 @@ class FindMeetingTimesAction(ActionHandler):
             result_data = {"result": True, "meeting_time_suggestions": suggestions}
 
             # Include empty suggestions reason if no suggestions found
-            empty_reason = response.get("emptySuggestionsReason", "")
+            empty_reason = response.data.get("emptySuggestionsReason", "")
             if empty_reason:
                 result_data["empty_suggestions_reason"] = empty_reason
 
@@ -2359,7 +2359,7 @@ class GetScheduleAction(ActionHandler):
 
             # Process schedule responses
             schedules = []
-            for schedule in response.get("value", []):
+            for schedule in response.data.get("value", []):
                 schedule_data = {
                     "email": schedule.get("scheduleId", ""),
                     "availability_view": schedule.get("availabilityView", ""),
@@ -2424,8 +2424,8 @@ class ListRoomsAction(ActionHandler):
                 while next_url and len(all_items) < limit:
                     response = await context.fetch(next_url, params=params if is_first else None)
                     is_first = False
-                    all_items.extend(response.get("value", []))
-                    next_url = response.get("@odata.nextLink")
+                    all_items.extend(response.data.get("value", []))
+                    next_url = response.data.get("@odata.nextLink")
                 all_items = all_items[:limit]
 
                 rooms = []
@@ -2459,8 +2459,8 @@ class ListRoomsAction(ActionHandler):
                 while next_url and len(all_items) < limit:
                     response = await context.fetch(next_url, params=params if is_first else None)
                     is_first = False
-                    all_items.extend(response.get("value", []))
-                    next_url = response.get("@odata.nextLink")
+                    all_items.extend(response.data.get("value", []))
+                    next_url = response.data.get("@odata.nextLink")
                 all_items = all_items[:limit]
 
                 rooms = []
@@ -2493,8 +2493,8 @@ class ListRoomsAction(ActionHandler):
                 while next_url and len(all_items) < limit:
                     response = await context.fetch(next_url, params=params if is_first else None)
                     is_first = False
-                    all_items.extend(response.get("value", []))
-                    next_url = response.get("@odata.nextLink")
+                    all_items.extend(response.data.get("value", []))
+                    next_url = response.data.get("@odata.nextLink")
                 all_items = all_items[:limit]
 
                 rooms = []
@@ -2550,7 +2550,7 @@ class CheckRoomAvailabilityAction(ActionHandler):
             available_rooms = []
             unavailable_rooms = []
 
-            for schedule in response.get("value", []):
+            for schedule in response.data.get("value", []):
                 email = schedule.get("scheduleId", "")
                 schedule_items = schedule.get("scheduleItems", [])
 

--- a/microsoft365/requirements.txt
+++ b/microsoft365/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp

--- a/monday-com/monday_com.py
+++ b/monday-com/monday_com.py
@@ -36,9 +36,7 @@ async def execute_graphql_query(query: str, variables: Dict[str, Any], context: 
 
     response = await context.fetch(url, method="POST", json=payload, headers=headers)
 
-    return response
-
-
+    return response.data
 @monday_com.action("get_boards")
 class GetBoards(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):

--- a/monday-com/requirements.txt
+++ b/monday-com/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/netlify/netlify.py
+++ b/netlify/netlify.py
@@ -23,7 +23,7 @@ class ListSitesAction(ActionHandler):
         try:
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites", method="GET")
 
-            sites = response if isinstance(response, list) else []
+            sites = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"sites": sites, "result": True}, cost_usd=0.0)
 
@@ -46,7 +46,7 @@ class CreateSiteAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites", method="POST", json=payload)
 
-            return ActionResult(data={"site": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"site": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"site": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -62,7 +62,7 @@ class GetSiteAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites/{site_id}", method="GET")
 
-            return ActionResult(data={"site": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"site": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"site": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -84,7 +84,7 @@ class UpdateSiteAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites/{site_id}", method="PATCH", json=payload)
 
-            return ActionResult(data={"site": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"site": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"site": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -119,7 +119,7 @@ class ListDeploysAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites/{site_id}/deploys", method="GET")
 
-            deploys = response if isinstance(response, list) else []
+            deploys = response.data if isinstance(response.data, list) else []
 
             return ActionResult(data={"deploys": deploys, "result": True}, cost_usd=0.0)
 
@@ -151,8 +151,8 @@ class CreateDeployAction(ActionHandler):
             )
 
             # Upload required files
-            required_hashes = deploy.get("required", [])
-            deploy_id = deploy.get("id")
+            required_hashes = deploy.data.get("required", [])
+            deploy_id = deploy.data.get("id")
 
             for sha1_hash in required_hashes:
                 if sha1_hash in hash_to_content:
@@ -169,10 +169,10 @@ class CreateDeployAction(ActionHandler):
             final_deploy = await context.fetch(f"{NETLIFY_API_BASE_URL}/deploys/{deploy_id}", method="GET")
 
             deploy_url = (
-                final_deploy.get("deploy_ssl_url") or final_deploy.get("ssl_url") or final_deploy.get("url", "")
+                final_deploy.data.get("deploy_ssl_url") or final_deploy.data.get("ssl_url") or final_deploy.data.get("url", "")
             )
 
-            return ActionResult(data={"deploy": final_deploy, "deploy_url": deploy_url, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deploy": final_deploy.data, "deploy_url": deploy_url, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deploy": {}, "deploy_url": "", "result": False, "error": str(e)}, cost_usd=0.0)
@@ -188,7 +188,7 @@ class GetDeployAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/deploys/{deploy_id}", method="GET")
 
-            return ActionResult(data={"deploy": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deploy": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deploy": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/netlify/requirements.txt
+++ b/netlify/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/notion/notion.py
+++ b/notion/notion.py
@@ -54,11 +54,11 @@ class NotionSearchHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "object": response.get("object", "list"),
-                    "results": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "object": response.data.get("object", "list"),
+                    "results": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -92,7 +92,7 @@ class NotionGetPageHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/pages/{page_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"page": response})
+            return ActionResult(data={"page": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "page": None})
@@ -125,7 +125,7 @@ class NotionCreatePageHandler(ActionHandler):
                 url="https://api.notion.com/v1/pages", method="POST", headers=headers, json=create_body
             )
 
-            return ActionResult(data={"page": response})
+            return ActionResult(data={"page": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "page": None})
@@ -158,7 +158,7 @@ class NotionCreateCommentHandler(ActionHandler):
                 url="https://api.notion.com/v1/comments", method="POST", headers=headers, json=comment_body
             )
 
-            return ActionResult(data={"comment": response})
+            return ActionResult(data={"comment": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "comment": None})
@@ -188,9 +188,9 @@ class NotionGetCommentsHandler(ActionHandler):
             )
 
             result = {
-                "comments": response.get("results", []),
-                "has_more": response.get("has_more", False),
-                "next_cursor": response.get("next_cursor"),
+                "comments": response.data.get("results", []),
+                "has_more": response.data.get("has_more", False),
+                "next_cursor": response.data.get("next_cursor"),
             }
 
             if include_child_blocks_with_comments:
@@ -200,7 +200,7 @@ class NotionGetCommentsHandler(ActionHandler):
                     url=f"https://api.notion.com/v1/blocks/{block_id}/children", method="GET", headers=headers
                 )
 
-                for block in blocks_response.get("results", []):
+                for block in blocks_response.data.get("results", []):
                     child_block_id = block.get("id")
                     if child_block_id:
                         comments_response = await context.fetch(
@@ -209,7 +209,7 @@ class NotionGetCommentsHandler(ActionHandler):
                             headers=headers,
                             params={"block_id": child_block_id, "page_size": 1},
                         )
-                        if comments_response.get("results"):
+                        if comments_response.data.get("results"):
                             blocks_with_comments.append(
                                 {"block_id": child_block_id, "block_type": block.get("type"), "has_comments": True}
                             )
@@ -257,9 +257,9 @@ class NotionListDataSourcesHandler(ActionHandler):
             )
             return ActionResult(
                 data={
-                    "data_sources": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
+                    "data_sources": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
                 }
             )
         except Exception as e:
@@ -289,7 +289,7 @@ class NotionGetDataSourceHandler(ActionHandler):
             response = await context.fetch(
                 url=f"https://api.notion.com/v1/data_sources/{data_source_id}", method="GET", headers=headers
             )
-            return ActionResult(data={"data_source": response})
+            return ActionResult(data={"data_source": response.data})
         except Exception as e:
             return ActionResult(data={"error": str(e), "data_source": None})
 
@@ -346,10 +346,10 @@ class NotionQueryDataSourceHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "results": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "results": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -394,10 +394,10 @@ class NotionGetBlockChildrenHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "blocks": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "blocks": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -443,10 +443,10 @@ class NotionAppendBlockChildrenHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "blocks": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "blocks": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -490,7 +490,7 @@ class NotionGetPagePropertyHandler(ActionHandler):
 
             response = await context.fetch(url=url, method="GET", headers=headers, params=params)
 
-            return ActionResult(data={"property": response})
+            return ActionResult(data={"property": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "property": None})
@@ -561,7 +561,7 @@ class NotionUpdateBlockHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/blocks/{block_id}", method="PATCH", headers=headers, json=update_body
             )
 
-            return ActionResult(data={"block": response})
+            return ActionResult(data={"block": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "block": None})
@@ -593,7 +593,7 @@ class NotionDeleteBlockHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/blocks/{block_id}", method="DELETE", headers=headers
             )
 
-            return ActionResult(data={"block": response})
+            return ActionResult(data={"block": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "block": None})
@@ -635,7 +635,7 @@ class NotionUpdatePageHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/pages/{page_id}", method="PATCH", headers=headers, json=update_body
             )
 
-            return ActionResult(data={"page": response})
+            return ActionResult(data={"page": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "page": None})

--- a/notion/requirements.txt
+++ b/notion/requirements.txt
@@ -1,5 +1,5 @@
 # Notion Integration Dependencies
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp>=3.12.0
 jsonschema>=4.17.0
 attrs>=25.0.0

--- a/nzbn/nzbn.py
+++ b/nzbn/nzbn.py
@@ -106,10 +106,8 @@ async def get_oauth_token(context: ExecutionContext) -> Optional[str]:
 
     # Handle response
     token_data = None
-    if hasattr(response, "status_code") and response.status_code == 200:
-        token_data = response.json()
-    elif isinstance(response, dict):
-        token_data = response
+    if response.status == 200:
+        token_data = response.data
 
     if token_data and "access_token" in token_data:
         access_token = token_data["access_token"]
@@ -144,24 +142,21 @@ async def make_request(
 
     response = await context.fetch(url, method=method, headers=headers, params=params)
 
-    if hasattr(response, "status_code"):
-        if response.status_code == 200:
-            return {"success": True, "data": response.json()}
-        elif response.status_code == 304:
-            return {"success": True, "data": None, "not_modified": True}
-        elif response.status_code == 400:
-            error_data = response.json() if hasattr(response, "json") else {}
-            return {"success": False, "error": error_data.get("errorDescription", "Bad request - validation failed")}
-        elif response.status_code == 401:
-            return {"success": False, "error": "Unauthorized - invalid credentials"}
-        elif response.status_code == 403:
-            return {"success": False, "error": "Forbidden - insufficient permissions"}
-        elif response.status_code == 404:
-            return {"success": False, "error": "Entity not found"}
-        else:
-            return {"success": False, "error": f"API error: {response.status_code}"}
-
-    return {"success": True, "data": response}
+    if response.status == 200:
+        return {"success": True, "data": response.data}
+    elif response.status == 304:
+        return {"success": True, "data": None, "not_modified": True}
+    elif response.status == 400:
+        error_data = response.data or {}
+        return {"success": False, "error": error_data.get("errorDescription", "Bad request - validation failed")}
+    elif response.status == 401:
+        return {"success": False, "error": "Unauthorized - invalid credentials"}
+    elif response.status == 403:
+        return {"success": False, "error": "Forbidden - insufficient permissions"}
+    elif response.status == 404:
+        return {"success": False, "error": "Entity not found"}
+    else:
+        return {"success": False, "error": f"API error: {response.status}"}
 
 
 # =============================================================================

--- a/nzbn/requirements.txt
+++ b/nzbn/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/pipedrive/pipedrive.py
+++ b/pipedrive/pipedrive.py
@@ -45,7 +45,7 @@ class CreateDealAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals", method="POST", json=data)
 
-            return ActionResult(data={"deal": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deal": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deal": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -61,7 +61,7 @@ class GetDealAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals/{deal_id}", method="GET")
 
-            return ActionResult(data={"deal": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deal": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deal": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -98,7 +98,7 @@ class UpdateDealAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals/{deal_id}", method="PUT", json=data)
 
-            return ActionResult(data={"deal": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deal": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deal": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -129,7 +129,7 @@ class ListDealsAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals", method="GET", params=params)
 
-            deals = response.get("data", [])
+            deals = response.data.get("data", [])
             return ActionResult(data={"deals": deals, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -177,7 +177,7 @@ class CreatePersonAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons", method="POST", json=data)
 
-            return ActionResult(data={"person": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"person": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"person": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -193,7 +193,7 @@ class GetPersonAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons/{person_id}", method="GET")
 
-            return ActionResult(data={"person": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"person": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"person": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -221,7 +221,7 @@ class UpdatePersonAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons/{person_id}", method="PUT", json=data)
 
-            return ActionResult(data={"person": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"person": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"person": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -248,7 +248,7 @@ class ListPersonsAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons", method="GET", params=params)
 
-            persons = response.get("data", [])
+            persons = response.data.get("data", [])
             return ActionResult(data={"persons": persons, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -291,7 +291,7 @@ class CreateOrganizationAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations", method="POST", json=data)
 
-            return ActionResult(data={"organization": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"organization": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"organization": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -307,7 +307,7 @@ class GetOrganizationAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations/{org_id}", method="GET")
 
-            return ActionResult(data={"organization": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"organization": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"organization": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -331,7 +331,7 @@ class UpdateOrganizationAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations/{org_id}", method="PUT", json=data)
 
-            return ActionResult(data={"organization": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"organization": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"organization": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -358,7 +358,7 @@ class ListOrganizationsAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations", method="GET", params=params)
 
-            organizations = response.get("data", [])
+            organizations = response.data.get("data", [])
             return ActionResult(data={"organizations": organizations, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -413,7 +413,7 @@ class CreateActivityAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/activities", method="POST", json=data)
 
-            return ActionResult(data={"activity": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"activity": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"activity": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -429,7 +429,7 @@ class GetActivityAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/activities/{activity_id}", method="GET")
 
-            return ActionResult(data={"activity": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"activity": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"activity": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -463,7 +463,7 @@ class UpdateActivityAction(ActionHandler):
                 f"{PIPEDRIVE_API_BASE_URL}/activities/{activity_id}", method="PUT", json=data
             )
 
-            return ActionResult(data={"activity": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"activity": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"activity": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -496,7 +496,7 @@ class ListActivitiesAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/activities", method="GET", params=params)
 
-            activities = response.get("data", [])
+            activities = response.data.get("data", [])
             return ActionResult(data={"activities": activities, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -539,7 +539,7 @@ class CreateNoteAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/notes", method="POST", json=data)
 
-            return ActionResult(data={"note": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"note": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"note": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -566,7 +566,7 @@ class ListNotesAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/notes", method="GET", params=params)
 
-            notes = response.get("data", [])
+            notes = response.data.get("data", [])
             return ActionResult(data={"notes": notes, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -584,7 +584,7 @@ class ListPipelinesAction(ActionHandler):
         try:
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/pipelines", method="GET")
 
-            pipelines = response.get("data", [])
+            pipelines = response.data.get("data", [])
             return ActionResult(data={"pipelines": pipelines, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -601,7 +601,7 @@ class GetPipelineAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/pipelines/{pipeline_id}", method="GET")
 
-            return ActionResult(data={"pipeline": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"pipeline": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"pipeline": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -625,7 +625,7 @@ class ListStagesAction(ActionHandler):
                 f"{PIPEDRIVE_API_BASE_URL}/stages", method="GET", params=params if params else None
             )
 
-            stages = response.get("data", [])
+            stages = response.data.get("data", [])
             return ActionResult(data={"stages": stages, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -656,7 +656,7 @@ class SearchAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/itemSearch", method="GET", params=params)
 
-            items = response.get("data", {}).get("items", [])
+            items = response.data.get("data", {}).get("items", [])
             return ActionResult(data={"items": items, "result": True}, cost_usd=0.0)
 
         except Exception as e:

--- a/pipedrive/requirements.txt
+++ b/pipedrive/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/powerbi/powerbi.py
+++ b/powerbi/powerbi.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -25,7 +25,7 @@ class ListWorkspacesAction(ActionHandler):
             response = await context.fetch(f"{POWERBI_API_BASE}/groups", params=params)
 
             workspaces = []
-            for workspace in response.get("value", []):
+            for workspace in response.data.get("value", []):
                 workspaces.append(
                     {
                         "id": workspace.get("id"),
@@ -36,11 +36,9 @@ class ListWorkspacesAction(ActionHandler):
                     }
                 )
 
-            return {"workspaces": workspaces, "result": True}
-
+            return ActionResult(data={"workspaces": workspaces, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"workspaces": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"workspaces": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_workspace")
 class GetWorkspaceAction(ActionHandler):
@@ -50,11 +48,9 @@ class GetWorkspaceAction(ActionHandler):
 
             response = await context.fetch(f"{POWERBI_API_BASE}/groups/{workspace_id}")
 
-            return {"workspace": response, "result": True}
-
+            return ActionResult(data={"workspace": response.data, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"workspace": {}, "result": False, "error": str(e)}
-
+            return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("list_datasets")
 class ListDatasetsAction(ActionHandler):
@@ -70,7 +66,7 @@ class ListDatasetsAction(ActionHandler):
             response = await context.fetch(url)
 
             datasets = []
-            for dataset in response.get("value", []):
+            for dataset in response.data.get("value", []):
                 datasets.append(
                     {
                         "id": dataset.get("id"),
@@ -83,11 +79,9 @@ class ListDatasetsAction(ActionHandler):
                     }
                 )
 
-            return {"datasets": datasets, "result": True}
-
+            return ActionResult(data={"datasets": datasets, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"datasets": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"datasets": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_dataset")
 class GetDatasetAction(ActionHandler):
@@ -103,11 +97,9 @@ class GetDatasetAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"dataset": response, "result": True}
-
+            return ActionResult(data={"dataset": response.data, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"dataset": {}, "result": False, "error": str(e)}
-
+            return ActionResult(data={"dataset": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("refresh_dataset")
 class RefreshDatasetAction(ActionHandler):
@@ -164,11 +156,9 @@ class RefreshDatasetAction(ActionHandler):
             if hasattr(response, "headers") and "x-ms-request-id" in response.headers:
                 request_id = response.headers["x-ms-request-id"]
 
-            return {"result": True, "message": "Dataset refresh initiated successfully", "request_id": request_id}
-
+            return ActionResult(data={"result": True, "message": "Dataset refresh initiated successfully", "request_id": request_id}, cost_usd=0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
-
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_refresh_history")
 class GetRefreshHistoryAction(ActionHandler):
@@ -188,7 +178,7 @@ class GetRefreshHistoryAction(ActionHandler):
             response = await context.fetch(url, params=params)
 
             refreshes = []
-            for refresh in response.get("value", []):
+            for refresh in response.data.get("value", []):
                 refreshes.append(
                     {
                         "refreshType": refresh.get("refreshType"),
@@ -199,11 +189,9 @@ class GetRefreshHistoryAction(ActionHandler):
                     }
                 )
 
-            return {"refreshes": refreshes, "result": True}
-
+            return ActionResult(data={"refreshes": refreshes, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"refreshes": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"refreshes": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("list_reports")
 class ListReportsAction(ActionHandler):
@@ -219,7 +207,7 @@ class ListReportsAction(ActionHandler):
             response = await context.fetch(url)
 
             reports = []
-            for report in response.get("value", []):
+            for report in response.data.get("value", []):
                 reports.append(
                     {
                         "id": report.get("id"),
@@ -230,11 +218,9 @@ class ListReportsAction(ActionHandler):
                     }
                 )
 
-            return {"reports": reports, "result": True}
-
+            return ActionResult(data={"reports": reports, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"reports": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"reports": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_report")
 class GetReportAction(ActionHandler):
@@ -250,11 +236,9 @@ class GetReportAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"report": response, "result": True}
-
+            return ActionResult(data={"report": response.data, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"report": {}, "result": False, "error": str(e)}
-
+            return ActionResult(data={"report": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_report_datasources")
 class GetReportDatasourcesAction(ActionHandler):
@@ -271,7 +255,7 @@ class GetReportDatasourcesAction(ActionHandler):
             response = await context.fetch(url)
 
             datasources = []
-            for datasource in response.get("value", []):
+            for datasource in response.data.get("value", []):
                 ds_data = {
                     "datasourceType": datasource.get("datasourceType"),
                     "datasourceId": datasource.get("datasourceId"),
@@ -286,11 +270,9 @@ class GetReportDatasourcesAction(ActionHandler):
 
                 datasources.append(ds_data)
 
-            return {"datasources": datasources, "result": True}
-
+            return ActionResult(data={"datasources": datasources, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"datasources": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"datasources": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("refresh_report")
 class RefreshReportAction(ActionHandler):
@@ -307,11 +289,10 @@ class RefreshReportAction(ActionHandler):
                 report_url = f"{POWERBI_API_BASE}/reports/{report_id}"
 
             report_response = await context.fetch(report_url)
-            dataset_id = report_response.get("datasetId")
+            dataset_id = report_response.data.get("datasetId")
 
             if not dataset_id:
-                return {"result": False, "error": "Report does not have an associated dataset"}
-
+                return ActionResult(data={"result": False, "error": "Report does not have an associated dataset"}, cost_usd=0)
             # Now refresh the dataset
             if workspace_id:
                 refresh_url = f"{POWERBI_API_BASE}/groups/{workspace_id}/datasets/{dataset_id}/refreshes"
@@ -322,15 +303,14 @@ class RefreshReportAction(ActionHandler):
 
             await context.fetch(refresh_url, method="POST", json=refresh_request)
 
-            return {
+            return ActionResult(data={
                 "result": True,
-                "message": f"Dataset refresh initiated successfully for report '{report_response.get('name')}'",
+                "message": f"Dataset refresh initiated successfully for report '{report_response.data.get('name')}'",
                 "dataset_id": dataset_id,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
-
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("clone_report")
 class CloneReportAction(ActionHandler):
@@ -357,17 +337,16 @@ class CloneReportAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=clone_request)
 
-            return {
-                "id": response.get("id"),
-                "name": response.get("name"),
-                "webUrl": response.get("webUrl"),
-                "embedUrl": response.get("embedUrl"),
+            return ActionResult(data={
+                "id": response.data.get("id"),
+                "name": response.data.get("name"),
+                "webUrl": response.data.get("webUrl"),
+                "embedUrl": response.data.get("embedUrl"),
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
-
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("export_report")
 class ExportReportAction(ActionHandler):
@@ -386,11 +365,9 @@ class ExportReportAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=export_request)
 
-            return {"export_id": response.get("id"), "result": True, "message": "Export initiated successfully"}
-
+            return ActionResult(data={"export_id": response.data.get("id"), "result": True, "message": "Export initiated successfully"}, cost_usd=0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
-
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_export_status")
 class GetExportStatusAction(ActionHandler):
@@ -407,15 +384,14 @@ class GetExportStatusAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {
-                "status": response.get("status"),
-                "percentComplete": response.get("percentComplete", 0),
+            return ActionResult(data={
+                "status": response.data.get("status"),
+                "percentComplete": response.data.get("percentComplete", 0),
                 "result": True,
-            }
+            }, cost_usd=0)
 
         except Exception as e:
-            return {"status": "Failed", "percentComplete": 0, "result": False, "error": str(e)}
-
+            return ActionResult(data={"status": "Failed", "percentComplete": 0, "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("list_dashboards")
 class ListDashboardsAction(ActionHandler):
@@ -431,7 +407,7 @@ class ListDashboardsAction(ActionHandler):
             response = await context.fetch(url)
 
             dashboards = []
-            for dashboard in response.get("value", []):
+            for dashboard in response.data.get("value", []):
                 dashboards.append(
                     {
                         "id": dashboard.get("id"),
@@ -441,11 +417,9 @@ class ListDashboardsAction(ActionHandler):
                     }
                 )
 
-            return {"dashboards": dashboards, "result": True}
-
+            return ActionResult(data={"dashboards": dashboards, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"dashboards": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"dashboards": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_dashboard")
 class GetDashboardAction(ActionHandler):
@@ -461,11 +435,9 @@ class GetDashboardAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"dashboard": response, "result": True}
-
+            return ActionResult(data={"dashboard": response.data, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"dashboard": {}, "result": False, "error": str(e)}
-
+            return ActionResult(data={"dashboard": {}, "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("get_dashboard_tiles")
 class GetDashboardTilesAction(ActionHandler):
@@ -482,7 +454,7 @@ class GetDashboardTilesAction(ActionHandler):
             response = await context.fetch(url)
 
             tiles = []
-            for tile in response.get("value", []):
+            for tile in response.data.get("value", []):
                 tiles.append(
                     {
                         "id": tile.get("id"),
@@ -493,11 +465,9 @@ class GetDashboardTilesAction(ActionHandler):
                     }
                 )
 
-            return {"tiles": tiles, "result": True}
-
+            return ActionResult(data={"tiles": tiles, "result": True}, cost_usd=0)
         except Exception as e:
-            return {"tiles": [], "result": False, "error": str(e)}
-
+            return ActionResult(data={"tiles": [], "result": False, "error": str(e)}, cost_usd=0)
 
 @powerbi.action("execute_queries")
 class ExecuteQueriesAction(ActionHandler):
@@ -516,7 +486,6 @@ class ExecuteQueriesAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=query_request)
 
-            return {"results": response.get("results", []), "result": True}
-
+            return ActionResult(data={"results": response.data.get("results", []), "result": True}, cost_usd=0)
         except Exception as e:
-            return {"results": [], "result": False, "error": str(e)}
+            return ActionResult(data={"results": [], "result": False, "error": str(e)}, cost_usd=0)

--- a/powerbi/requirements.txt
+++ b/powerbi/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/productboard/productboard.py
+++ b/productboard/productboard.py
@@ -19,9 +19,9 @@ def get_common_headers() -> Dict[str, str]:
 def parse_error(response, default_msg: str = "Unknown error") -> str:
     """Extract error message from Productboard API error response."""
     try:
-        body = response.json()
+        body = response.data
     except Exception:
-        return f"{default_msg} (HTTP {response.status_code})"
+        return f"{default_msg} (HTTP {response.status})"
 
     errors = body.get("errors")
     if isinstance(errors, list) and errors:
@@ -29,10 +29,10 @@ def parse_error(response, default_msg: str = "Unknown error") -> str:
         detail = first.get("detail") or first.get("title")
         code = first.get("code")
         if code:
-            return f"{detail or default_msg} (code={code}, http={response.status_code})"
+            return f"{detail or default_msg} (code={code}, http={response.status})"
         return detail or default_msg
 
-    return f"{default_msg} (HTTP {response.status_code})"
+    return f"{default_msg} (HTTP {response.status})"
 
 
 def extract_page_cursor(next_link: Optional[str]) -> Optional[str]:
@@ -87,13 +87,13 @@ class ListEntitiesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entities": [], "result": False, "error": parse_error(response, "Failed to list entities")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             next_link = data.get("links", {}).get("next")
             next_cursor = extract_page_cursor(next_link)
 
@@ -124,13 +124,13 @@ class GetEntityAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entity": {}, "result": False, "error": parse_error(response, "Failed to get entity")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"entity": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -167,13 +167,13 @@ class CreateEntityAction(ActionHandler):
                 json={"data": entity_data},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entity": {}, "result": False, "error": parse_error(response, "Failed to create entity")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"entity": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -220,13 +220,13 @@ class UpdateEntityAction(ActionHandler):
                 json={"data": {"patch": patch_operations}},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entity": {}, "result": False, "error": parse_error(response, "Failed to update entity")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"entity": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -247,7 +247,7 @@ class GetEntityConfigurationAction(ActionHandler):
                 headers=get_common_headers(),
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={
                         "configuration": {},
@@ -257,7 +257,7 @@ class GetEntityConfigurationAction(ActionHandler):
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"configuration": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -307,13 +307,13 @@ class ListNotesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"notes": [], "result": False, "error": parse_error(response, "Failed to list notes")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             next_link = data.get("links", {}).get("next")
             next_cursor = extract_page_cursor(next_link)
 
@@ -344,13 +344,13 @@ class GetNoteAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"note": {}, "result": False, "error": parse_error(response, "Failed to get note")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"note": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -401,13 +401,13 @@ class CreateNoteAction(ActionHandler):
                 json={"data": note_data},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"note": {}, "result": False, "error": parse_error(response, "Failed to create note")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"note": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -463,13 +463,13 @@ class UpdateNoteAction(ActionHandler):
                 json={"data": {"patch": patch_operations}},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"note": {}, "result": False, "error": parse_error(response, "Failed to update note")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"note": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -488,7 +488,7 @@ class GetNoteConfigurationAction(ActionHandler):
                 headers=get_common_headers(),
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={
                         "configuration": {},
@@ -498,7 +498,7 @@ class GetNoteConfigurationAction(ActionHandler):
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"configuration": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -526,13 +526,13 @@ class ListAnalyticsReportsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"reports": [], "result": False, "error": parse_error(response, "Failed to list reports")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             next_link = data.get("links", {}).get("next")
             next_cursor = extract_page_cursor(next_link)
 
@@ -558,13 +558,13 @@ class GetAnalyticsReportAction(ActionHandler):
                 headers=get_common_headers(),
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"report": {}, "result": False, "error": parse_error(response, "Failed to get report")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"report": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -584,13 +584,13 @@ class GetCurrentUserAction(ActionHandler):
                 f"{PRODUCTBOARD_API_BASE_URL}/oauth2/token/info", method="GET", headers=get_common_headers()
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"user": {}, "result": False, "error": parse_error(response, "Failed to get user info")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"user": data, "result": True}, cost_usd=0.0)
 
         except Exception as e:

--- a/productboard/requirements.txt
+++ b/productboard/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/retail-express/requirements.txt
+++ b/retail-express/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/retail-express/retail_express.py
+++ b/retail-express/retail_express.py
@@ -33,7 +33,7 @@ async def get_access_token(context: ExecutionContext) -> str:
         headers={"x-api-key": api_key, "Accept": "application/json"},
     )
 
-    return response.get("access_token", "")
+    return response.data.get("access_token", "")
 
 
 async def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
@@ -95,14 +95,14 @@ class ListProductsAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/products", method="GET", headers=headers, params=params
             )
 
-            products = response.get("data", [])
+            products = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "products": products,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(products)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(products)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -136,7 +136,7 @@ class GetProductAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/products/{product_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"product": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"product": response.data.get("data", response.data), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -165,14 +165,14 @@ class ListCustomersAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/customers", method="GET", headers=headers, params=params
             )
 
-            customers = response.get("data", [])
+            customers = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "customers": customers,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(customers)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(customers)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -206,7 +206,7 @@ class GetCustomerAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/customers/{customer_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"customer": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data.get("data", response.data), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -240,7 +240,7 @@ class CreateCustomerAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/customers", method="POST", headers=headers, json=body
             )
 
-            return ActionResult(data={"customer": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data.get("data", response.data), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -278,7 +278,7 @@ class UpdateCustomerAction(ActionHandler):
                 json=body,
             )
 
-            return ActionResult(data={"customer": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data.get("data", response.data), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -309,14 +309,14 @@ class ListOrdersAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/orders", method="GET", headers=headers, params=params
             )
 
-            orders = response.get("data", [])
+            orders = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "orders": orders,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(orders)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(orders)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -350,7 +350,7 @@ class GetOrderAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/orders/{order_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"order": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"order": response.data.get("data", response.data), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"order": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -373,14 +373,14 @@ class ListOutletsAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/outlets", method="GET", headers=headers, params=params
             )
 
-            outlets = response.get("data", [])
+            outlets = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "outlets": outlets,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(outlets)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(outlets)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -414,7 +414,7 @@ class GetOutletAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/outlets/{outlet_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"outlet": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"outlet": response.data.get("data", response.data), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"outlet": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/rss-reader-feedparser-ah-fetch/requirements.txt
+++ b/rss-reader-feedparser-ah-fetch/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 feedparser

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -1,5 +1,5 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
@@ -57,7 +57,7 @@ class GetFeedAction(ActionHandler):
             response = await context.fetch(feed_url)
 
         # Parse feed
-        feed = feedparser.parse(response)
+        feed = feedparser.parse(response.data)
 
         # Check for parsing errors
         if hasattr(feed, "bozo_exception"):
@@ -76,4 +76,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}, cost_usd=0)

--- a/rss-reader-feedparser/requirements.txt
+++ b/rss-reader-feedparser/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 feedparser

--- a/rss-reader-feedparser/rss_reader.py
+++ b/rss-reader-feedparser/rss_reader.py
@@ -1,5 +1,5 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
@@ -34,4 +34,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}, cost_usd=0)


### PR DESCRIPTION
## Summary

Migrates 23 integrations (float through humanitix) to `autohive-integrations-sdk~=2.0.0`.

### Changes
- **requirements.txt**: Bumped SDK version to `~=2.0.0` for all affected integrations
- **Fetch response handling**: Updated all `context.fetch()` calls to access response body via `.data` (SDK 2.0.0 breaking change — returns `FetchResponse` object instead of raw data)
- **ActionResult wrapping**: Wrapped all bare `return {...}` in `execute()` methods with `return ActionResult(data={...}, cost_usd=0)`

### Integrations updated
float, freshdesk, front, ghost, github, gitlab, gong, google-ads, google-analytics, google-business-profile, google-calendar, google-chat, google-docs, google-looker, google-search-console, google-sheets, google-tasks, grammarly, hackernews, harvest, heartbeat, heygen, humanitix

## Test plan
- [ ] Verify each integration builds without import errors
- [ ] Verify `context.fetch()` `.data` access is correct for integrations that use it directly
- [ ] Verify `ActionResult` is properly imported and all execute methods return it
- [ ] Smoke test a representative action for each integration