### PR TITLE
chore: migrate integrations (instagram → rss-reader-feedparser-ah-fetch) to SDK 2.0.0

### DIFF
--- a/instagram/actions/account.py
+++ b/instagram/actions/account.py
@@ -37,14 +37,14 @@ class GetAccountAction(ActionHandler):
 
         return ActionResult(
             data={
-                "id": response.get("id", ""),
-                "username": response.get("username", ""),
-                "name": response.get("name", ""),
-                "biography": response.get("biography", ""),
-                "followers_count": response.get("followers_count", 0),
-                "following_count": response.get("follows_count", 0),
-                "media_count": response.get("media_count", 0),
-                "profile_picture_url": response.get("profile_picture_url", ""),
-                "website": response.get("website", ""),
+                "id": response.data.get("id", ""),
+                "username": response.data.get("username", ""),
+                "name": response.data.get("name", ""),
+                "biography": response.data.get("biography", ""),
+                "followers_count": response.data.get("followers_count", 0),
+                "following_count": response.data.get("follows_count", 0),
+                "media_count": response.data.get("media_count", 0),
+                "profile_picture_url": response.data.get("profile_picture_url", ""),
+                "website": response.data.get("website", ""),
             }
         )

--- a/instagram/actions/comments.py
+++ b/instagram/actions/comments.py
@@ -61,9 +61,9 @@ class GetCommentsAction(ActionHandler):
 
         response = await context.fetch(f"{INSTAGRAM_GRAPH_API_BASE}/{media_id}/comments", method="GET", params=params)
 
-        comments = [_build_comment_response(c) for c in response.get("data", [])]
+        comments = [_build_comment_response(c) for c in response.data.get("data", [])]
 
-        paging = response.get("paging", {})
+        paging = response.data.get("paging", {})
         cursors = paging.get("cursors", {})
         next_cursor = cursors.get("after") if paging.get("next") else None
 
@@ -93,7 +93,7 @@ class ManageCommentAction(ActionHandler):
             response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{comment_id}/replies", method="POST", data={"message": message}
             )
-            return ActionResult(data={"success": True, "action_taken": "reply", "reply_id": response.get("id", "")})
+            return ActionResult(data={"success": True, "action_taken": "reply", "reply_id": response.data.get("id", "")})
 
         elif action in ("hide", "unhide"):
             hide_value = action == "hide"

--- a/instagram/actions/insights.py
+++ b/instagram/actions/insights.py
@@ -81,7 +81,7 @@ class GetInsightsAction(ActionHandler):
             media_response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{target_id}", method="GET", params={"fields": "media_product_type"}
             )
-            media_product_type = media_response.get("media_product_type", "FEED")
+            media_product_type = media_response.data.get("media_product_type", "FEED")
 
             if media_product_type == "REELS":
                 metrics = custom_metrics or self.DEFAULT_MEDIA_METRICS_REELS
@@ -96,7 +96,7 @@ class GetInsightsAction(ActionHandler):
         response = await context.fetch(endpoint, method="GET", params=params)
 
         metrics_data = {}
-        for item in response.get("data", []):
+        for item in response.data.get("data", []):
             metric_name = item.get("name", "")
 
             total_value = item.get("total_value", {})

--- a/instagram/actions/media.py
+++ b/instagram/actions/media.py
@@ -73,9 +73,9 @@ class GetPostsAction(ActionHandler):
             response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="GET", params=params
             )
-            media_list = [_build_media_response(m) for m in response.get("data", [])]
+            media_list = [_build_media_response(m) for m in response.data.get("data", [])]
 
-            paging = response.get("paging", {})
+            paging = response.data.get("paging", {})
             cursors = paging.get("cursors", {})
             next_cursor = cursors.get("after") if paging.get("next") else None
 
@@ -127,7 +127,7 @@ class CreatePostAction(ActionHandler):
                 child_response = await context.fetch(
                     f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="POST", data=child_data
                 )
-                child_container_ids.append(child_response.get("id"))
+                child_container_ids.append(child_response.data.get("id"))
 
             for container_id in child_container_ids:
                 await wait_for_media_container(context, container_id)
@@ -137,7 +137,7 @@ class CreatePostAction(ActionHandler):
                 method="POST",
                 data={"media_type": "CAROUSEL", "caption": caption, "children": ",".join(child_container_ids)},
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         elif media_type == "REELS":
             if not media_url:
@@ -148,7 +148,7 @@ class CreatePostAction(ActionHandler):
                 method="POST",
                 data={"media_type": "REELS", "video_url": media_url, "caption": caption},
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         elif media_type == "VIDEO":
             if not media_url:
@@ -159,7 +159,7 @@ class CreatePostAction(ActionHandler):
                 method="POST",
                 data={"media_type": "VIDEO", "video_url": media_url, "caption": caption},
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         else:
             if not media_url:
@@ -172,7 +172,7 @@ class CreatePostAction(ActionHandler):
             container_response = await context.fetch(
                 f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="POST", data=data
             )
-            container_id = container_response.get("id")
+            container_id = container_response.data.get("id")
 
         await wait_for_media_container(context, container_id)
 
@@ -180,13 +180,13 @@ class CreatePostAction(ActionHandler):
             f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media_publish", method="POST", data={"creation_id": container_id}
         )
 
-        media_id = publish_response.get("id", "")
+        media_id = publish_response.data.get("id", "")
 
         media_details = await context.fetch(
             f"{INSTAGRAM_GRAPH_API_BASE}/{media_id}", method="GET", params={"fields": "permalink"}
         )
 
-        return ActionResult(data={"media_id": media_id, "permalink": media_details.get("permalink", "")})
+        return ActionResult(data={"media_id": media_id, "permalink": media_details.data.get("permalink", "")})
 
 
 @instagram.action("create_story")
@@ -214,7 +214,7 @@ class CreateStoryAction(ActionHandler):
         container_response = await context.fetch(
             f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media", method="POST", data=data
         )
-        container_id = container_response.get("id")
+        container_id = container_response.data.get("id")
 
         await wait_for_media_container(context, container_id)
 
@@ -222,4 +222,4 @@ class CreateStoryAction(ActionHandler):
             f"{INSTAGRAM_GRAPH_API_BASE}/{account_id}/media_publish", method="POST", data={"creation_id": container_id}
         )
 
-        return ActionResult(data={"media_id": publish_response.get("id", "")})
+        return ActionResult(data={"media_id": publish_response.data.get("id", "")})

--- a/instagram/helpers.py
+++ b/instagram/helpers.py
@@ -28,7 +28,7 @@ async def get_instagram_account_id(context: ExecutionContext) -> str:
     """
     response = await context.fetch(f"{INSTAGRAM_GRAPH_API_BASE}/me", method="GET", params={"fields": "id,username"})
 
-    account_id = response.get("id")
+    account_id = response.data.get("id")
     if not account_id:
         raise Exception(
             "Failed to retrieve Instagram account ID. "
@@ -66,15 +66,15 @@ async def wait_for_media_container(
             f"{INSTAGRAM_GRAPH_API_BASE}/{container_id}", method="GET", params={"fields": "status_code,status"}
         )
 
-        status_code = response.get("status_code", "").upper()
+        status_code = response.data.get("status_code", "").upper()
 
         if status_code == "FINISHED":
             return response
         elif status_code == "ERROR":
-            error_msg = response.get("status", "Unknown error during media processing")
+            error_msg = response.data.get("status", "Unknown error during media processing")
             raise Exception(f"Media container processing failed: {error_msg}")
         elif status_code in ("EXPIRED", "FAILED"):
-            raise Exception(f"Media container {status_code.lower()}: {response.get('status', 'Unknown error')}")
+            raise Exception(f"Media container {status_code.lower()}: {response.data.get('status', 'Unknown error')}")
 
         await asyncio.sleep(delay)
 

--- a/instagram/instagram.py
+++ b/instagram/instagram.py
@@ -43,13 +43,13 @@ class InstagramConnectedAccountHandler(ConnectedAccountHandler):
 
         response = await context.fetch(f"{INSTAGRAM_GRAPH_API_BASE}/me", method="GET", params={"fields": fields})
 
-        name = response.get("name", "")
+        name = response.data.get("name", "")
         name_parts = name.split(maxsplit=1) if name else []
 
         return ConnectedAccountInfo(
-            username=response.get("username"),
+            username=response.data.get("username"),
             first_name=name_parts[0] if len(name_parts) > 0 else None,
             last_name=name_parts[1] if len(name_parts) > 1 else None,
-            avatar_url=response.get("profile_picture_url"),
-            user_id=response.get("id"),
+            avatar_url=response.data.get("profile_picture_url"),
+            user_id=response.data.get("id"),
         )

--- a/instagram/requirements.txt
+++ b/instagram/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/jira/jira.py
+++ b/jira/jira.py
@@ -68,7 +68,7 @@ async def get_cloud_id(access_token: str, context: ExecutionContext) -> str:
     if jira_resource:
         return jira_resource["id"]
 
-    return resources[0]["id"]
+    return resources.data[0]["id"]
 
 
 def api_url(cloud_id: str, path: str) -> str:
@@ -222,9 +222,9 @@ class CreateIssueAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "issueId": body.get("id") if isinstance(body, dict) else None,
-                    "issueKey": body.get("key") if isinstance(body, dict) else None,
-                    "issueUrl": body.get("self") if isinstance(body, dict) else None,
+                    "issueId": body.data.get("id") if isinstance(body, dict) else None,
+                    "issueKey": body.data.get("key") if isinstance(body, dict) else None,
+                    "issueUrl": body.data.get("self") if isinstance(body, dict) else None,
                     "message": "Issue created successfully",
                 },
                 cost_usd=None,
@@ -261,7 +261,7 @@ class GetIssueAction(ActionHandler):
             url = api_url(cloud_id, f"/issue/{safe_path(issue_key)}")
             body = await jira_request("GET", url, access_token, context, params=params or None)
 
-            fields_data = body.get("fields", {}) if isinstance(body, dict) else {}
+            fields_data = body.data.get("fields", {}) if isinstance(body, dict) else {}
             assignee = fields_data.get("assignee") or {}
             reporter = fields_data.get("reporter") or {}
             status = fields_data.get("status") or {}
@@ -272,8 +272,8 @@ class GetIssueAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "issueId": body.get("id"),
-                    "issueKey": body.get("key"),
+                    "issueId": body.data.get("id"),
+                    "issueKey": body.data.get("key"),
                     "summary": fields_data.get("summary"),
                     "description": fields_data.get("description"),
                     "status": status.get("name"),
@@ -295,7 +295,7 @@ class GetIssueAction(ActionHandler):
                     "subtasks": fields_data.get("subtasks", []),
                     "parent": fields_data.get("parent"),
                     "rawFields": fields_data,
-                    "issueUrl": body.get("self"),
+                    "issueUrl": body.data.get("self"),
                 },
                 cost_usd=None,
             )
@@ -462,7 +462,7 @@ class SearchIssuesAction(ActionHandler):
             body = await jira_request("POST", url, access_token, context, payload=payload)
 
             issues = []
-            for issue in body.get("issues") or []:
+            for issue in body.data.get("issues") or []:
                 f = issue.get("fields") or {}
                 status = f.get("status") or {}
                 assignee = f.get("assignee") or {}
@@ -488,9 +488,9 @@ class SearchIssuesAction(ActionHandler):
                 data={
                     "result": True,
                     "issues": issues,
-                    "total": body.get("total", len(issues)),
-                    "maxResults": body.get("maxResults", max_results),
-                    "nextPageToken": body.get("nextPageToken"),
+                    "total": body.data.get("total", len(issues)),
+                    "maxResults": body.data.get("maxResults", max_results),
+                    "nextPageToken": body.data.get("nextPageToken"),
                 },
                 cost_usd=None,
             )
@@ -518,7 +518,7 @@ class GetIssueTransitionsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context)
 
             transitions = []
-            for t in body.get("transitions") or []:
+            for t in body.data.get("transitions") or []:
                 to_status = t.get("to") or {}
                 transitions.append(
                     {
@@ -700,7 +700,7 @@ class GetCommentsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             comments = []
-            for c in body.get("comments") or []:
+            for c in body.data.get("comments") or []:
                 author = c.get("author") or {}
                 comments.append(
                     {
@@ -718,8 +718,8 @@ class GetCommentsAction(ActionHandler):
                     "result": True,
                     "issueKey": issue_key,
                     "comments": comments,
-                    "total": body.get("total", len(comments)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(comments)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -848,7 +848,7 @@ class ListProjectsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             projects = []
-            for p in body.get("values") or []:
+            for p in body.data.get("values") or []:
                 lead = p.get("lead") or {}
                 projects.append(
                     {
@@ -868,8 +868,8 @@ class ListProjectsAction(ActionHandler):
                 data={
                     "result": True,
                     "projects": projects,
-                    "total": body.get("total", len(projects)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(projects)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -902,32 +902,32 @@ class GetProjectAction(ActionHandler):
             url = api_url(cloud_id, f"/project/{safe_path(project_key)}")
             body = await jira_request("GET", url, access_token, context, params=params or None)
 
-            lead = (body.get("lead") or {}) if isinstance(body, dict) else {}
+            lead = (body.data.get("lead") or {}) if isinstance(body, dict) else {}
 
             return ActionResult(
                 data={
                     "result": True,
-                    "projectId": body.get("id"),
-                    "projectKey": body.get("key"),
-                    "name": body.get("name"),
-                    "description": body.get("description"),
-                    "projectType": body.get("projectTypeKey"),
-                    "style": body.get("style"),
+                    "projectId": body.data.get("id"),
+                    "projectKey": body.data.get("key"),
+                    "name": body.data.get("name"),
+                    "description": body.data.get("description"),
+                    "projectType": body.data.get("projectTypeKey"),
+                    "style": body.data.get("style"),
                     "leadDisplayName": lead.get("displayName"),
                     "leadAccountId": lead.get("accountId"),
                     "issueTypes": [
-                        {"id": it.get("id"), "name": it.get("name")} for it in (body.get("issueTypes") or [])
+                        {"id": it.get("id"), "name": it.get("name")} for it in (body.data.get("issueTypes") or [])
                     ],
-                    "components": [{"id": c.get("id"), "name": c.get("name")} for c in (body.get("components") or [])],
+                    "components": [{"id": c.get("id"), "name": c.get("name")} for c in (body.data.get("components") or [])],
                     "versions": [
                         {
                             "id": v.get("id"),
                             "name": v.get("name"),
                             "released": v.get("released"),
                         }
-                        for v in (body.get("versions") or [])
+                        for v in (body.data.get("versions") or [])
                     ],
-                    "url": body.get("self"),
+                    "url": body.data.get("self"),
                 },
                 cost_usd=None,
             )
@@ -1012,7 +1012,7 @@ class GetProjectVersionsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             versions = []
-            for v in body.get("values") or []:
+            for v in body.data.get("values") or []:
                 versions.append(
                     {
                         "versionId": v.get("id"),
@@ -1031,8 +1031,8 @@ class GetProjectVersionsAction(ActionHandler):
                     "result": True,
                     "projectKey": project_key,
                     "versions": versions,
-                    "total": body.get("total", len(versions)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(versions)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -1081,8 +1081,8 @@ class CreateProjectVersionAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "versionId": body.get("id") if isinstance(body, dict) else None,
-                    "name": body.get("name") if isinstance(body, dict) else None,
+                    "versionId": body.data.get("id") if isinstance(body, dict) else None,
+                    "name": body.data.get("name") if isinstance(body, dict) else None,
                     "projectKey": project_key,
                     "message": "Version created successfully",
                 },
@@ -1113,13 +1113,13 @@ class GetCurrentUserAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "accountId": body.get("accountId") if isinstance(body, dict) else None,
-                    "displayName": body.get("displayName") if isinstance(body, dict) else None,
-                    "emailAddress": body.get("emailAddress") if isinstance(body, dict) else None,
-                    "active": body.get("active") if isinstance(body, dict) else None,
-                    "locale": body.get("locale") if isinstance(body, dict) else None,
-                    "timeZone": body.get("timeZone") if isinstance(body, dict) else None,
-                    "avatarUrls": body.get("avatarUrls") if isinstance(body, dict) else None,
+                    "accountId": body.data.get("accountId") if isinstance(body, dict) else None,
+                    "displayName": body.data.get("displayName") if isinstance(body, dict) else None,
+                    "emailAddress": body.data.get("emailAddress") if isinstance(body, dict) else None,
+                    "active": body.data.get("active") if isinstance(body, dict) else None,
+                    "locale": body.data.get("locale") if isinstance(body, dict) else None,
+                    "timeZone": body.data.get("timeZone") if isinstance(body, dict) else None,
+                    "avatarUrls": body.data.get("avatarUrls") if isinstance(body, dict) else None,
                 },
                 cost_usd=None,
             )
@@ -1151,12 +1151,12 @@ class GetUserAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "accountId": body.get("accountId") if isinstance(body, dict) else None,
-                    "displayName": body.get("displayName") if isinstance(body, dict) else None,
-                    "emailAddress": body.get("emailAddress") if isinstance(body, dict) else None,
-                    "active": body.get("active") if isinstance(body, dict) else None,
-                    "timeZone": body.get("timeZone") if isinstance(body, dict) else None,
-                    "avatarUrls": body.get("avatarUrls") if isinstance(body, dict) else None,
+                    "accountId": body.data.get("accountId") if isinstance(body, dict) else None,
+                    "displayName": body.data.get("displayName") if isinstance(body, dict) else None,
+                    "emailAddress": body.data.get("emailAddress") if isinstance(body, dict) else None,
+                    "active": body.data.get("active") if isinstance(body, dict) else None,
+                    "timeZone": body.data.get("timeZone") if isinstance(body, dict) else None,
+                    "avatarUrls": body.data.get("avatarUrls") if isinstance(body, dict) else None,
                 },
                 cost_usd=None,
             )
@@ -1241,7 +1241,7 @@ class ListBoardsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             boards = []
-            for b in body.get("values") or []:
+            for b in body.data.get("values") or []:
                 location = b.get("location") or {}
                 boards.append(
                     {
@@ -1258,8 +1258,8 @@ class ListBoardsAction(ActionHandler):
                 data={
                     "result": True,
                     "boards": boards,
-                    "total": body.get("total", len(boards)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(boards)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -1295,7 +1295,7 @@ class GetSprintsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             sprints = []
-            for s in body.get("values") or []:
+            for s in body.data.get("values") or []:
                 sprints.append(
                     {
                         "sprintId": s.get("id"),
@@ -1314,8 +1314,8 @@ class GetSprintsAction(ActionHandler):
                     "result": True,
                     "boardId": board_id,
                     "sprints": sprints,
-                    "total": body.get("total", len(sprints)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(sprints)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -1356,7 +1356,7 @@ class GetSprintIssuesAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             issues = []
-            for issue in body.get("issues") or []:
+            for issue in body.data.get("issues") or []:
                 f = issue.get("fields") or {}
                 status = f.get("status") or {}
                 assignee = f.get("assignee") or {}
@@ -1380,8 +1380,8 @@ class GetSprintIssuesAction(ActionHandler):
                     "result": True,
                     "sprintId": sprint_id,
                     "issues": issues,
-                    "total": body.get("total", len(issues)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(issues)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -1434,18 +1434,18 @@ class AddWorklogAction(ActionHandler):
             url = api_url(cloud_id, f"/issue/{safe_path(issue_key)}/worklog")
             body = await jira_request("POST", url, access_token, context, params=params, payload=payload)
 
-            author = (body.get("author") or {}) if isinstance(body, dict) else {}
+            author = (body.data.get("author") or {}) if isinstance(body, dict) else {}
 
             return ActionResult(
                 data={
                     "result": True,
-                    "worklogId": body.get("id") if isinstance(body, dict) else None,
+                    "worklogId": body.data.get("id") if isinstance(body, dict) else None,
                     "issueKey": issue_key,
-                    "timeSpent": body.get("timeSpent") if isinstance(body, dict) else None,
-                    "timeSpentSeconds": body.get("timeSpentSeconds") if isinstance(body, dict) else None,
+                    "timeSpent": body.data.get("timeSpent") if isinstance(body, dict) else None,
+                    "timeSpentSeconds": body.data.get("timeSpentSeconds") if isinstance(body, dict) else None,
                     "authorDisplayName": author.get("displayName"),
                     "authorAccountId": author.get("accountId"),
-                    "started": body.get("started") if isinstance(body, dict) else None,
+                    "started": body.data.get("started") if isinstance(body, dict) else None,
                     "message": "Worklog added successfully",
                 },
                 cost_usd=None,
@@ -1479,7 +1479,7 @@ class GetWorklogsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             worklogs = []
-            for w in body.get("worklogs") or []:
+            for w in body.data.get("worklogs") or []:
                 author = w.get("author") or {}
                 worklogs.append(
                     {
@@ -1499,8 +1499,8 @@ class GetWorklogsAction(ActionHandler):
                     "result": True,
                     "issueKey": issue_key,
                     "worklogs": worklogs,
-                    "total": body.get("total", len(worklogs)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(worklogs)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -1573,7 +1573,7 @@ class GetIssueLinkTypesAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context)
 
             link_types = []
-            for lt in body.get("issueLinkTypes") or []:
+            for lt in body.data.get("issueLinkTypes") or []:
                 link_types.append(
                     {
                         "id": lt.get("id"),
@@ -1651,7 +1651,7 @@ class GetWatchersAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context)
 
             watchers = []
-            for w in body.get("watchers") or []:
+            for w in body.data.get("watchers") or []:
                 watchers.append(
                     {
                         "accountId": w.get("accountId"),
@@ -1664,8 +1664,8 @@ class GetWatchersAction(ActionHandler):
                 data={
                     "result": True,
                     "issueKey": issue_key,
-                    "watchCount": body.get("watchCount", len(watchers)) if isinstance(body, dict) else len(watchers),
-                    "isWatching": body.get("isWatching") if isinstance(body, dict) else None,
+                    "watchCount": body.data.get("watchCount", len(watchers)) if isinstance(body, dict) else len(watchers),
+                    "isWatching": body.data.get("isWatching") if isinstance(body, dict) else None,
                     "watchers": watchers,
                 },
                 cost_usd=None,
@@ -1836,7 +1836,7 @@ class GetIssueChangelogAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             changelog = []
-            for entry in body.get("values") or []:
+            for entry in body.data.get("values") or []:
                 author = entry.get("author") or {}
                 items = []
                 for item in entry.get("items") or []:
@@ -1865,8 +1865,8 @@ class GetIssueChangelogAction(ActionHandler):
                     "result": True,
                     "issueKey": issue_key,
                     "changelog": changelog,
-                    "total": body.get("total", len(changelog)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(changelog)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -1917,10 +1917,10 @@ class BulkCreateIssuesAction(ActionHandler):
             body = await jira_request("POST", url, access_token, context, payload=payload)
 
             created = []
-            for issue in body.get("issues") or []:
+            for issue in body.data.get("issues") or []:
                 created.append({"issueId": issue.get("id"), "issueKey": issue.get("key")})
 
-            errors = body.get("errors", []) if isinstance(body, dict) else []
+            errors = body.data.get("errors", []) if isinstance(body, dict) else []
 
             return ActionResult(
                 data={
@@ -1969,7 +1969,7 @@ class GetBoardIssuesAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             issues = []
-            for issue in body.get("issues") or []:
+            for issue in body.data.get("issues") or []:
                 f = issue.get("fields") or {}
                 status = f.get("status") or {}
                 assignee = f.get("assignee") or {}
@@ -1993,8 +1993,8 @@ class GetBoardIssuesAction(ActionHandler):
                     "result": True,
                     "boardId": board_id,
                     "issues": issues,
-                    "total": body.get("total", len(issues)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(issues)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -2035,7 +2035,7 @@ class GetBacklogIssuesAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             issues = []
-            for issue in body.get("issues") or []:
+            for issue in body.data.get("issues") or []:
                 f = issue.get("fields") or {}
                 status = f.get("status") or {}
                 assignee = f.get("assignee") or {}
@@ -2055,8 +2055,8 @@ class GetBacklogIssuesAction(ActionHandler):
                     "result": True,
                     "boardId": board_id,
                     "issues": issues,
-                    "total": body.get("total", len(issues)),
-                    "startAt": body.get("startAt", start_at),
+                    "total": body.data.get("total", len(issues)),
+                    "startAt": body.data.get("startAt", start_at),
                 },
                 cost_usd=None,
             )
@@ -2140,9 +2140,9 @@ class CreateSprintAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "sprintId": body.get("id") if isinstance(body, dict) else None,
-                    "name": body.get("name") if isinstance(body, dict) else None,
-                    "state": body.get("state") if isinstance(body, dict) else None,
+                    "sprintId": body.data.get("id") if isinstance(body, dict) else None,
+                    "name": body.data.get("name") if isinstance(body, dict) else None,
+                    "state": body.data.get("state") if isinstance(body, dict) else None,
                     "boardId": board_id,
                     "message": "Sprint created successfully",
                 },
@@ -2200,8 +2200,8 @@ class UpdateSprintAction(ActionHandler):
                 data={
                     "result": True,
                     "sprintId": sprint_id,
-                    "name": body.get("name") if isinstance(body, dict) else None,
-                    "state": body.get("state") if isinstance(body, dict) else None,
+                    "name": body.data.get("name") if isinstance(body, dict) else None,
+                    "state": body.data.get("state") if isinstance(body, dict) else None,
                     "message": "Sprint updated successfully",
                 },
                 cost_usd=None,
@@ -2316,7 +2316,7 @@ class ListDashboardsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             dashboards = []
-            for d in body.get("dashboards", []) if isinstance(body, dict) else []:
+            for d in body.data.get("dashboards", []) if isinstance(body, dict) else []:
                 dashboards.append(
                     {
                         "id": d.get("id"),
@@ -2332,8 +2332,8 @@ class ListDashboardsAction(ActionHandler):
                 data={
                     "result": True,
                     "dashboards": dashboards,
-                    "total": body.get("total") if isinstance(body, dict) else None,
-                    "startAt": body.get("startAt") if isinstance(body, dict) else None,
+                    "total": body.data.get("total") if isinstance(body, dict) else None,
+                    "startAt": body.data.get("startAt") if isinstance(body, dict) else None,
                     "count": len(dashboards),
                 },
                 cost_usd=None,
@@ -2364,16 +2364,16 @@ class GetDashboardAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "id": body.get("id"),
-                    "name": body.get("name"),
-                    "self": body.get("self"),
-                    "view": body.get("view"),
-                    "isFavourite": body.get("isFavourite"),
-                    "owner": body.get("owner", {}).get("displayName") if isinstance(body.get("owner"), dict) else None,
-                    "popularity": body.get("popularity"),
-                    "rank": body.get("rank"),
-                    "sharePermissions": body.get("sharePermissions", []),
-                    "editPermissions": body.get("editPermissions", []),
+                    "id": body.data.get("id"),
+                    "name": body.data.get("name"),
+                    "self": body.data.get("self"),
+                    "view": body.data.get("view"),
+                    "isFavourite": body.data.get("isFavourite"),
+                    "owner": body.data.get("owner", {}).get("displayName") if isinstance(body.data.get("owner"), dict) else None,
+                    "popularity": body.data.get("popularity"),
+                    "rank": body.data.get("rank"),
+                    "sharePermissions": body.data.get("sharePermissions", []),
+                    "editPermissions": body.data.get("editPermissions", []),
                 },
                 cost_usd=None,
             )
@@ -2420,7 +2420,7 @@ class SearchDashboardsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context, params=params)
 
             dashboards = []
-            for d in body.get("values", []) if isinstance(body, dict) else []:
+            for d in body.data.get("values", []) if isinstance(body, dict) else []:
                 dashboards.append(
                     {
                         "id": d.get("id"),
@@ -2436,8 +2436,8 @@ class SearchDashboardsAction(ActionHandler):
                 data={
                     "result": True,
                     "dashboards": dashboards,
-                    "total": body.get("total") if isinstance(body, dict) else None,
-                    "startAt": body.get("startAt") if isinstance(body, dict) else None,
+                    "total": body.data.get("total") if isinstance(body, dict) else None,
+                    "startAt": body.data.get("startAt") if isinstance(body, dict) else None,
                     "count": len(dashboards),
                 },
                 cost_usd=None,
@@ -2466,7 +2466,7 @@ class GetDashboardGadgetsAction(ActionHandler):
             body = await jira_request("GET", url, access_token, context)
 
             gadgets = []
-            for g in body.get("gadgets", []) if isinstance(body, dict) else []:
+            for g in body.data.get("gadgets", []) if isinstance(body, dict) else []:
                 gadgets.append(
                     {
                         "id": g.get("id"),

--- a/jira/requirements.txt
+++ b/jira/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/linkedin-ads/linkedin_ads.py
+++ b/linkedin-ads/linkedin_ads.py
@@ -77,7 +77,7 @@ async def make_request(
         else:
             return {"success": False, "error": f"Unsupported HTTP method: {method}"}
 
-        return {"success": True, "data": response}
+        return {"success": True, "data": response.data}
     except Exception as e:
         error_message = str(e)
         error_details = {"raw_error": error_message}

--- a/linkedin-ads/requirements.txt
+++ b/linkedin-ads/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -48,8 +48,8 @@ async def get_current_user_urn(context: ExecutionContext) -> str:
     user_info_url = "https://api.linkedin.com/v2/userinfo"
     user_response = await context.fetch(user_info_url, method="GET")
 
-    if isinstance(user_response, dict) and user_response.get("sub"):
-        return f"urn:li:person:{user_response.get('sub')}"
+    if isinstance(user_response, dict) and user_response.data.get("sub"):
+        return f"urn:li:person:{user_response.data.get('sub')}"
     raise ValueError("Could not determine current user. Please ensure proper authentication.")
 
 
@@ -72,7 +72,7 @@ async def post_to_linkedin(url: str, payload: dict, access_token: str) -> Tuple[
             body = None
             if response.content_length and response.content_length > 0:
                 try:
-                    body = await response.json()
+                    body = await response.data
                 except Exception:
                     body = await response.text()
 
@@ -105,7 +105,7 @@ async def initialize_image_upload(context: ExecutionContext, owner_urn: str) -> 
     response = await context.fetch(url, method="POST", json=payload, headers=get_linkedin_headers())
 
     if isinstance(response, dict) and "value" in response:
-        value = response["value"]
+        value = response.data["value"]
         return {"upload_url": value.get("uploadUrl"), "image_urn": value.get("image")}
 
     raise ValueError(f"Failed to initialize image upload: {response}")
@@ -211,15 +211,15 @@ class UserInfoActionHandler(ActionHandler):
 
         response = await context.fetch(url, method="GET")
 
-        if isinstance(response, dict) and response.get("sub"):
+        if isinstance(response, dict) and response.data.get("sub"):
             return ActionResult(
                 data={
                     "result": "User information retrieved successfully.",
-                    "user_info": response,
+                    "user_info": response.data,
                 }
             )
         else:
-            error_details = response.get("error", "Unknown error") if isinstance(response, dict) else "Unknown error"
+            error_details = response.data.get("error", "Unknown error") if isinstance(response, dict) else "Unknown error"
             return ActionResult(
                 data={
                     "result": "Failed to retrieve user information.",
@@ -582,7 +582,7 @@ class GetPostActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=get_linkedin_headers())
 
-            return ActionResult(data={"result": "Post retrieved successfully.", "post": response})
+            return ActionResult(data={"result": "Post retrieved successfully.", "post": response.data})
         except Exception as e:
             error_message = str(e)
             error_details = getattr(e, "response_data", str(e))
@@ -629,8 +629,8 @@ class GetPostsActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=headers)
 
-            posts = response.get("elements", []) if isinstance(response, dict) else []
-            paging = response.get("paging") if isinstance(response, dict) else None
+            posts = response.data.get("elements", []) if isinstance(response, dict) else []
+            paging = response.data.get("paging") if isinstance(response, dict) else None
 
             return ActionResult(
                 data={
@@ -728,8 +728,8 @@ class GetCommentsActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=get_linkedin_headers())
 
-            comments = response.get("elements", []) if isinstance(response, dict) else []
-            paging = response.get("paging") if isinstance(response, dict) else None
+            comments = response.data.get("elements", []) if isinstance(response, dict) else []
+            paging = response.data.get("paging") if isinstance(response, dict) else None
 
             return ActionResult(
                 data={
@@ -783,13 +783,13 @@ class CreateCommentActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="POST", json=payload, headers=get_linkedin_headers())
 
-            comment_id = response.get("id") if isinstance(response, dict) else None
+            comment_id = response.data.get("id") if isinstance(response, dict) else None
 
             return ActionResult(
                 data={
                     "result": "Comment created successfully.",
                     "comment_id": comment_id,
-                    "comment": response,
+                    "comment": response.data,
                 }
             )
         except Exception as e:
@@ -871,8 +871,8 @@ class GetReactionsActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="GET", headers=get_linkedin_headers())
 
-            reactions = response.get("elements", []) if isinstance(response, dict) else []
-            paging = response.get("paging") if isinstance(response, dict) else None
+            reactions = response.data.get("elements", []) if isinstance(response, dict) else []
+            paging = response.data.get("paging") if isinstance(response, dict) else None
 
             return ActionResult(
                 data={
@@ -925,7 +925,7 @@ class CreateReactionActionHandler(ActionHandler):
         try:
             response = await context.fetch(url, method="POST", json=payload, headers=get_linkedin_headers())
 
-            return ActionResult(data={"result": "Reaction created successfully.", "reaction": response})
+            return ActionResult(data={"result": "Reaction created successfully.", "reaction": response.data})
         except Exception as e:
             error_message = str(e)
             error_details = getattr(e, "response_data", str(e))

--- a/linkedin/requirements.txt
+++ b/linkedin/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/mailchimp/mailchimp.py
+++ b/mailchimp/mailchimp.py
@@ -151,8 +151,8 @@ class GetListsAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "lists": response.get("lists", []),
-                    "total_items": response.get("total_items", 0),
+                    "lists": response.data.get("lists", []),
+                    "total_items": response.data.get("total_items", 0),
                 },
                 cost_usd=0.0,
             )
@@ -203,7 +203,7 @@ class FindListAction(ActionHandler):
             # Search for matching list (case-insensitive)
             search_name = name.lower()
             matching_list = None
-            for lst in response.get("lists", []):
+            for lst in response.data.get("lists", []):
                 if search_name in lst.get("name", "").lower():
                     matching_list = lst
                     break
@@ -250,7 +250,7 @@ class GetListAction(ActionHandler):
             # Make rate-limited request
             response = await rate_limiter.make_request(context, url, method="GET")
 
-            return ActionResult(data={"result": True, "list": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "list": response.data}, cost_usd=0.0)
 
         except MailchimpRateLimitException as e:
             return ActionResult(
@@ -314,7 +314,7 @@ class CreateListAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "list": {"id": response.get("id"), "name": response.get("name")},
+                    "list": {"id": response.data.get("id"), "name": response.data.get("name")},
                 },
                 cost_usd=0.0,
             )
@@ -377,9 +377,9 @@ class AddMemberAction(ActionHandler):
                 data={
                     "result": True,
                     "member": {
-                        "id": response.get("id"),
-                        "email_address": response.get("email_address"),
-                        "status": response.get("status"),
+                        "id": response.data.get("id"),
+                        "email_address": response.data.get("email_address"),
+                        "status": response.data.get("status"),
                     },
                 },
                 cost_usd=0.0,
@@ -452,9 +452,9 @@ class UpdateMemberAction(ActionHandler):
                 data={
                     "result": True,
                     "member": {
-                        "id": response.get("id"),
-                        "email_address": response.get("email_address"),
-                        "status": response.get("status"),
+                        "id": response.data.get("id"),
+                        "email_address": response.data.get("email_address"),
+                        "status": response.data.get("status"),
                     },
                 },
                 cost_usd=0.0,
@@ -514,10 +514,10 @@ class GetMemberAction(ActionHandler):
                 data={
                     "result": True,
                     "member": {
-                        "id": response.get("id"),
-                        "email_address": response.get("email_address"),
-                        "status": response.get("status"),
-                        "merge_fields": response.get("merge_fields", {}),
+                        "id": response.data.get("id"),
+                        "email_address": response.data.get("email_address"),
+                        "status": response.data.get("status"),
+                        "merge_fields": response.data.get("merge_fields", {}),
                     },
                 },
                 cost_usd=0.0,
@@ -576,8 +576,8 @@ class GetListMembersAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "members": response.get("members", []),
-                    "total_items": response.get("total_items", 0),
+                    "members": response.data.get("members", []),
+                    "total_items": response.data.get("total_items", 0),
                 },
                 cost_usd=0.0,
             )
@@ -633,7 +633,7 @@ class FindCampaignAction(ActionHandler):
             # Search for matching campaign (case-insensitive in title or subject_line)
             search_query = query.lower()
             matching_campaign = None
-            for campaign in response.get("campaigns", []):
+            for campaign in response.data.get("campaigns", []):
                 settings = campaign.get("settings", {})
                 title = settings.get("title", "").lower()
                 subject_line = settings.get("subject_line", "").lower()
@@ -692,8 +692,8 @@ class GetCampaignsAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "campaigns": response.get("campaigns", []),
-                    "total_items": response.get("total_items", 0),
+                    "campaigns": response.data.get("campaigns", []),
+                    "total_items": response.data.get("total_items", 0),
                 },
                 cost_usd=0.0,
             )
@@ -777,9 +777,9 @@ class CreateCampaignAction(ActionHandler):
                 data={
                     "result": True,
                     "campaign": {
-                        "id": response.get("id"),
-                        "type": response.get("type"),
-                        "status": response.get("status"),
+                        "id": response.data.get("id"),
+                        "type": response.data.get("type"),
+                        "status": response.data.get("status"),
                     },
                 },
                 cost_usd=0.0,
@@ -819,7 +819,7 @@ class GetCampaignAction(ActionHandler):
             # Make rate-limited request
             response = await rate_limiter.make_request(context, url, method="GET")
 
-            return ActionResult(data={"result": True, "campaign": response}, cost_usd=0.0)
+            return ActionResult(data={"result": True, "campaign": response.data}, cost_usd=0.0)
 
         except MailchimpRateLimitException as e:
             return ActionResult(
@@ -857,12 +857,12 @@ class MailchimpConnectedAccountHandler(ConnectedAccountHandler):
             # Extract relevant account information
             # Mailchimp returns: account_id, account_name, email, role, etc.
             return ConnectedAccountInfo(
-                email=response.get("email"),
-                username=response.get("username") or response.get("login_name"),
-                first_name=response.get("first_name"),
-                last_name=response.get("last_name"),
-                organization=response.get("account_name"),
-                user_id=response.get("account_id"),
+                email=response.data.get("email"),
+                username=response.data.get("username") or response.data.get("login_name"),
+                first_name=response.data.get("first_name"),
+                last_name=response.data.get("last_name"),
+                organization=response.data.get("account_name"),
+                user_id=response.data.get("account_id"),
             )
 
         except Exception as e:

--- a/mailchimp/requirements.txt
+++ b/mailchimp/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/microsoft-excel/microsoft_excel.py
+++ b/microsoft-excel/microsoft_excel.py
@@ -55,7 +55,7 @@ class ListWorkbooks(ActionHandler):
 
             response = await context.fetch(url, method="GET", params=params)
 
-            items = response.get("value", [])
+            items = response.data.get("value", [])
 
             workbooks = []
             for item in items:
@@ -73,7 +73,7 @@ class ListWorkbooks(ActionHandler):
                     )
 
             result_data = {"workbooks": workbooks, "result": True}
-            next_link = response.get("@odata.nextLink")
+            next_link = response.data.get("@odata.nextLink")
             if next_link:
                 result_data["next_page_token"] = next_link
 
@@ -105,7 +105,7 @@ class GetWorkbook(ActionHandler):
             worksheets = []
             try:
                 ws_data = await context.fetch(worksheets_url, method="GET")
-                for ws in ws_data.get("value", []):
+                for ws in ws_data.data.get("value", []):
                     worksheets.append(
                         {
                             "id": ws.get("id"),
@@ -123,7 +123,7 @@ class GetWorkbook(ActionHandler):
             tables = []
             try:
                 tables_data = await context.fetch(tables_url, method="GET")
-                for table in tables_data.get("value", []):
+                for table in tables_data.data.get("value", []):
                     tables.append(
                         {
                             "id": table.get("id"),
@@ -142,7 +142,7 @@ class GetWorkbook(ActionHandler):
             named_ranges = []
             try:
                 names_data = await context.fetch(names_url, method="GET")
-                for name in names_data.get("value", []):
+                for name in names_data.data.get("value", []):
                     named_ranges.append(
                         {
                             "name": name.get("name"),
@@ -157,10 +157,10 @@ class GetWorkbook(ActionHandler):
             return ActionResult(
                 data={
                     "workbook": {
-                        "id": file_data.get("id"),
-                        "name": file_data.get("name"),
-                        "webUrl": file_data.get("webUrl"),
-                        "lastModifiedDateTime": file_data.get("lastModifiedDateTime"),
+                        "id": file_data.data.get("id"),
+                        "name": file_data.data.get("name"),
+                        "webUrl": file_data.data.get("webUrl"),
+                        "lastModifiedDateTime": file_data.data.get("lastModifiedDateTime"),
                     },
                     "worksheets": worksheets,
                     "tables": tables,
@@ -190,7 +190,7 @@ class ListWorksheets(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             worksheets = []
-            for ws in response.get("value", []):
+            for ws in response.data.get("value", []):
                 worksheets.append(
                     {
                         "id": ws.get("id"),
@@ -230,16 +230,16 @@ class ReadRange(ActionHandler):
             )
             response = await context.fetch(url, method="GET")
 
-            values = response.get("values", [])
-            formulas = response.get("formulas", []) if value_render_option == "FORMULA" else []
-            number_format = response.get("numberFormat", [])
+            values = response.data.get("values", [])
+            formulas = response.data.get("formulas", []) if value_render_option == "FORMULA" else []
+            number_format = response.data.get("numberFormat", [])
 
             row_count = len(values)
             column_count = len(values[0]) if values else 0
 
             return ActionResult(
                 data={
-                    "range": response.get("address", range_address),
+                    "range": response.data.get("address", range_address),
                     "values": values,
                     "formulas": formulas,
                     "number_format": number_format,
@@ -284,7 +284,7 @@ class WriteRange(ActionHandler):
 
             return ActionResult(
                 data={
-                    "updated_range": response.get("address", range_address),
+                    "updated_range": response.data.get("address", range_address),
                     "updated_rows": row_count,
                     "updated_columns": column_count,
                     "updated_cells": row_count * column_count,
@@ -319,7 +319,7 @@ class ListTables(ActionHandler):
             response = await context.fetch(url, method="GET")
 
             tables = []
-            for table in response.get("value", []):
+            for table in response.data.get("value", []):
                 tables.append(
                     {
                         "id": table.get("id"),
@@ -359,7 +359,7 @@ class GetTableData(ActionHandler):
             # Get headers
             header_url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/tables/{encoded_table}/headerRowRange"
             header_data = await context.fetch(header_url, method="GET")
-            all_headers = header_data.get("values", [[]])[0]
+            all_headers = header_data.data.get("values", [[]])[0]
 
             # Validate select_columns if specified
             if select_columns:
@@ -376,7 +376,7 @@ class GetTableData(ActionHandler):
             # Get rows
             rows_url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/tables/{encoded_table}/dataBodyRange"
             rows_data = await context.fetch(rows_url, method="GET")
-            all_rows = rows_data.get("values", [])
+            all_rows = rows_data.data.get("values", [])
 
             # Check max_rows safety limit
             if max_rows and len(all_rows) > max_rows:
@@ -457,7 +457,7 @@ class AddTableRow(ActionHandler):
             table_range = ""
             try:
                 range_data = await context.fetch(range_url, method="GET")
-                table_range = range_data.get("address", "")
+                table_range = range_data.data.get("address", "")
             except Exception:  # nosec B110
                 # API error handled - rows were added, range info is optional
                 pass
@@ -500,9 +500,9 @@ class GetUsedRange(ActionHandler):
                 url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/worksheets/{encoded_ws}/usedRange"
 
             response = await context.fetch(url, method="GET")
-            values = response.get("values", [])
-            row_count = response.get("rowCount", len(values))
-            column_count = response.get("columnCount", len(values[0]) if values else 0)
+            values = response.data.get("values", [])
+            row_count = response.data.get("rowCount", len(values))
+            column_count = response.data.get("columnCount", len(values[0]) if values else 0)
             cell_count = row_count * column_count
 
             # Check max_cells safety limit
@@ -521,7 +521,7 @@ class GetUsedRange(ActionHandler):
 
             return ActionResult(
                 data={
-                    "range": response.get("address", ""),
+                    "range": response.data.get("address", ""),
                     "row_count": row_count,
                     "column_count": column_count,
                     "values": values,
@@ -555,10 +555,10 @@ class CreateWorksheet(ActionHandler):
             return ActionResult(
                 data={
                     "worksheet": {
-                        "id": response.get("id"),
-                        "name": response.get("name"),
-                        "position": response.get("position"),
-                        "visibility": response.get("visibility"),
+                        "id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "position": response.data.get("position"),
+                        "visibility": response.data.get("visibility"),
                     },
                     "result": True,
                 },
@@ -617,9 +617,9 @@ class CreateTable(ActionHandler):
             return ActionResult(
                 data={
                     "table": {
-                        "id": response.get("id"),
-                        "name": response.get("name"),
-                        "showHeaders": response.get("showHeaders"),
+                        "id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "showHeaders": response.data.get("showHeaders"),
                     },
                     "result": True,
                 },
@@ -654,7 +654,7 @@ class UpdateTableRow(ActionHandler):
             body = {"values": [values]}
             response = await context.fetch(url, method="PATCH", json=body)
 
-            return ActionResult(data={"updated_row": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"updated_row": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -751,7 +751,7 @@ class ApplyFilter(ActionHandler):
             columns_url = f"{GRAPH_BASE_URL}/me/drive/items/{workbook_id}/workbook/tables/{encoded_table}/columns"
             columns_data = await context.fetch(columns_url, method="GET")
 
-            columns = columns_data.get("value", [])
+            columns = columns_data.data.get("value", [])
             if column_index < 0 or column_index >= len(columns):
                 return ActionResult(
                     data={

--- a/microsoft-excel/requirements.txt
+++ b/microsoft-excel/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/microsoft-planner/microsoft_planner.py
+++ b/microsoft-planner/microsoft_planner.py
@@ -34,7 +34,7 @@ async def get_etag(context: ExecutionContext, resource_url: str) -> Optional[str
     try:
         response = await context.fetch(resource_url, method="GET")
         # ETag is returned in the response with @odata.etag key
-        return response.get("@odata.etag")
+        return response.data.get("@odata.etag")
     except Exception:
         return None
 
@@ -63,7 +63,7 @@ class ListGroupsAction(ActionHandler):
                 params=params,
             )
 
-            groups = response.get("value", [])
+            groups = response.data.get("value", [])
             return ActionResult(data={"groups": groups, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -86,7 +86,7 @@ class GetUserByEmailAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/users", method="GET", params=params)
 
-            users = response.get("value", [])
+            users = response.data.get("value", [])
 
             if users:
                 user = users[0]
@@ -139,7 +139,7 @@ class SearchUsersAction(ActionHandler):
                 headers=headers,
             )
 
-            users = response.get("value", [])
+            users = response.data.get("value", [])
 
             # Format users for easier consumption
             formatted_users = [
@@ -168,10 +168,10 @@ class GetCurrentUserAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "user": response,
-                    "user_id": response.get("id"),
-                    "display_name": response.get("displayName"),
-                    "email": response.get("mail") or response.get("userPrincipalName"),
+                    "user": response.data,
+                    "user_id": response.data.get("id"),
+                    "display_name": response.data.get("displayName"),
+                    "email": response.data.get("mail") or response.data.get("userPrincipalName"),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -191,7 +191,7 @@ class ListUserTasksAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/users/{user_id}/planner/tasks", method="GET")
 
-            tasks = response.get("value", [])
+            tasks = response.data.get("value", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -208,7 +208,7 @@ class ListUserPlansAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/users/{user_id}/planner/plans", method="GET")
 
-            plans = response.get("value", [])
+            plans = response.data.get("value", [])
             return ActionResult(data={"plans": plans, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -228,7 +228,7 @@ class ListPlansAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/groups/{group_id}/planner/plans", method="GET")
 
-            plans = response.get("value", [])
+            plans = response.data.get("value", [])
             return ActionResult(data={"plans": plans, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -245,7 +245,7 @@ class GetPlanAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans/{plan_id}", method="GET")
 
-            return ActionResult(data={"plan": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"plan": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"plan": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -281,7 +281,7 @@ class CreatePlanAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans", method="POST", json=body)
 
-            return ActionResult(data={"plan": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"plan": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"plan": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -322,7 +322,7 @@ class UpdatePlanAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"plan": response if response else {}, "result": True},
+                data={"plan": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -375,7 +375,7 @@ class GetPlanDetailsAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans/{plan_id}/details", method="GET")
 
-            return ActionResult(data={"plan_details": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"plan_details": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -428,7 +428,7 @@ class UpdatePlanDetailsAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"plan_details": response if response else {}, "result": True},
+                data={"plan_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -455,7 +455,7 @@ class ListBucketsAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets", method="GET", params=params)
 
-            buckets = response.get("value", [])
+            buckets = response.data.get("value", [])
             return ActionResult(data={"buckets": buckets, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -472,7 +472,7 @@ class GetBucketAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets/{bucket_id}", method="GET")
 
-            return ActionResult(data={"bucket": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bucket": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bucket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -493,7 +493,7 @@ class CreateBucketAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets", method="POST", json=body)
 
-            return ActionResult(data={"bucket": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"bucket": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"bucket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -534,7 +534,7 @@ class UpdateBucketAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"bucket": response if response else {}, "result": True},
+                data={"bucket": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -584,7 +584,7 @@ class ListBucketTasksAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/buckets/{bucket_id}/tasks", method="GET")
 
-            tasks = response.get("value", [])
+            tasks = response.data.get("value", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -604,7 +604,7 @@ class ListTasksAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/plans/{plan_id}/tasks", method="GET")
 
-            tasks = response.get("value", [])
+            tasks = response.data.get("value", [])
             return ActionResult(data={"tasks": tasks, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -621,7 +621,7 @@ class GetTaskAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}", method="GET")
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -677,7 +677,7 @@ class CreateTaskAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks", method="POST", json=body)
 
-            return ActionResult(data={"task": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"task": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -775,7 +775,7 @@ class UpdateTaskAction(ActionHandler):
 
             # Ensure we always return an object for task, even if response is None
             return ActionResult(
-                data={"task": response if response else {}, "result": True},
+                data={"task": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -828,7 +828,7 @@ class GetTaskDetailsAction(ActionHandler):
 
             response = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
-            return ActionResult(data={"task_details": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"task_details": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -887,7 +887,7 @@ class UpdateTaskDetailsAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"task_details": response if response else {}, "result": True},
+                data={"task_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -913,7 +913,7 @@ class AddChecklistItemAction(ActionHandler):
             current_details = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
             # Get current ETag (required for updates)
-            etag = current_details.get("@odata.etag")
+            etag = current_details.data.get("@odata.etag")
             if not etag:
                 return ActionResult(
                     data={
@@ -924,7 +924,7 @@ class AddChecklistItemAction(ActionHandler):
                 )
 
             # Get existing checklist or initialize empty dict
-            existing_checklist = current_details.get("checklist", {})
+            existing_checklist = current_details.data.get("checklist", {})
 
             # Clean existing checklist items by removing read-only fields
             # Don't include orderHint for existing items since we're not reordering them
@@ -961,7 +961,7 @@ class AddChecklistItemAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "task_details": response if response else {},
+                    "task_details": response.data if response else {},
                     "item_id": item_id,
                     "result": True,
                 },
@@ -985,7 +985,7 @@ class UpdateChecklistItemAction(ActionHandler):
             current_details = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
             # Get current ETag (required for updates)
-            etag = current_details.get("@odata.etag")
+            etag = current_details.data.get("@odata.etag")
             if not etag:
                 return ActionResult(
                     data={
@@ -996,7 +996,7 @@ class UpdateChecklistItemAction(ActionHandler):
                 )
 
             # Get existing checklist
-            existing_checklist = current_details.get("checklist", {})
+            existing_checklist = current_details.data.get("checklist", {})
 
             if item_id not in existing_checklist:
                 return ActionResult(
@@ -1036,7 +1036,7 @@ class UpdateChecklistItemAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"task_details": response if response else {}, "result": True},
+                data={"task_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1057,7 +1057,7 @@ class RemoveChecklistItemAction(ActionHandler):
             current_details = await context.fetch(f"{GRAPH_API_BASE_URL}/planner/tasks/{task_id}/details", method="GET")
 
             # Get current ETag (required for updates)
-            etag = current_details.get("@odata.etag")
+            etag = current_details.data.get("@odata.etag")
             if not etag:
                 return ActionResult(
                     data={
@@ -1068,7 +1068,7 @@ class RemoveChecklistItemAction(ActionHandler):
                 )
 
             # Get existing checklist
-            existing_checklist = current_details.get("checklist", {})
+            existing_checklist = current_details.data.get("checklist", {})
 
             if item_id not in existing_checklist:
                 return ActionResult(
@@ -1103,7 +1103,7 @@ class RemoveChecklistItemAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"task_details": response if response else {}, "result": True},
+                data={"task_details": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1127,7 +1127,7 @@ class GetTaskAssignedToBoardFormatAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"board_format": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board_format": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -1181,7 +1181,7 @@ class UpdateTaskAssignedToBoardFormatAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"board_format": response if response else {}, "result": True},
+                data={"board_format": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1205,7 +1205,7 @@ class GetTaskBucketBoardFormatAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"board_format": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board_format": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -1255,7 +1255,7 @@ class UpdateTaskBucketBoardFormatAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"board_format": response if response else {}, "result": True},
+                data={"board_format": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 
@@ -1279,7 +1279,7 @@ class GetTaskProgressBoardFormatAction(ActionHandler):
                 method="GET",
             )
 
-            return ActionResult(data={"board_format": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"board_format": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(
@@ -1329,7 +1329,7 @@ class UpdateTaskProgressBoardFormatAction(ActionHandler):
             )
 
             return ActionResult(
-                data={"board_format": response if response else {}, "result": True},
+                data={"board_format": response.data if response else {}, "result": True},
                 cost_usd=0.0,
             )
 

--- a/microsoft-planner/requirements.txt
+++ b/microsoft-planner/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/microsoft-powerpoint/microsoft_powerpoint.py
+++ b/microsoft-powerpoint/microsoft_powerpoint.py
@@ -121,7 +121,7 @@ class ListPresentationsAction(ActionHandler):
             else:
                 response = await context.fetch(base_url, method="GET", params=params)
 
-            items = response.get("value", [])
+            items = response.data.get("value", [])
             presentations = [
                 {
                     "id": item.get("id"),
@@ -133,7 +133,7 @@ class ListPresentationsAction(ActionHandler):
                 for item in items
             ]
 
-            next_page_token = response.get("@odata.nextLink")
+            next_page_token = response.data.get("@odata.nextLink")
 
             return ActionResult(
                 data={
@@ -172,15 +172,15 @@ class GetPresentationAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response.get("id"),
-                    "name": response.get("name"),
-                    "size": response.get("size"),
-                    "webUrl": response.get("webUrl"),
-                    "createdDateTime": response.get("createdDateTime"),
-                    "lastModifiedDateTime": response.get("lastModifiedDateTime"),
-                    "createdBy": response.get("createdBy"),
-                    "lastModifiedBy": response.get("lastModifiedBy"),
-                    "parentReference": response.get("parentReference"),
+                    "id": response.data.get("id"),
+                    "name": response.data.get("name"),
+                    "size": response.data.get("size"),
+                    "webUrl": response.data.get("webUrl"),
+                    "createdDateTime": response.data.get("createdDateTime"),
+                    "lastModifiedDateTime": response.data.get("lastModifiedDateTime"),
+                    "createdBy": response.data.get("createdBy"),
+                    "lastModifiedBy": response.data.get("lastModifiedBy"),
+                    "parentReference": response.data.get("parentReference"),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -214,7 +214,7 @@ class GetSlidesAction(ActionHandler):
                         f"{GRAPH_API_BASE_URL}/me/drive/items/{presentation_id}/thumbnails",
                         method="GET",
                     )
-                    thumbnail_sets = thumbnails_response.get("value", [])
+                    thumbnail_sets = thumbnails_response.data.get("value", [])
                     if thumbnail_sets:
                         size_data = thumbnail_sets[0].get(thumbnail_size, thumbnail_sets[0].get("medium", {}))
                         thumbnail_data = {
@@ -305,7 +305,7 @@ class GetSlideAction(ActionHandler):
                         f"{GRAPH_API_BASE_URL}/me/drive/items/{presentation_id}/thumbnails",
                         method="GET",
                     )
-                    thumbnail_sets = thumbnails_response.get("value", [])
+                    thumbnail_sets = thumbnails_response.data.get("value", [])
                     if thumbnail_sets:
                         size_data = thumbnail_sets[0].get(thumbnail_size, thumbnail_sets[0].get("large", {}))
                         result_data["thumbnailUrl"] = size_data.get("url")
@@ -361,13 +361,13 @@ class CreatePresentationAction(ActionHandler):
                     json=copy_body,
                 )
 
-                if response.get("id"):
+                if response.data.get("id"):
                     return ActionResult(
                         data={
-                            "id": response.get("id"),
-                            "name": response.get("name"),
-                            "webUrl": response.get("webUrl"),
-                            "createdDateTime": response.get("createdDateTime"),
+                            "id": response.data.get("id"),
+                            "name": response.data.get("name"),
+                            "webUrl": response.data.get("webUrl"),
+                            "createdDateTime": response.data.get("createdDateTime"),
                             "result": True,
                         },
                         cost_usd=0.0,
@@ -387,10 +387,10 @@ class CreatePresentationAction(ActionHandler):
 
                 return ActionResult(
                     data={
-                        "id": response.get("id"),
-                        "name": response.get("name"),
-                        "webUrl": response.get("webUrl"),
-                        "createdDateTime": response.get("createdDateTime"),
+                        "id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "webUrl": response.data.get("webUrl"),
+                        "createdDateTime": response.data.get("createdDateTime"),
                         "result": True,
                     },
                     cost_usd=0.0,
@@ -671,8 +671,8 @@ class ExportPdfAction(ActionHandler):
                 params={"$select": "name,parentReference"},
             )
 
-            original_name = file_info.get("name", "presentation.pptx")
-            parent_path = file_info.get("parentReference", {}).get("path", "/drive/root:").replace("/drive/root:", "")
+            original_name = file_info.data.get("name", "presentation.pptx")
+            parent_path = file_info.data.get("parentReference", {}).get("path", "/drive/root:").replace("/drive/root:", "")
 
             if output_name:
                 pdf_name = output_name if output_name.endswith(".pdf") else f"{output_name}.pdf"
@@ -700,17 +700,17 @@ class ExportPdfAction(ActionHandler):
             )
 
             download_response = await context.fetch(
-                f"{GRAPH_API_BASE_URL}/me/drive/items/{response.get('id')}",
+                f"{GRAPH_API_BASE_URL}/me/drive/items/{response.data.get('id')}",
                 method="GET",
             )
 
             return ActionResult(
                 data={
-                    "pdf_id": response.get("id"),
-                    "pdf_name": response.get("name"),
-                    "pdf_webUrl": response.get("webUrl"),
-                    "pdf_size": response.get("size"),
-                    "download_url": download_response.get("@microsoft.graph.downloadUrl"),
+                    "pdf_id": response.data.get("id"),
+                    "pdf_name": response.data.get("name"),
+                    "pdf_webUrl": response.data.get("webUrl"),
+                    "pdf_size": response.data.get("size"),
+                    "download_url": download_response.data.get("@microsoft.graph.downloadUrl"),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -761,7 +761,7 @@ class GetSlideImageAction(ActionHandler):
                 method="GET",
             )
 
-            thumbnail_sets = thumbnails_response.get("value", [])
+            thumbnail_sets = thumbnails_response.data.get("value", [])
 
             if not thumbnail_sets:
                 return ActionResult(

--- a/microsoft-powerpoint/requirements.txt
+++ b/microsoft-powerpoint/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 python-pptx>=0.6.21

--- a/microsoft-word/microsoft_word.py
+++ b/microsoft-word/microsoft_word.py
@@ -350,7 +350,7 @@ class ListDocuments(ActionHandler):
             response = await context.fetch(url, method="GET", params=params)
 
             documents = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 if item.get("name", "").lower().endswith(".docx"):
                     documents.append(
                         {
@@ -363,7 +363,7 @@ class ListDocuments(ActionHandler):
                         }
                     )
 
-            next_link = response.get("@odata.nextLink")
+            next_link = response.data.get("@odata.nextLink")
 
             return ActionResult(
                 data={"documents": documents, "next_page_token": next_link if next_link else None, "result": True},
@@ -392,7 +392,7 @@ class GetDocument(ActionHandler):
 
             document = await context.fetch(url, method="GET", params=params)
 
-            return ActionResult(data={"document": document, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"document": document.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
@@ -474,8 +474,8 @@ class CreateDocument(ActionHandler):
                     folder_url = f"{GRAPH_API_BASE}/me/drive/root:/{encoded_path}"
                     folder_info = await context.fetch(folder_url, method="GET")
                     copy_body["parentReference"] = {
-                        "driveId": folder_info.get("parentReference", {}).get("driveId"),
-                        "id": folder_info.get("id"),
+                        "driveId": folder_info.data.get("parentReference", {}).get("driveId"),
+                        "id": folder_info.data.get("id"),
                     }
 
                 await context.fetch(copy_url, method="POST", json=copy_body)
@@ -514,9 +514,9 @@ class CreateDocument(ActionHandler):
 
                 return ActionResult(
                     data={
-                        "document_id": response.get("id"),
-                        "name": response.get("name"),
-                        "webUrl": response.get("webUrl"),
+                        "document_id": response.data.get("id"),
+                        "name": response.data.get("name"),
+                        "webUrl": response.data.get("webUrl"),
                         "result": True,
                     },
                     cost_usd=0.0,
@@ -793,7 +793,7 @@ class ExportPdf(ActionHandler):
             if save_to_drive:
                 if not output_name:
                     doc_info = await context.fetch(f"{GRAPH_API_BASE}/me/drive/items/{document_id}", method="GET")
-                    original_name = doc_info.get("name", "document.docx")
+                    original_name = doc_info.data.get("name", "document.docx")
                     output_name = original_name.rsplit(".", 1)[0] + ".pdf"
 
                 if not output_name.lower().endswith(".pdf"):
@@ -814,9 +814,9 @@ class ExportPdf(ActionHandler):
 
                 return ActionResult(
                     data={
-                        "pdf_url": uploaded.get("webUrl"),
-                        "pdf_id": uploaded.get("id"),
-                        "size": uploaded.get("size"),
+                        "pdf_url": uploaded.data.get("webUrl"),
+                        "pdf_id": uploaded.data.get("id"),
+                        "size": uploaded.data.get("size"),
                         "result": True,
                     },
                     cost_usd=0.0,

--- a/microsoft-word/requirements.txt
+++ b/microsoft-word/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 defusedxml~=0.7.1

--- a/microsoft365/microsoft365.py
+++ b/microsoft365/microsoft365.py
@@ -99,8 +99,8 @@ class CreateCalendarEventAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "webLink": response["webLink"],
+                    "id": response.data["id"],
+                    "webLink": response.data["webLink"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -138,9 +138,9 @@ class UploadFileAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "webUrl": response["webUrl"],
-                    "size": response["size"],
+                    "id": response.data["id"],
+                    "webUrl": response.data["webUrl"],
+                    "size": response.data["size"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -173,7 +173,7 @@ class ListFilesAction(ActionHandler):
 
             # Format files
             files = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 file_item = {
                     "id": item["id"],
                     "name": item["name"],
@@ -237,8 +237,8 @@ class UpdateCalendarEventAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "webLink": response["webLink"],
+                    "id": response.data["id"],
+                    "webLink": response.data["webLink"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -290,7 +290,7 @@ class ListCalendarEventsAction(ActionHandler):
 
             # Format events
             events = []
-            for event in response.get("value", []):
+            for event in response.data.get("value", []):
                 # Process attendees
                 attendees = []
                 for attendee in event.get("attendees", []):
@@ -368,7 +368,7 @@ class ListEmailsAction(ActionHandler):
 
             # Format emails
             emails = []
-            for email in response.get("value", []):
+            for email in response.data.get("value", []):
                 emails.append(
                     {
                         "id": email["id"],
@@ -411,7 +411,7 @@ class ListEmailsFromContactAction(ActionHandler):
 
             # Format emails
             emails = []
-            for email in response.get("value", []):
+            for email in response.data.get("value", []):
                 emails.append(
                     {
                         "id": email["id"],
@@ -461,9 +461,9 @@ class MarkEmailReadAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "isRead": response["isRead"],
-                    "lastModifiedDateTime": response["lastModifiedDateTime"],
+                    "id": response.data["id"],
+                    "isRead": response.data["isRead"],
+                    "lastModifiedDateTime": response.data["lastModifiedDateTime"],
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -514,8 +514,8 @@ class ListMailFoldersAction(ActionHandler):
                     # nextLink already contains query params, don't pass params again
                     response = await context.fetch(next_url)
 
-                all_folder_items.extend(response.get("value", []))
-                next_url = response.get("@odata.nextLink")
+                all_folder_items.extend(response.data.get("value", []))
+                next_url = response.data.get("@odata.nextLink")
 
             # Format folders
             folders = []
@@ -577,8 +577,8 @@ class ListMailFoldersAction(ActionHandler):
                     # nextLink already contains query params, don't pass params again
                     response = await context.fetch(next_url)
 
-                all_folder_items.extend(response.get("value", []))
-                next_url = response.get("@odata.nextLink")
+                all_folder_items.extend(response.data.get("value", []))
+                next_url = response.data.get("@odata.nextLink")
 
             folders = []
             for folder in all_folder_items:
@@ -626,13 +626,13 @@ class GetMailFolderAction(ActionHandler):
             response = await context.fetch(api_url, params=params)
 
             folder_data = {
-                "id": response["id"],
-                "displayName": response.get("displayName", ""),
-                "parentFolderId": response.get("parentFolderId", ""),
-                "childFolderCount": response.get("childFolderCount", 0),
-                "unreadItemCount": response.get("unreadItemCount", 0),
-                "totalItemCount": response.get("totalItemCount", 0),
-                "isHidden": response.get("isHidden", False),
+                "id": response.data["id"],
+                "displayName": response.data.get("displayName", ""),
+                "parentFolderId": response.data.get("parentFolderId", ""),
+                "childFolderCount": response.data.get("childFolderCount", 0),
+                "unreadItemCount": response.data.get("unreadItemCount", 0),
+                "totalItemCount": response.data.get("totalItemCount", 0),
+                "isHidden": response.data.get("isHidden", False),
             }
 
             return ActionResult(data={"folder": folder_data, "result": True}, cost_usd=0.0)
@@ -669,9 +669,9 @@ class MoveEmailAction(ActionHandler):
 
             return ActionResult(
                 data={
-                    "id": response["id"],
-                    "parentFolderId": response["parentFolderId"],
-                    "subject": response.get("subject", ""),
+                    "id": response.data["id"],
+                    "parentFolderId": response.data["parentFolderId"],
+                    "subject": response.data.get("subject", ""),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -696,12 +696,12 @@ class ReadEmailAction(ActionHandler):
 
             # Format email details
             email_details = {
-                "id": email_response["id"],
-                "subject": email_response.get("subject") or "",
-                "sender": email_response["sender"],
-                "receivedDateTime": email_response["receivedDateTime"],
-                "body": email_response.get("body", {}),
-                "hasAttachments": email_response.get("hasAttachments", False),
+                "id": email_response.data["id"],
+                "subject": email_response.data.get("subject") or "",
+                "sender": email_response.data["sender"],
+                "receivedDateTime": email_response.data["receivedDateTime"],
+                "body": email_response.data.get("body", {}),
+                "hasAttachments": email_response.data.get("hasAttachments", False),
             }
 
             attachments = []
@@ -710,7 +710,7 @@ class ReadEmailAction(ActionHandler):
                 # Get attachments
                 attachments_response = await context.fetch(f"{GRAPH_API_BASE}/me/messages/{email_id}/attachments")
 
-                for attachment in attachments_response.get("value", []):
+                for attachment in attachments_response.data.get("value", []):
                     attachment_id = attachment["id"]
                     attachment_name = attachment["name"]
                     attachment_size = attachment.get("size", 0)
@@ -765,7 +765,7 @@ class ReadContactsAction(ActionHandler):
             response = await context.fetch(api_url, params=params)
 
             # Format and filter contacts
-            all_contacts = response.get("value", [])
+            all_contacts = response.data.get("value", [])
             contacts = []
 
             for contact in all_contacts:
@@ -880,7 +880,7 @@ class SearchOneDriveFilesAction(ActionHandler):
 
             # Format search results
             files = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 file_item = {
                     "id": item["id"],
                     "name": item["name"],
@@ -917,10 +917,10 @@ class ReadOneDriveFileContentAction(ActionHandler):
                 f"{GRAPH_API_BASE}/me/drive/items/{file_id}", params=metadata_params
             )
 
-            file_name = metadata_response["name"]
-            file_size = metadata_response.get("size", 0)
-            mime_type = metadata_response.get("mimeType", "")
-            web_url = metadata_response.get("webUrl", "")
+            file_name = metadata_response.data["name"]
+            file_size = metadata_response.data.get("size", 0)
+            mime_type = metadata_response.data.get("mimeType", "")
+            web_url = metadata_response.data.get("webUrl", "")
 
             # Try to get file content
             content = None
@@ -1116,10 +1116,10 @@ class CreateDraftEmailAction(ActionHandler):
             return ActionResult(
                 data={
                     "result": True,
-                    "draft_id": response["id"],
-                    "subject": response.get("subject") or "",
-                    "created_datetime": response.get("createdDateTime") or "",
-                    "is_draft": response.get("isDraft", True),
+                    "draft_id": response.data["id"],
+                    "subject": response.data.get("subject") or "",
+                    "created_datetime": response.data.get("createdDateTime") or "",
+                    "is_draft": response.data.get("isDraft", True),
                 },
                 cost_usd=0.0,
             )
@@ -1271,11 +1271,11 @@ class DownloadEmailAttachmentAction(ActionHandler):
             )
 
             # Extract metadata
-            attachment_id_val = attachment_response["id"]
-            attachment_name = attachment_response.get("name") or ""
-            content_type = attachment_response.get("contentType") or "application/octet-stream"
-            size = attachment_response.get("size", 0)
-            is_inline = attachment_response.get("isInline", False)
+            attachment_id_val = attachment_response.data["id"]
+            attachment_name = attachment_response.data.get("name") or ""
+            content_type = attachment_response.data.get("contentType") or "application/octet-stream"
+            size = attachment_response.data.get("size", 0)
+            is_inline = attachment_response.data.get("isInline", False)
 
             # Get attachment content if requested
             content = ""
@@ -1295,8 +1295,8 @@ class DownloadEmailAttachmentAction(ActionHandler):
 
                 except Exception as content_error:
                     # If binary content fails, try getting contentBytes from attachment object
-                    if "contentBytes" in attachment_response:
-                        content = attachment_response["contentBytes"]
+                    if "contentBytes" in attachment_response.data:
+                        content = attachment_response.data["contentBytes"]
                         content_available = True
                     else:
                         content = ""
@@ -1399,8 +1399,8 @@ class SearchEmailsAction(ActionHandler):
             messages = []
             total_results = 0
 
-            if response.get("value") and len(response["value"]) > 0:
-                search_result = response["value"][0]
+            if response.data.get("value") and len(response.data["value"]) > 0:
+                search_result = response.data["value"][0]
                 hits = search_result.get("hitsContainers", [])
 
                 if hits:
@@ -1470,7 +1470,7 @@ class SearchSharePointSitesAction(ActionHandler):
 
             # Process search results according to API response format
             sites = []
-            for site in response.get("value", []):
+            for site in response.data.get("value", []):
                 sites.append(
                     {
                         "id": site.get("id") or "",
@@ -1518,19 +1518,19 @@ class GetSharePointSiteDetailsAction(ActionHandler):
 
             # Process response according to API documentation
             site_details = {
-                "id": response.get("id") or "",
-                "display_name": response.get("displayName") or "",
-                "name": response.get("name") or "",
-                "description": response.get("description") or "",
-                "web_url": response.get("webUrl") or "",
-                "created_datetime": response.get("createdDateTime") or "",
-                "last_modified_datetime": response.get("lastModifiedDateTime") or "",
-                "is_personal_site": response.get("isPersonalSite", False),
+                "id": response.data.get("id") or "",
+                "display_name": response.data.get("displayName") or "",
+                "name": response.data.get("name") or "",
+                "description": response.data.get("description") or "",
+                "web_url": response.data.get("webUrl") or "",
+                "created_datetime": response.data.get("createdDateTime") or "",
+                "last_modified_datetime": response.data.get("lastModifiedDateTime") or "",
+                "is_personal_site": response.data.get("isPersonalSite", False),
             }
 
             # Add additional metadata if available
-            if "siteCollection" in response:
-                site_details["site_collection"] = response["siteCollection"]
+            if "siteCollection" in response.data:
+                site_details["site_collection"] = response.data["siteCollection"]
 
             return ActionResult(data={"result": True, "site": site_details}, cost_usd=0.0)
 
@@ -1577,7 +1577,7 @@ class ListSharePointLibrariesAction(ActionHandler):
 
             # Process response according to API documentation
             libraries = []
-            for drive in response.get("value", []):
+            for drive in response.data.get("value", []):
                 library_data = {
                     "id": drive.get("id", ""),
                     "name": drive.get("name", ""),
@@ -1642,7 +1642,7 @@ class SearchSharePointDocumentsAction(ActionHandler):
             # GET /sites/{site-id}/drives
             drives_response = await context.fetch(f"{GRAPH_API_BASE}/sites/{site_id}/drives")
 
-            drives = drives_response.get("value", [])
+            drives = drives_response.data.get("value", [])
             if not drives:
                 return ActionResult(
                     data={
@@ -1679,7 +1679,7 @@ class SearchSharePointDocumentsAction(ActionHandler):
                     drive_response = await context.fetch(api_url, params=params)
 
                     # Process files from this drive
-                    for item in drive_response.get("value", []):
+                    for item in drive_response.data.get("value", []):
                         file_item = {
                             "id": item["id"],
                             "name": item["name"],
@@ -1763,10 +1763,10 @@ class ReadSharePointDocumentAction(ActionHandler):
 
             metadata_response = await context.fetch(metadata_url, params=metadata_params)
 
-            file_name = metadata_response["name"]
-            file_size = metadata_response.get("size", 0)
-            mime_type = metadata_response.get("mimeType", "")
-            web_url = metadata_response.get("webUrl", "")
+            file_name = metadata_response.data["name"]
+            file_size = metadata_response.data.get("size", 0)
+            mime_type = metadata_response.data.get("mimeType", "")
+            web_url = metadata_response.data.get("webUrl", "")
 
             # Try to get file content (reuse OneDrive logic)
             content = None
@@ -1939,7 +1939,7 @@ class ListSharePointPagesAction(ActionHandler):
 
             # Process response according to API documentation
             pages = []
-            for page in response.get("value", []):
+            for page in response.data.get("value", []):
                 page_data = {
                     "id": page.get("id", ""),
                     "name": page.get("name", ""),
@@ -2016,25 +2016,25 @@ class ReadSharePointPageContentAction(ActionHandler):
 
             # Process response according to API documentation
             page_data = {
-                "id": response.get("id", ""),
-                "name": response.get("name", ""),
-                "title": response.get("title", ""),
-                "web_url": response.get("webUrl", ""),
-                "page_layout": response.get("pageLayout", ""),
-                "created_datetime": response.get("createdDateTime", ""),
-                "last_modified_datetime": response.get("lastModifiedDateTime", ""),
+                "id": response.data.get("id", ""),
+                "name": response.data.get("name", ""),
+                "title": response.data.get("title", ""),
+                "web_url": response.data.get("webUrl", ""),
+                "page_layout": response.data.get("pageLayout", ""),
+                "created_datetime": response.data.get("createdDateTime", ""),
+                "last_modified_datetime": response.data.get("lastModifiedDateTime", ""),
             }
 
             # Add creator information if available
-            if "createdBy" in response and "user" in response["createdBy"]:
+            if "createdBy" in response.data and "user" in response.data["createdBy"]:
                 page_data["created_by"] = {
-                    "display_name": response["createdBy"]["user"].get("displayName", ""),
-                    "email": response["createdBy"]["user"].get("email", ""),
+                    "display_name": response.data["createdBy"]["user"].get("displayName", ""),
+                    "email": response.data["createdBy"]["user"].get("email", ""),
                 }
 
             # Add page content if available
-            if include_content and "canvasLayout" in response:
-                page_data["content"] = response["canvasLayout"]
+            if include_content and "canvasLayout" in response.data:
+                page_data["content"] = response.data["canvasLayout"]
 
             return ActionResult(
                 data={"result": True, "site_id": site_id, "page": page_data},
@@ -2068,7 +2068,7 @@ class ListSharePointSubsitesAction(ActionHandler):
 
             # Process response
             subsites = []
-            for site in response.get("value", []):
+            for site in response.data.get("value", []):
                 subsites.append(
                     {
                         "id": site.get("id", ""),
@@ -2088,7 +2088,7 @@ class ListSharePointSubsitesAction(ActionHandler):
                     "site_id": site_id,
                     "subsites": subsites,
                     "total_subsites": len(subsites),
-                    "has_more": "@odata.nextLink" in response,
+                    "has_more": "@odata.nextLink" in response.data,
                 },
                 cost_usd=0.0,
             )
@@ -2134,7 +2134,7 @@ class ListSharePointFolderContentsAction(ActionHandler):
 
             # Process response
             items = []
-            for item in response.get("value", []):
+            for item in response.data.get("value", []):
                 item_data = {
                     "id": item.get("id", ""),
                     "name": item.get("name", ""),
@@ -2173,7 +2173,7 @@ class ListSharePointFolderContentsAction(ActionHandler):
             }
 
             # Include pagination indicator
-            result["has_more"] = "@odata.nextLink" in response
+            result["has_more"] = "@odata.nextLink" in response.data
 
             return ActionResult(data=result, cost_usd=0.0)
 
@@ -2286,7 +2286,7 @@ class FindMeetingTimesAction(ActionHandler):
 
             # Process meeting time suggestions
             suggestions = []
-            for suggestion in response.get("meetingTimeSuggestions", []):
+            for suggestion in response.data.get("meetingTimeSuggestions", []):
                 time_slot = suggestion.get("meetingTimeSlot", {})
                 start_info = time_slot.get("start", {})
                 end_info = time_slot.get("end", {})
@@ -2326,7 +2326,7 @@ class FindMeetingTimesAction(ActionHandler):
             result_data = {"result": True, "meeting_time_suggestions": suggestions}
 
             # Include empty suggestions reason if no suggestions found
-            empty_reason = response.get("emptySuggestionsReason", "")
+            empty_reason = response.data.get("emptySuggestionsReason", "")
             if empty_reason:
                 result_data["empty_suggestions_reason"] = empty_reason
 
@@ -2359,7 +2359,7 @@ class GetScheduleAction(ActionHandler):
 
             # Process schedule responses
             schedules = []
-            for schedule in response.get("value", []):
+            for schedule in response.data.get("value", []):
                 schedule_data = {
                     "email": schedule.get("scheduleId", ""),
                     "availability_view": schedule.get("availabilityView", ""),
@@ -2424,8 +2424,8 @@ class ListRoomsAction(ActionHandler):
                 while next_url and len(all_items) < limit:
                     response = await context.fetch(next_url, params=params if is_first else None)
                     is_first = False
-                    all_items.extend(response.get("value", []))
-                    next_url = response.get("@odata.nextLink")
+                    all_items.extend(response.data.get("value", []))
+                    next_url = response.data.get("@odata.nextLink")
                 all_items = all_items[:limit]
 
                 rooms = []
@@ -2459,8 +2459,8 @@ class ListRoomsAction(ActionHandler):
                 while next_url and len(all_items) < limit:
                     response = await context.fetch(next_url, params=params if is_first else None)
                     is_first = False
-                    all_items.extend(response.get("value", []))
-                    next_url = response.get("@odata.nextLink")
+                    all_items.extend(response.data.get("value", []))
+                    next_url = response.data.get("@odata.nextLink")
                 all_items = all_items[:limit]
 
                 rooms = []
@@ -2493,8 +2493,8 @@ class ListRoomsAction(ActionHandler):
                 while next_url and len(all_items) < limit:
                     response = await context.fetch(next_url, params=params if is_first else None)
                     is_first = False
-                    all_items.extend(response.get("value", []))
-                    next_url = response.get("@odata.nextLink")
+                    all_items.extend(response.data.get("value", []))
+                    next_url = response.data.get("@odata.nextLink")
                 all_items = all_items[:limit]
 
                 rooms = []
@@ -2550,7 +2550,7 @@ class CheckRoomAvailabilityAction(ActionHandler):
             available_rooms = []
             unavailable_rooms = []
 
-            for schedule in response.get("value", []):
+            for schedule in response.data.get("value", []):
                 email = schedule.get("scheduleId", "")
                 schedule_items = schedule.get("scheduleItems", [])
 

--- a/microsoft365/requirements.txt
+++ b/microsoft365/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp

--- a/monday-com/requirements.txt
+++ b/monday-com/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/netlify/netlify.py
+++ b/netlify/netlify.py
@@ -46,7 +46,7 @@ class CreateSiteAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites", method="POST", json=payload)
 
-            return ActionResult(data={"site": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"site": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"site": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -62,7 +62,7 @@ class GetSiteAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites/{site_id}", method="GET")
 
-            return ActionResult(data={"site": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"site": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"site": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -84,7 +84,7 @@ class UpdateSiteAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/sites/{site_id}", method="PATCH", json=payload)
 
-            return ActionResult(data={"site": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"site": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"site": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -151,8 +151,8 @@ class CreateDeployAction(ActionHandler):
             )
 
             # Upload required files
-            required_hashes = deploy.get("required", [])
-            deploy_id = deploy.get("id")
+            required_hashes = deploy.data.get("required", [])
+            deploy_id = deploy.data.get("id")
 
             for sha1_hash in required_hashes:
                 if sha1_hash in hash_to_content:
@@ -169,10 +169,10 @@ class CreateDeployAction(ActionHandler):
             final_deploy = await context.fetch(f"{NETLIFY_API_BASE_URL}/deploys/{deploy_id}", method="GET")
 
             deploy_url = (
-                final_deploy.get("deploy_ssl_url") or final_deploy.get("ssl_url") or final_deploy.get("url", "")
+                final_deploy.data.get("deploy_ssl_url") or final_deploy.data.get("ssl_url") or final_deploy.data.get("url", "")
             )
 
-            return ActionResult(data={"deploy": final_deploy, "deploy_url": deploy_url, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deploy": final_deploy.data, "deploy_url": deploy_url, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deploy": {}, "deploy_url": "", "result": False, "error": str(e)}, cost_usd=0.0)
@@ -188,7 +188,7 @@ class GetDeployAction(ActionHandler):
 
             response = await context.fetch(f"{NETLIFY_API_BASE_URL}/deploys/{deploy_id}", method="GET")
 
-            return ActionResult(data={"deploy": response, "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deploy": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deploy": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/netlify/requirements.txt
+++ b/netlify/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/notion/notion.py
+++ b/notion/notion.py
@@ -54,11 +54,11 @@ class NotionSearchHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "object": response.get("object", "list"),
-                    "results": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "object": response.data.get("object", "list"),
+                    "results": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -92,7 +92,7 @@ class NotionGetPageHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/pages/{page_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"page": response})
+            return ActionResult(data={"page": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "page": None})
@@ -125,7 +125,7 @@ class NotionCreatePageHandler(ActionHandler):
                 url="https://api.notion.com/v1/pages", method="POST", headers=headers, json=create_body
             )
 
-            return ActionResult(data={"page": response})
+            return ActionResult(data={"page": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "page": None})
@@ -158,7 +158,7 @@ class NotionCreateCommentHandler(ActionHandler):
                 url="https://api.notion.com/v1/comments", method="POST", headers=headers, json=comment_body
             )
 
-            return ActionResult(data={"comment": response})
+            return ActionResult(data={"comment": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "comment": None})
@@ -188,9 +188,9 @@ class NotionGetCommentsHandler(ActionHandler):
             )
 
             result = {
-                "comments": response.get("results", []),
-                "has_more": response.get("has_more", False),
-                "next_cursor": response.get("next_cursor"),
+                "comments": response.data.get("results", []),
+                "has_more": response.data.get("has_more", False),
+                "next_cursor": response.data.get("next_cursor"),
             }
 
             if include_child_blocks_with_comments:
@@ -200,7 +200,7 @@ class NotionGetCommentsHandler(ActionHandler):
                     url=f"https://api.notion.com/v1/blocks/{block_id}/children", method="GET", headers=headers
                 )
 
-                for block in blocks_response.get("results", []):
+                for block in blocks_response.data.get("results", []):
                     child_block_id = block.get("id")
                     if child_block_id:
                         comments_response = await context.fetch(
@@ -209,7 +209,7 @@ class NotionGetCommentsHandler(ActionHandler):
                             headers=headers,
                             params={"block_id": child_block_id, "page_size": 1},
                         )
-                        if comments_response.get("results"):
+                        if comments_response.data.get("results"):
                             blocks_with_comments.append(
                                 {"block_id": child_block_id, "block_type": block.get("type"), "has_comments": True}
                             )
@@ -257,9 +257,9 @@ class NotionListDataSourcesHandler(ActionHandler):
             )
             return ActionResult(
                 data={
-                    "data_sources": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
+                    "data_sources": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
                 }
             )
         except Exception as e:
@@ -289,7 +289,7 @@ class NotionGetDataSourceHandler(ActionHandler):
             response = await context.fetch(
                 url=f"https://api.notion.com/v1/data_sources/{data_source_id}", method="GET", headers=headers
             )
-            return ActionResult(data={"data_source": response})
+            return ActionResult(data={"data_source": response.data})
         except Exception as e:
             return ActionResult(data={"error": str(e), "data_source": None})
 
@@ -346,10 +346,10 @@ class NotionQueryDataSourceHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "results": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "results": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -394,10 +394,10 @@ class NotionGetBlockChildrenHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "blocks": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "blocks": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -443,10 +443,10 @@ class NotionAppendBlockChildrenHandler(ActionHandler):
 
             return ActionResult(
                 data={
-                    "blocks": response.get("results", []),
-                    "has_more": response.get("has_more", False),
-                    "next_cursor": response.get("next_cursor"),
-                    "type": response.get("type"),
+                    "blocks": response.data.get("results", []),
+                    "has_more": response.data.get("has_more", False),
+                    "next_cursor": response.data.get("next_cursor"),
+                    "type": response.data.get("type"),
                 }
             )
 
@@ -490,7 +490,7 @@ class NotionGetPagePropertyHandler(ActionHandler):
 
             response = await context.fetch(url=url, method="GET", headers=headers, params=params)
 
-            return ActionResult(data={"property": response})
+            return ActionResult(data={"property": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "property": None})
@@ -561,7 +561,7 @@ class NotionUpdateBlockHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/blocks/{block_id}", method="PATCH", headers=headers, json=update_body
             )
 
-            return ActionResult(data={"block": response})
+            return ActionResult(data={"block": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "block": None})
@@ -593,7 +593,7 @@ class NotionDeleteBlockHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/blocks/{block_id}", method="DELETE", headers=headers
             )
 
-            return ActionResult(data={"block": response})
+            return ActionResult(data={"block": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "block": None})
@@ -635,7 +635,7 @@ class NotionUpdatePageHandler(ActionHandler):
                 url=f"https://api.notion.com/v1/pages/{page_id}", method="PATCH", headers=headers, json=update_body
             )
 
-            return ActionResult(data={"page": response})
+            return ActionResult(data={"page": response.data})
 
         except Exception as e:
             return ActionResult(data={"error": str(e), "page": None})

--- a/notion/requirements.txt
+++ b/notion/requirements.txt
@@ -1,5 +1,5 @@
 # Notion Integration Dependencies
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 aiohttp>=3.12.0
 jsonschema>=4.17.0
 attrs>=25.0.0

--- a/nzbn/nzbn.py
+++ b/nzbn/nzbn.py
@@ -106,10 +106,9 @@ async def get_oauth_token(context: ExecutionContext) -> Optional[str]:
 
     # Handle response
     token_data = None
-    if hasattr(response, "status_code") and response.status_code == 200:
-        token_data = response.json()
-    elif isinstance(response, dict):
-        token_data = response
+    if response.status == 200:
+        token_data = response.data
+
 
     if token_data and "access_token" in token_data:
         access_token = token_data["access_token"]
@@ -144,24 +143,21 @@ async def make_request(
 
     response = await context.fetch(url, method=method, headers=headers, params=params)
 
-    if hasattr(response, "status_code"):
-        if response.status_code == 200:
-            return {"success": True, "data": response.json()}
-        elif response.status_code == 304:
-            return {"success": True, "data": None, "not_modified": True}
-        elif response.status_code == 400:
-            error_data = response.json() if hasattr(response, "json") else {}
-            return {"success": False, "error": error_data.get("errorDescription", "Bad request - validation failed")}
-        elif response.status_code == 401:
-            return {"success": False, "error": "Unauthorized - invalid credentials"}
-        elif response.status_code == 403:
-            return {"success": False, "error": "Forbidden - insufficient permissions"}
-        elif response.status_code == 404:
-            return {"success": False, "error": "Entity not found"}
-        else:
-            return {"success": False, "error": f"API error: {response.status_code}"}
-
-    return {"success": True, "data": response}
+    if response.status == 200:
+        return {"success": True, "data": response.data}
+    elif response.status == 304:
+        return {"success": True, "data": None, "not_modified": True}
+    elif response.status == 400:
+        error_data = response.data if response.data else {}
+        return {"success": False, "error": error_data.get("errorDescription", "Bad request - validation failed")}
+    elif response.status == 401:
+        return {"success": False, "error": "Unauthorized - invalid credentials"}
+    elif response.status == 403:
+        return {"success": False, "error": "Forbidden - insufficient permissions"}
+    elif response.status == 404:
+        return {"success": False, "error": "Entity not found"}
+    else:
+        return {"success": False, "error": f"API error: {response.status}"}
 
 
 # =============================================================================

--- a/nzbn/requirements.txt
+++ b/nzbn/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/pipedrive/pipedrive.py
+++ b/pipedrive/pipedrive.py
@@ -45,7 +45,7 @@ class CreateDealAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals", method="POST", json=data)
 
-            return ActionResult(data={"deal": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deal": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deal": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -61,7 +61,7 @@ class GetDealAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals/{deal_id}", method="GET")
 
-            return ActionResult(data={"deal": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deal": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deal": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -98,7 +98,7 @@ class UpdateDealAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals/{deal_id}", method="PUT", json=data)
 
-            return ActionResult(data={"deal": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"deal": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"deal": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -129,7 +129,7 @@ class ListDealsAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/deals", method="GET", params=params)
 
-            deals = response.get("data", [])
+            deals = response.data.get("data", [])
             return ActionResult(data={"deals": deals, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -177,7 +177,7 @@ class CreatePersonAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons", method="POST", json=data)
 
-            return ActionResult(data={"person": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"person": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"person": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -193,7 +193,7 @@ class GetPersonAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons/{person_id}", method="GET")
 
-            return ActionResult(data={"person": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"person": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"person": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -221,7 +221,7 @@ class UpdatePersonAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons/{person_id}", method="PUT", json=data)
 
-            return ActionResult(data={"person": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"person": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"person": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -248,7 +248,7 @@ class ListPersonsAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/persons", method="GET", params=params)
 
-            persons = response.get("data", [])
+            persons = response.data.get("data", [])
             return ActionResult(data={"persons": persons, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -291,7 +291,7 @@ class CreateOrganizationAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations", method="POST", json=data)
 
-            return ActionResult(data={"organization": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"organization": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"organization": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -307,7 +307,7 @@ class GetOrganizationAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations/{org_id}", method="GET")
 
-            return ActionResult(data={"organization": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"organization": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"organization": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -331,7 +331,7 @@ class UpdateOrganizationAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations/{org_id}", method="PUT", json=data)
 
-            return ActionResult(data={"organization": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"organization": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"organization": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -358,7 +358,7 @@ class ListOrganizationsAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/organizations", method="GET", params=params)
 
-            organizations = response.get("data", [])
+            organizations = response.data.get("data", [])
             return ActionResult(data={"organizations": organizations, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -413,7 +413,7 @@ class CreateActivityAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/activities", method="POST", json=data)
 
-            return ActionResult(data={"activity": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"activity": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"activity": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -429,7 +429,7 @@ class GetActivityAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/activities/{activity_id}", method="GET")
 
-            return ActionResult(data={"activity": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"activity": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"activity": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -463,7 +463,7 @@ class UpdateActivityAction(ActionHandler):
                 f"{PIPEDRIVE_API_BASE_URL}/activities/{activity_id}", method="PUT", json=data
             )
 
-            return ActionResult(data={"activity": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"activity": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"activity": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -496,7 +496,7 @@ class ListActivitiesAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/activities", method="GET", params=params)
 
-            activities = response.get("data", [])
+            activities = response.data.get("data", [])
             return ActionResult(data={"activities": activities, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -539,7 +539,7 @@ class CreateNoteAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/notes", method="POST", json=data)
 
-            return ActionResult(data={"note": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"note": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"note": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -566,7 +566,7 @@ class ListNotesAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/notes", method="GET", params=params)
 
-            notes = response.get("data", [])
+            notes = response.data.get("data", [])
             return ActionResult(data={"notes": notes, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -584,7 +584,7 @@ class ListPipelinesAction(ActionHandler):
         try:
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/pipelines", method="GET")
 
-            pipelines = response.get("data", [])
+            pipelines = response.data.get("data", [])
             return ActionResult(data={"pipelines": pipelines, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -601,7 +601,7 @@ class GetPipelineAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/pipelines/{pipeline_id}", method="GET")
 
-            return ActionResult(data={"pipeline": response.get("data", {}), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"pipeline": response.data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"pipeline": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -625,7 +625,7 @@ class ListStagesAction(ActionHandler):
                 f"{PIPEDRIVE_API_BASE_URL}/stages", method="GET", params=params if params else None
             )
 
-            stages = response.get("data", [])
+            stages = response.data.get("data", [])
             return ActionResult(data={"stages": stages, "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -656,7 +656,7 @@ class SearchAction(ActionHandler):
 
             response = await context.fetch(f"{PIPEDRIVE_API_BASE_URL}/itemSearch", method="GET", params=params)
 
-            items = response.get("data", {}).get("items", [])
+            items = response.data.get("data", {}).get("items", [])
             return ActionResult(data={"items": items, "result": True}, cost_usd=0.0)
 
         except Exception as e:

--- a/pipedrive/requirements.txt
+++ b/pipedrive/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/powerbi/powerbi.py
+++ b/powerbi/powerbi.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -25,7 +25,7 @@ class ListWorkspacesAction(ActionHandler):
             response = await context.fetch(f"{POWERBI_API_BASE}/groups", params=params)
 
             workspaces = []
-            for workspace in response.get("value", []):
+            for workspace in response.data.get("value", []):
                 workspaces.append(
                     {
                         "id": workspace.get("id"),
@@ -36,10 +36,10 @@ class ListWorkspacesAction(ActionHandler):
                     }
                 )
 
-            return {"workspaces": workspaces, "result": True}
+            return ActionResult(data={"workspaces": workspaces, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"workspaces": [], "result": False, "error": str(e)}
+            return ActionResult(data={"workspaces": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_workspace")
@@ -50,10 +50,10 @@ class GetWorkspaceAction(ActionHandler):
 
             response = await context.fetch(f"{POWERBI_API_BASE}/groups/{workspace_id}")
 
-            return {"workspace": response, "result": True}
+            return ActionResult(data={"workspace": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"workspace": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("list_datasets")
@@ -70,7 +70,7 @@ class ListDatasetsAction(ActionHandler):
             response = await context.fetch(url)
 
             datasets = []
-            for dataset in response.get("value", []):
+            for dataset in response.data.get("value", []):
                 datasets.append(
                     {
                         "id": dataset.get("id"),
@@ -83,10 +83,10 @@ class ListDatasetsAction(ActionHandler):
                     }
                 )
 
-            return {"datasets": datasets, "result": True}
+            return ActionResult(data={"datasets": datasets, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"datasets": [], "result": False, "error": str(e)}
+            return ActionResult(data={"datasets": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_dataset")
@@ -103,10 +103,10 @@ class GetDatasetAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"dataset": response, "result": True}
+            return ActionResult(data={"dataset": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"dataset": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"dataset": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("refresh_dataset")
@@ -164,10 +164,10 @@ class RefreshDatasetAction(ActionHandler):
             if hasattr(response, "headers") and "x-ms-request-id" in response.headers:
                 request_id = response.headers["x-ms-request-id"]
 
-            return {"result": True, "message": "Dataset refresh initiated successfully", "request_id": request_id}
+            return ActionResult(data={"result": True, "message": "Dataset refresh initiated successfully", "request_id": request_id}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_refresh_history")
@@ -188,7 +188,7 @@ class GetRefreshHistoryAction(ActionHandler):
             response = await context.fetch(url, params=params)
 
             refreshes = []
-            for refresh in response.get("value", []):
+            for refresh in response.data.get("value", []):
                 refreshes.append(
                     {
                         "refreshType": refresh.get("refreshType"),
@@ -199,10 +199,10 @@ class GetRefreshHistoryAction(ActionHandler):
                     }
                 )
 
-            return {"refreshes": refreshes, "result": True}
+            return ActionResult(data={"refreshes": refreshes, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"refreshes": [], "result": False, "error": str(e)}
+            return ActionResult(data={"refreshes": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("list_reports")
@@ -219,7 +219,7 @@ class ListReportsAction(ActionHandler):
             response = await context.fetch(url)
 
             reports = []
-            for report in response.get("value", []):
+            for report in response.data.get("value", []):
                 reports.append(
                     {
                         "id": report.get("id"),
@@ -230,10 +230,10 @@ class ListReportsAction(ActionHandler):
                     }
                 )
 
-            return {"reports": reports, "result": True}
+            return ActionResult(data={"reports": reports, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"reports": [], "result": False, "error": str(e)}
+            return ActionResult(data={"reports": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_report")
@@ -250,10 +250,10 @@ class GetReportAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"report": response, "result": True}
+            return ActionResult(data={"report": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"report": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"report": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_report_datasources")
@@ -271,7 +271,7 @@ class GetReportDatasourcesAction(ActionHandler):
             response = await context.fetch(url)
 
             datasources = []
-            for datasource in response.get("value", []):
+            for datasource in response.data.get("value", []):
                 ds_data = {
                     "datasourceType": datasource.get("datasourceType"),
                     "datasourceId": datasource.get("datasourceId"),
@@ -286,10 +286,10 @@ class GetReportDatasourcesAction(ActionHandler):
 
                 datasources.append(ds_data)
 
-            return {"datasources": datasources, "result": True}
+            return ActionResult(data={"datasources": datasources, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"datasources": [], "result": False, "error": str(e)}
+            return ActionResult(data={"datasources": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("refresh_report")
@@ -307,10 +307,10 @@ class RefreshReportAction(ActionHandler):
                 report_url = f"{POWERBI_API_BASE}/reports/{report_id}"
 
             report_response = await context.fetch(report_url)
-            dataset_id = report_response.get("datasetId")
+            dataset_id = report_response.data.get("datasetId")
 
             if not dataset_id:
-                return {"result": False, "error": "Report does not have an associated dataset"}
+                return ActionResult(data={"result": False, "error": "Report does not have an associated dataset"}, cost_usd=0.0)
 
             # Now refresh the dataset
             if workspace_id:
@@ -322,14 +322,14 @@ class RefreshReportAction(ActionHandler):
 
             await context.fetch(refresh_url, method="POST", json=refresh_request)
 
-            return {
+            return ActionResult(data={
                 "result": True,
-                "message": f"Dataset refresh initiated successfully for report '{report_response.get('name')}'",
+                "message": f"Dataset refresh initiated successfully for report '{report_response.data.get('name')}'",
                 "dataset_id": dataset_id,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("clone_report")
@@ -357,16 +357,16 @@ class CloneReportAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=clone_request)
 
-            return {
-                "id": response.get("id"),
-                "name": response.get("name"),
-                "webUrl": response.get("webUrl"),
-                "embedUrl": response.get("embedUrl"),
+            return ActionResult(data={
+                "id": response.data.get("id"),
+                "name": response.data.get("name"),
+                "webUrl": response.data.get("webUrl"),
+                "embedUrl": response.data.get("embedUrl"),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("export_report")
@@ -386,10 +386,10 @@ class ExportReportAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=export_request)
 
-            return {"export_id": response.get("id"), "result": True, "message": "Export initiated successfully"}
+            return ActionResult(data={"export_id": response.data.get("id"), "result": True, "message": "Export initiated successfully"}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_export_status")
@@ -407,14 +407,14 @@ class GetExportStatusAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {
-                "status": response.get("status"),
-                "percentComplete": response.get("percentComplete", 0),
+            return ActionResult(data={
+                "status": response.data.get("status"),
+                "percentComplete": response.data.get("percentComplete", 0),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"status": "Failed", "percentComplete": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"status": "Failed", "percentComplete": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("list_dashboards")
@@ -431,7 +431,7 @@ class ListDashboardsAction(ActionHandler):
             response = await context.fetch(url)
 
             dashboards = []
-            for dashboard in response.get("value", []):
+            for dashboard in response.data.get("value", []):
                 dashboards.append(
                     {
                         "id": dashboard.get("id"),
@@ -441,10 +441,10 @@ class ListDashboardsAction(ActionHandler):
                     }
                 )
 
-            return {"dashboards": dashboards, "result": True}
+            return ActionResult(data={"dashboards": dashboards, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"dashboards": [], "result": False, "error": str(e)}
+            return ActionResult(data={"dashboards": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_dashboard")
@@ -461,10 +461,10 @@ class GetDashboardAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"dashboard": response, "result": True}
+            return ActionResult(data={"dashboard": response.data, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"dashboard": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"dashboard": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_dashboard_tiles")
@@ -482,7 +482,7 @@ class GetDashboardTilesAction(ActionHandler):
             response = await context.fetch(url)
 
             tiles = []
-            for tile in response.get("value", []):
+            for tile in response.data.get("value", []):
                 tiles.append(
                     {
                         "id": tile.get("id"),
@@ -493,10 +493,10 @@ class GetDashboardTilesAction(ActionHandler):
                     }
                 )
 
-            return {"tiles": tiles, "result": True}
+            return ActionResult(data={"tiles": tiles, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"tiles": [], "result": False, "error": str(e)}
+            return ActionResult(data={"tiles": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("execute_queries")
@@ -516,7 +516,7 @@ class ExecuteQueriesAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=query_request)
 
-            return {"results": response.get("results", []), "result": True}
+            return ActionResult(data={"results": response.data.get("results", []), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"results": [], "result": False, "error": str(e)}
+            return ActionResult(data={"results": [], "result": False, "error": str(e)}, cost_usd=0.0)

--- a/powerbi/requirements.txt
+++ b/powerbi/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/productboard/productboard.py
+++ b/productboard/productboard.py
@@ -18,21 +18,17 @@ def get_common_headers() -> Dict[str, str]:
 
 def parse_error(response, default_msg: str = "Unknown error") -> str:
     """Extract error message from Productboard API error response."""
-    try:
-        body = response.json()
-    except Exception:
-        return f"{default_msg} (HTTP {response.status_code})"
-
+    body = response.data if response.data else {}
     errors = body.get("errors")
     if isinstance(errors, list) and errors:
         first = errors[0] or {}
         detail = first.get("detail") or first.get("title")
         code = first.get("code")
         if code:
-            return f"{detail or default_msg} (code={code}, http={response.status_code})"
+            return f"{detail or default_msg} (code={code}, http={response.status})"
         return detail or default_msg
 
-    return f"{default_msg} (HTTP {response.status_code})"
+    return f"{default_msg} (HTTP {response.status})"
 
 
 def extract_page_cursor(next_link: Optional[str]) -> Optional[str]:
@@ -87,13 +83,13 @@ class ListEntitiesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entities": [], "result": False, "error": parse_error(response, "Failed to list entities")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             next_link = data.get("links", {}).get("next")
             next_cursor = extract_page_cursor(next_link)
 
@@ -124,13 +120,13 @@ class GetEntityAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entity": {}, "result": False, "error": parse_error(response, "Failed to get entity")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"entity": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -167,13 +163,13 @@ class CreateEntityAction(ActionHandler):
                 json={"data": entity_data},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entity": {}, "result": False, "error": parse_error(response, "Failed to create entity")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"entity": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -220,13 +216,13 @@ class UpdateEntityAction(ActionHandler):
                 json={"data": {"patch": patch_operations}},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"entity": {}, "result": False, "error": parse_error(response, "Failed to update entity")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"entity": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -247,7 +243,7 @@ class GetEntityConfigurationAction(ActionHandler):
                 headers=get_common_headers(),
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={
                         "configuration": {},
@@ -257,7 +253,7 @@ class GetEntityConfigurationAction(ActionHandler):
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"configuration": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -307,13 +303,13 @@ class ListNotesAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"notes": [], "result": False, "error": parse_error(response, "Failed to list notes")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             next_link = data.get("links", {}).get("next")
             next_cursor = extract_page_cursor(next_link)
 
@@ -344,13 +340,13 @@ class GetNoteAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"note": {}, "result": False, "error": parse_error(response, "Failed to get note")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"note": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -401,13 +397,13 @@ class CreateNoteAction(ActionHandler):
                 json={"data": note_data},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"note": {}, "result": False, "error": parse_error(response, "Failed to create note")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"note": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -463,13 +459,13 @@ class UpdateNoteAction(ActionHandler):
                 json={"data": {"patch": patch_operations}},
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"note": {}, "result": False, "error": parse_error(response, "Failed to update note")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"note": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -488,7 +484,7 @@ class GetNoteConfigurationAction(ActionHandler):
                 headers=get_common_headers(),
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={
                         "configuration": {},
@@ -498,7 +494,7 @@ class GetNoteConfigurationAction(ActionHandler):
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"configuration": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -526,13 +522,13 @@ class ListAnalyticsReportsAction(ActionHandler):
                 params=params if params else None,
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"reports": [], "result": False, "error": parse_error(response, "Failed to list reports")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             next_link = data.get("links", {}).get("next")
             next_cursor = extract_page_cursor(next_link)
 
@@ -558,13 +554,13 @@ class GetAnalyticsReportAction(ActionHandler):
                 headers=get_common_headers(),
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"report": {}, "result": False, "error": parse_error(response, "Failed to get report")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"report": data.get("data", {}), "result": True}, cost_usd=0.0)
 
         except Exception as e:
@@ -584,13 +580,13 @@ class GetCurrentUserAction(ActionHandler):
                 f"{PRODUCTBOARD_API_BASE_URL}/oauth2/token/info", method="GET", headers=get_common_headers()
             )
 
-            if response.status_code not in SUCCESS_STATUSES:
+            if response.status not in SUCCESS_STATUSES:
                 return ActionResult(
                     data={"user": {}, "result": False, "error": parse_error(response, "Failed to get user info")},
                     cost_usd=0.0,
                 )
 
-            data = response.json()
+            data = response.data
             return ActionResult(data={"user": data, "result": True}, cost_usd=0.0)
 
         except Exception as e:

--- a/productboard/requirements.txt
+++ b/productboard/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/retail-express/requirements.txt
+++ b/retail-express/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/retail-express/retail_express.py
+++ b/retail-express/retail_express.py
@@ -33,7 +33,7 @@ async def get_access_token(context: ExecutionContext) -> str:
         headers={"x-api-key": api_key, "Accept": "application/json"},
     )
 
-    return response.get("access_token", "")
+    return response.data.get("access_token", "")
 
 
 async def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
@@ -95,14 +95,14 @@ class ListProductsAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/products", method="GET", headers=headers, params=params
             )
 
-            products = response.get("data", [])
+            products = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "products": products,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(products)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(products)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -136,7 +136,7 @@ class GetProductAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/products/{product_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"product": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"product": response.data.get("data", response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"product": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -165,14 +165,14 @@ class ListCustomersAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/customers", method="GET", headers=headers, params=params
             )
 
-            customers = response.get("data", [])
+            customers = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "customers": customers,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(customers)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(customers)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -206,7 +206,7 @@ class GetCustomerAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/customers/{customer_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"customer": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data.get("data", response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -240,7 +240,7 @@ class CreateCustomerAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/customers", method="POST", headers=headers, json=body
             )
 
-            return ActionResult(data={"customer": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data.get("data", response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -278,7 +278,7 @@ class UpdateCustomerAction(ActionHandler):
                 json=body,
             )
 
-            return ActionResult(data={"customer": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"customer": response.data.get("data", response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"customer": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -309,14 +309,14 @@ class ListOrdersAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/orders", method="GET", headers=headers, params=params
             )
 
-            orders = response.get("data", [])
+            orders = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "orders": orders,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(orders)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(orders)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -350,7 +350,7 @@ class GetOrderAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/orders/{order_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"order": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"order": response.data.get("data", response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"order": {}, "result": False, "error": str(e)}, cost_usd=0.0)
@@ -373,14 +373,14 @@ class ListOutletsAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/outlets", method="GET", headers=headers, params=params
             )
 
-            outlets = response.get("data", [])
+            outlets = response.data.get("data", [])
 
             return ActionResult(
                 data={
                     "outlets": outlets,
-                    "page_number": response.get("page_number", 1),
-                    "page_size": response.get("page_size", 20),
-                    "total_records": response.get("total_records", len(outlets)),
+                    "page_number": response.data.get("page_number", 1),
+                    "page_size": response.data.get("page_size", 20),
+                    "total_records": response.data.get("total_records", len(outlets)),
                     "result": True,
                 },
                 cost_usd=0.0,
@@ -414,7 +414,7 @@ class GetOutletAction(ActionHandler):
                 f"{RETAIL_EXPRESS_API_BASE_URL}/{API_VERSION}/outlets/{outlet_id}", method="GET", headers=headers
             )
 
-            return ActionResult(data={"outlet": response.get("data", response), "result": True}, cost_usd=0.0)
+            return ActionResult(data={"outlet": response.data.get("data", response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
             return ActionResult(data={"outlet": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/rss-reader-feedparser-ah-fetch/requirements.txt
+++ b/rss-reader-feedparser-ah-fetch/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 feedparser

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -1,5 +1,5 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
@@ -57,7 +57,7 @@ class GetFeedAction(ActionHandler):
             response = await context.fetch(feed_url)
 
         # Parse feed
-        feed = feedparser.parse(response)
+        feed = feedparser.parse(response.data)
 
         # Check for parsing errors
         if hasattr(feed, "bozo_exception"):
@@ -76,4 +76,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}, cost_usd=0.0)

--- a/rss-reader-feedparser/requirements.txt
+++ b/rss-reader-feedparser/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0
 feedparser

--- a/rss-reader-feedparser/rss_reader.py
+++ b/rss-reader-feedparser/rss_reader.py
@@ -1,5 +1,5 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
@@ -34,4 +34,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}, cost_usd=0.0)


### PR DESCRIPTION
## Summary
- Bump `autohive-integrations-sdk` to `~=2.0.0` for all integrations in this batch
- Update all `context.fetch()` response access to use `response.data` (SDK 2.0 `FetchResponse` breaking change)
- Replace `response.status_code` with `response.status` and `response.json()` with `response.data`
- Wrap all action handler return values in `ActionResult(data=..., cost_usd=0.0)`
- Add `ActionResult` to imports where missing (powerbi, rss-reader-feedparser, rss-reader-feedparser-ah-fetch)
- Fix nzbn `make_request` and `get_oauth_token` to use `response.status`/`response.data` directly (removed `hasattr(response, "status_code")` guard which was always False with SDK 2.0)

## Integrations covered
`instagram`, `jira`, `linkedin`, `linkedin-ads`, `mailchimp`, `microsoft365`, `microsoft-excel`, `microsoft-planner`, `microsoft-powerpoint`, `microsoft-word`, `monday-com`, `netlify`, `notion`, `nzbn`, `pipedrive`, `powerbi`, `productboard`, `reddit`, `retail-express`, `rss-reader-feedparser`, `rss-reader-feedparser-ah-fetch`