### PR TITLE
fix: add ActionResult to integrations missing it

### DIFF
--- a/app-business-reviews/app_business_reviews.py
+++ b/app-business-reviews/app_business_reviews.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -48,7 +48,7 @@ class SearchAppsIOS(ActionHandler):
             }
             apps.append(app)
 
-        return {"apps": apps, "total_results": len(apps)}
+        return ActionResult(data={"apps": apps, "total_results": len(apps)}, cost_usd=0.0)
 
 
 @app_business_reviews.action("get_reviews_app_store")
@@ -143,12 +143,12 @@ class GetReviewsAppStore(ActionHandler):
             if not pagination_info.get("next"):
                 break
 
-        return {
+        return ActionResult(data={
             "reviews": all_reviews,
             "total_reviews": len(all_reviews),
             "app_name": app_title,
             "product_id": product_id,
-        }
+        }, cost_usd=0.0)
 
 
 # ---- Google Play Store Actions ----
@@ -189,7 +189,7 @@ class SearchAppsAndroid(ActionHandler):
             if len(apps) >= limit:
                 break
 
-        return {"apps": apps, "total_results": len(apps)}
+        return ActionResult(data={"apps": apps, "total_results": len(apps)}, cost_usd=0.0)
 
 
 @app_business_reviews.action("get_reviews_google_play")
@@ -293,13 +293,13 @@ class GetReviewsGooglePlay(ActionHandler):
         # Extract app information from the response
         app_info = response.get("product_info", {})
 
-        return {
+        return ActionResult(data={
             "reviews": all_reviews,
             "total_reviews": len(all_reviews),
             "app_name": app_info.get("title", ""),
             "app_rating": app_info.get("rating") or 0.0,
             "product_id": product_id,
-        }
+        }, cost_usd=0.0)
 
 
 # ---- Google Maps Actions ----
@@ -340,7 +340,7 @@ class SearchPlacesGoogleMaps(ActionHandler):
             }
             places.append(place)
 
-        return {"places": places, "total_results": len(places)}
+        return ActionResult(data={"places": places, "total_results": len(places)}, cost_usd=0.0)
 
 
 @app_business_reviews.action("get_reviews_google_maps")
@@ -458,10 +458,10 @@ class GetReviewsGoogleMaps(ActionHandler):
             if local_results:
                 business_name = local_results[0].get("title", business_name)
 
-        return {
+        return ActionResult(data={
             "reviews": all_reviews,
             "total_reviews": len(all_reviews),
             "average_rating": place_info.get("rating") or 0.0,
             "business_name": business_name,
             "place_id": place_id or place_info.get("place_id", inputs.get("place_id", "")),
-        }
+        }, cost_usd=0.0)

--- a/app-business-reviews/requirements.txt
+++ b/app-business-reviews/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/box/box.py
+++ b/box/box.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import json
 import base64
@@ -52,10 +52,10 @@ class ListSharedFolders(ActionHandler):
             if current_offset + page_size < total_count:
                 response_data["nextPageToken"] = str(current_offset + page_size)
 
-            return response_data
+            return ActionResult(data=response_data, cost_usd=0.0)
 
         except Exception as e:
-            return {"folders": [], "result": False, "error": str(e)}
+            return ActionResult(data={"folders": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @box.action("list_files")
@@ -114,10 +114,10 @@ class ListFiles(ActionHandler):
             if "next_marker" in data:
                 response_data["nextPageToken"] = data["next_marker"]
 
-            return response_data
+            return ActionResult(data=response_data, cost_usd=0.0)
 
         except Exception as e:
-            return {"files": [], "result": False, "error": str(e)}
+            return ActionResult(data={"files": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @box.action("list_folder_contents")
@@ -176,10 +176,10 @@ class ListFolderContents(ActionHandler):
             if "next_marker" in data:
                 response_data["nextPageToken"] = data["next_marker"]
 
-            return response_data
+            return ActionResult(data=response_data, cost_usd=0.0)
 
         except Exception as e:
-            return {"items": [], "result": False, "error": str(e)}
+            return ActionResult(data={"items": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @box.action("get_file")
@@ -238,19 +238,19 @@ class GetFile(ActionHandler):
                 "parents": [metadata.get("parent", {}).get("id", "")] if metadata.get("parent") else [],
             }
 
-            return {
+            return ActionResult(data={
                 "file": {"name": file_name, "content": content_base64, "contentType": content_type},
                 "metadata": structured_metadata,
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {
+            return ActionResult(data={
                 "file": {"name": "", "content": "", "contentType": ""},
                 "metadata": {"id": file_id},
                 "result": False,
                 "error": str(e),
-            }
+            }, cost_usd=0.0)
 
 
 @box.action("upload_file")
@@ -324,7 +324,7 @@ class UploadFile(ActionHandler):
                         }
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 # ---- Polling Trigger Handlers ----

--- a/box/requirements.txt
+++ b/box/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 aiohttp  # Required directly: SDK context.fetch() lacks binary download and multipart form upload support

--- a/coda/coda.py
+++ b/coda/coda.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -70,10 +70,10 @@ class ListDocsAction(ActionHandler):
             # Extract docs from response
             docs = response.get("items", [])
 
-            return {"docs": docs, "result": True}
+            return ActionResult(data={"docs": docs, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"docs": [], "result": False, "error": str(e)}
+            return ActionResult(data={"docs": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("get_doc")
@@ -94,10 +94,10 @@ class GetDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("create_doc")
@@ -130,10 +130,10 @@ class CreateDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs"
             response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("update_doc")
@@ -164,10 +164,10 @@ class UpdateDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
             response = await context.fetch(url, method="PATCH", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("delete_doc")
@@ -190,10 +190,10 @@ class DeleteDocAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}"
             response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("list_pages")
@@ -233,10 +233,10 @@ class ListPagesAction(ActionHandler):
             if next_page_token:
                 result["next_page_token"] = next_page_token
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"pages": [], "result": False, "error": str(e)}
+            return ActionResult(data={"pages": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("get_page")
@@ -258,10 +258,10 @@ class GetPageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("create_page")
@@ -309,10 +309,10 @@ class CreatePageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages"
             response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("update_page")
@@ -352,10 +352,10 @@ class UpdatePageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
             response = await context.fetch(url, method="PUT", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("delete_page")
@@ -379,10 +379,10 @@ class DeletePageAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/pages/{page_id_or_name}"
             response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("list_tables")
@@ -428,10 +428,10 @@ class ListTablesAction(ActionHandler):
             if next_page_token:
                 result["next_page_token"] = next_page_token
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"tables": [], "result": False, "error": str(e)}
+            return ActionResult(data={"tables": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("get_table")
@@ -453,10 +453,10 @@ class GetTableAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("list_columns")
@@ -500,10 +500,10 @@ class ListColumnsAction(ActionHandler):
             if next_page_token:
                 result["next_page_token"] = next_page_token
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"columns": [], "result": False, "error": str(e)}
+            return ActionResult(data={"columns": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("get_column")
@@ -526,10 +526,10 @@ class GetColumnAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/columns/{column_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("list_rows")
@@ -585,10 +585,10 @@ class ListRowsAction(ActionHandler):
             if next_page_token:
                 result["next_page_token"] = next_page_token
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"rows": [], "result": False, "error": str(e)}
+            return ActionResult(data={"rows": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("get_row")
@@ -620,10 +620,10 @@ class GetRowAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
             response = await context.fetch(url, method="GET", headers=headers, params=params)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("upsert_rows")
@@ -660,10 +660,10 @@ class UpsertRowsAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
             response = await context.fetch(url, method="POST", headers=headers, params=params, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("update_row")
@@ -697,10 +697,10 @@ class UpdateRowAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
             response = await context.fetch(url, method="PUT", headers=headers, params=params, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("delete_row")
@@ -724,10 +724,10 @@ class DeleteRowAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows/{row_id_or_name}"
             response = await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @coda.action("delete_rows")
@@ -754,7 +754,7 @@ class DeleteRowsAction(ActionHandler):
             url = f"{CODA_API_BASE_URL}/docs/{doc_id}/tables/{table_id_or_name}/rows"
             response = await context.fetch(url, method="DELETE", headers=headers, json=body)
 
-            return {"data": response, "result": True}
+            return ActionResult(data={"data": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"data": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"data": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/coda/requirements.txt
+++ b/coda/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/doc-maker/doc_maker.py
+++ b/doc-maker/doc_maker.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 from docx import Document
 from docx.shared import Inches
@@ -667,7 +667,7 @@ class GetDocumentElementsAction(ActionHandler):
                         pattern = cell["pattern_type"]
                         pattern_counts[pattern] = pattern_counts.get(pattern, 0) + 1
 
-        return {
+        return ActionResult(data={
             "template_summary": {
                 "structure": f"{analysis['paragraphs']}p,{analysis['tables']}t",
                 "fillable_total": int(analysis["fillable_paragraphs"] + analysis["fillable_cells"]),
@@ -680,7 +680,7 @@ class GetDocumentElementsAction(ActionHandler):
             "pattern_distribution": pattern_counts,
             "recommended_strategy": "mixed" if len(pattern_counts) > 2 else "single_method",
             "template_ready": True,
-        }
+        }, cost_usd=0.0)
 
 
 @doc_maker.action("create_document")
@@ -722,7 +722,7 @@ class CreateDocumentAction(ActionHandler):
             "markdown_processed": bool(markdown_content),
         }
 
-        return await save_and_return_document(result, document_id, context, custom_filename)
+        return ActionResult(data=await save_and_return_document(result, document_id, context, custom_filename), cost_usd=0.0)
 
 
 @doc_maker.action("add_table")
@@ -749,7 +749,7 @@ class AddTableAction(ActionHandler):
                 table.cell(row_idx, col_idx).text = str(cell_value)
 
         original_result = {"table_rows": rows, "table_cols": cols}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)
 
 
 @doc_maker.action("add_image")
@@ -798,7 +798,7 @@ class AddImageAction(ActionHandler):
             paragraph.add_run().add_picture(image_file)
 
         original_result = {"image_added": True}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)
 
 
 @doc_maker.action("add_markdown_content")
@@ -822,7 +822,7 @@ class AddMarkdownContentAction(ActionHandler):
         elements_added = len([p for p in doc.paragraphs if p.text.strip()])
 
         original_result = {"markdown_processed": True, "elements_added": elements_added}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)
 
 
 @doc_maker.action("update_by_position")
@@ -893,7 +893,7 @@ class UpdateByPositionAction(ActionHandler):
             + (f", {len(failed_updates)} failed" if failed_updates else ""),
             "failures": failed_updates[:3] if failed_updates else [],  # Limit failure details
         }
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)
 
 
 @doc_maker.action("find_and_replace")
@@ -1150,7 +1150,7 @@ class FindAndReplaceAction(ActionHandler):
             "alerts": warnings[:3] if warnings else [],
             "safety_active": True,
         }
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)
 
 
 @doc_maker.action("fill_template_fields")
@@ -1388,7 +1388,7 @@ class FillTemplateFieldsAction(ActionHandler):
             "template_status": "partially_complete" if blocked_operations > 0 else "complete",
             "action_required": "Review safety warnings and use more specific context" if safety_warnings else "none",
         }
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)
 
 
 @doc_maker.action("save_document")
@@ -1415,7 +1415,7 @@ class SaveDocumentAction(ActionHandler):
             # Get file name from path
             file_name = os.path.basename(file_path)
 
-            return {
+            return ActionResult(data={
                 "saved": True,
                 "file_path": file_path,
                 "file": {
@@ -1423,9 +1423,9 @@ class SaveDocumentAction(ActionHandler):
                     "name": file_name,
                     "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 },
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {
+            return ActionResult(data={
                 "saved": False,
                 "file_path": file_path,
                 "file": {
@@ -1434,7 +1434,7 @@ class SaveDocumentAction(ActionHandler):
                     "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 },
                 "error": f"Could not generate document for streaming: {str(e)}",
-            }
+            }, cost_usd=0.0)
 
 
 @doc_maker.action("add_page_break")
@@ -1453,4 +1453,4 @@ class AddPageBreakAction(ActionHandler):
         paragraph.add_run().add_break(WD_BREAK.PAGE)
 
         original_result = {"page_break_added": True}
-        return await save_and_return_document(original_result, document_id, context)
+        return ActionResult(data=await save_and_return_document(original_result, document_id, context), cost_usd=0.0)

--- a/doc-maker/requirements.txt
+++ b/doc-maker/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 python-docx
 markdown
 beautifulsoup4

--- a/elevenlabs/elevenlabs.py
+++ b/elevenlabs/elevenlabs.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import base64
 import aiohttp
@@ -57,10 +57,10 @@ class ListVoicesAction(ActionHandler):
             )
 
             voices = response.get("voices", [])
-            return {"voices": voices, "result": True}
+            return ActionResult(data={"voices": voices, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"voices": [], "result": False, "error": str(e)}
+            return ActionResult(data={"voices": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @elevenlabs.action("get_voice")
@@ -84,10 +84,10 @@ class GetVoiceAction(ActionHandler):
                 params=params if params else None,
             )
 
-            return {"voice": response, "result": True}
+            return ActionResult(data={"voice": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"voice": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"voice": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @elevenlabs.action("get_voice_settings")
@@ -104,10 +104,10 @@ class GetVoiceSettingsAction(ActionHandler):
                 f"{ELEVENLABS_API_BASE_URL}/voices/{voice_id}/settings", method="GET", headers=headers
             )
 
-            return {"settings": response, "result": True}
+            return ActionResult(data={"settings": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"settings": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"settings": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @elevenlabs.action("list_history")
@@ -130,10 +130,10 @@ class ListHistoryAction(ActionHandler):
             )
 
             history = response.get("history", [])
-            return {"history": history, "result": True}
+            return ActionResult(data={"history": history, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"history": [], "result": False, "error": str(e)}
+            return ActionResult(data={"history": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @elevenlabs.action("download_history_audio")
@@ -171,7 +171,7 @@ class DownloadHistoryAudioAction(ActionHandler):
                         return {"audio": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}
 
         except Exception as e:
-            return {"audio": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"audio": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @elevenlabs.action("get_user_subscription")
@@ -186,10 +186,10 @@ class GetUserSubscriptionAction(ActionHandler):
                 f"{ELEVENLABS_API_BASE_URL}/user/subscription", method="GET", headers=headers
             )
 
-            return {"subscription": response, "result": True}
+            return ActionResult(data={"subscription": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"subscription": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"subscription": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @elevenlabs.action("text_to_speech")
@@ -240,4 +240,4 @@ class TextToSpeechAction(ActionHandler):
                         return {"audio": {}, "result": False, "error": f"HTTP {resp.status}: {error_text}"}
 
         except Exception as e:
-            return {"audio": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"audio": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/elevenlabs/requirements.txt
+++ b/elevenlabs/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/freshdesk/freshdesk.py
+++ b/freshdesk/freshdesk.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import base64
 
@@ -80,10 +80,10 @@ class ListCompaniesAction(ActionHandler):
             # Response is a list of companies
             companies = response if isinstance(response, list) else []
 
-            return {"companies": companies, "total": len(companies), "result": True}
+            return ActionResult(data={"companies": companies, "total": len(companies), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"companies": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"companies": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("create_company")
@@ -119,10 +119,10 @@ class CreateCompanyAction(ActionHandler):
             url = f"{base_url}/companies"
             response = await context.fetch(url, method="POST", headers=headers, json=body)
 
-            return {"company": response, "result": True}
+            return ActionResult(data={"company": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"company": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"company": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("get_company")
@@ -144,10 +144,10 @@ class GetCompanyAction(ActionHandler):
             url = f"{base_url}/companies/{company_id}"
             response = await context.fetch(url, method="GET", headers=headers)
 
-            return {"company": response, "result": True}
+            return ActionResult(data={"company": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"company": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"company": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("update_company")
@@ -188,10 +188,10 @@ class UpdateCompanyAction(ActionHandler):
             url = f"{base_url}/companies/{company_id}"
             response = await context.fetch(url, method="PUT", headers=headers, json=body)
 
-            return {"company": response, "result": True}
+            return ActionResult(data={"company": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"company": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"company": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("delete_company")
@@ -214,10 +214,10 @@ class DeleteCompanyAction(ActionHandler):
             url = f"{base_url}/companies/{company_id}"
             await context.fetch(url, method="DELETE", headers=headers)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("search_companies")
@@ -248,10 +248,10 @@ class SearchCompaniesAction(ActionHandler):
             # Extract companies from response
             companies = response.get("companies", []) if isinstance(response, dict) else []
 
-            return {"companies": companies, "total": len(companies), "result": True}
+            return ActionResult(data={"companies": companies, "total": len(companies), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"companies": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"companies": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 # ---- Ticket Handlers ----
@@ -285,10 +285,10 @@ class CreateTicketAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets", method="POST", headers=headers, json=body)
 
-            return {"ticket": response, "result": True}
+            return ActionResult(data={"ticket": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"ticket": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"ticket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("list_tickets")
@@ -306,10 +306,10 @@ class ListTicketsAction(ActionHandler):
 
             tickets = response if isinstance(response, list) else []
 
-            return {"tickets": tickets, "total": len(tickets), "result": True}
+            return ActionResult(data={"tickets": tickets, "total": len(tickets), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"tickets": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"tickets": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("get_ticket")
@@ -325,10 +325,10 @@ class GetTicketAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets/{ticket_id}", method="GET", headers=headers)
 
-            return {"ticket": response, "result": True}
+            return ActionResult(data={"ticket": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"ticket": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"ticket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("update_ticket")
@@ -356,10 +356,10 @@ class UpdateTicketAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/tickets/{ticket_id}", method="PUT", headers=headers, json=body)
 
-            return {"ticket": response, "result": True}
+            return ActionResult(data={"ticket": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"ticket": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"ticket": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("delete_ticket")
@@ -375,10 +375,10 @@ class DeleteTicketAction(ActionHandler):
 
             await context.fetch(f"{base_url}/tickets/{ticket_id}", method="DELETE", headers=headers)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 # ---- Contact Handlers ----
@@ -410,10 +410,10 @@ class CreateContactAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/contacts", method="POST", headers=headers, json=body)
 
-            return {"contact": response, "result": True}
+            return ActionResult(data={"contact": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"contact": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"contact": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("list_contacts")
@@ -431,10 +431,10 @@ class ListContactsAction(ActionHandler):
 
             contacts = response if isinstance(response, list) else []
 
-            return {"contacts": contacts, "total": len(contacts), "result": True}
+            return ActionResult(data={"contacts": contacts, "total": len(contacts), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"contacts": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"contacts": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("get_contact")
@@ -450,10 +450,10 @@ class GetContactAction(ActionHandler):
 
             response = await context.fetch(f"{base_url}/contacts/{contact_id}", method="GET", headers=headers)
 
-            return {"contact": response, "result": True}
+            return ActionResult(data={"contact": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"contact": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"contact": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("update_contact")
@@ -485,10 +485,10 @@ class UpdateContactAction(ActionHandler):
                 f"{base_url}/contacts/{contact_id}", method="PUT", headers=headers, json=body
             )
 
-            return {"contact": response, "result": True}
+            return ActionResult(data={"contact": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"contact": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"contact": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("delete_contact")
@@ -504,10 +504,10 @@ class DeleteContactAction(ActionHandler):
 
             await context.fetch(f"{base_url}/contacts/{contact_id}", method="DELETE", headers=headers)
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("search_contacts")
@@ -538,10 +538,10 @@ class SearchContactsAction(ActionHandler):
             # Response is directly an array of contacts
             contacts = response if isinstance(response, list) else []
 
-            return {"contacts": contacts, "total": len(contacts), "result": True}
+            return ActionResult(data={"contacts": contacts, "total": len(contacts), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"contacts": [], "total": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"contacts": [], "total": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 # ---- Conversation Handlers ----
@@ -564,10 +564,10 @@ class ListConversationsAction(ActionHandler):
 
             conversations = response if isinstance(response, list) else []
 
-            return {"conversations": conversations, "result": True}
+            return ActionResult(data={"conversations": conversations, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversations": [], "result": False, "error": str(e)}
+            return ActionResult(data={"conversations": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("create_note")
@@ -589,10 +589,10 @@ class CreateNoteAction(ActionHandler):
                 f"{base_url}/tickets/{ticket_id}/notes", method="POST", headers=headers, json=body
             )
 
-            return {"conversation": response, "result": True}
+            return ActionResult(data={"conversation": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"conversation": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @freshdesk.action("create_reply")
@@ -614,7 +614,7 @@ class CreateReplyAction(ActionHandler):
                 f"{base_url}/tickets/{ticket_id}/reply", method="POST", headers=headers, json=body
             )
 
-            return {"conversation": response, "result": True}
+            return ActionResult(data={"conversation": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"conversation": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/freshdesk/requirements.txt
+++ b/freshdesk/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/front/front.py
+++ b/front/front.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 import base64
 import aiohttp
@@ -87,11 +87,11 @@ class GetInboxAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "inbox": {},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse inbox
             inbox = {
@@ -108,10 +108,10 @@ class GetInboxAction(ActionHandler):
             if "is_private" in response:
                 inbox["is_private"] = response["is_private"]
 
-            return {"inbox": inbox, "result": True}
+            return ActionResult(data={"inbox": inbox, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"inbox": {}, "result": False, "error": f"Error getting inbox: {str(e)}"}
+            return ActionResult(data={"inbox": {}, "result": False, "error": f"Error getting inbox: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("list_inbox_conversations")
@@ -135,11 +135,11 @@ class ListInboxConversationsAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "conversations": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse conversations
             conversations = []
@@ -148,10 +148,10 @@ class ListInboxConversationsAction(ActionHandler):
             for raw_conv in raw_conversations:
                 conversations.append(FrontDataParser.parse_conversation(raw_conv))
 
-            return {"conversations": conversations, "result": True}
+            return ActionResult(data={"conversations": conversations, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversations": [], "result": False, "error": f"Error listing inbox conversations: {str(e)}"}
+            return ActionResult(data={"conversations": [], "result": False, "error": f"Error listing inbox conversations: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("get_conversation")
@@ -165,19 +165,19 @@ class GetConversationAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "conversation": {},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse conversation - Front returns conversation data directly
             conversation = FrontDataParser.parse_conversation(response)
 
-            return {"conversation": conversation, "result": True}
+            return ActionResult(data={"conversation": conversation, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": f"Error getting conversation: {str(e)}"}
+            return ActionResult(data={"conversation": {}, "result": False, "error": f"Error getting conversation: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("list_conversation_messages")
@@ -194,11 +194,11 @@ class ListConversationMessagesAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "messages": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse messages
             messages = []
@@ -207,10 +207,10 @@ class ListConversationMessagesAction(ActionHandler):
             for raw_msg in raw_messages:
                 messages.append(FrontDataParser.parse_message(raw_msg))
 
-            return {"messages": messages, "result": True}
+            return ActionResult(data={"messages": messages, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"messages": [], "result": False, "error": f"Error listing conversation messages: {str(e)}"}
+            return ActionResult(data={"messages": [], "result": False, "error": f"Error listing conversation messages: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("create_message_reply")
@@ -284,17 +284,17 @@ class CreateMessageReplyAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "message_uid": "",
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Front returns message_uid for async processing
-            return {"message_uid": response.get("message_uid", ""), "result": True}
+            return ActionResult(data={"message_uid": response.get("message_uid", ""), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"message_uid": "", "result": False, "error": f"Error creating message reply: {str(e)}"}
+            return ActionResult(data={"message_uid": "", "result": False, "error": f"Error creating message reply: {str(e)}"}, cost_usd=0.0)
 
     async def _send_reply_with_attachments(
         self,
@@ -435,19 +435,19 @@ class GetMessageAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "message": {},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse message
             message = FrontDataParser.parse_message(response)
 
-            return {"message": message, "result": True}
+            return ActionResult(data={"message": message, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"message": {}, "result": False, "error": f"Error getting message: {str(e)}"}
+            return ActionResult(data={"message": {}, "result": False, "error": f"Error getting message: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("download_message_attachment")
@@ -511,7 +511,7 @@ class DownloadMessageAttachmentAction(ActionHandler):
                     }
 
         except Exception as e:
-            return {"file": {}, "result": False, "error": f"Error downloading attachment: {str(e)}"}
+            return ActionResult(data={"file": {}, "result": False, "error": f"Error downloading attachment: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("create_message")
@@ -579,17 +579,17 @@ class CreateMessageAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "message_uid": "",
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Front returns message_uid for async processing
-            return {"message_uid": response.get("message_uid", ""), "result": True}
+            return ActionResult(data={"message_uid": response.get("message_uid", ""), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"message_uid": "", "result": False, "error": f"Error creating message: {str(e)}"}
+            return ActionResult(data={"message_uid": "", "result": False, "error": f"Error creating message: {str(e)}"}, cost_usd=0.0)
 
     async def _send_with_attachments(
         self,
@@ -728,11 +728,11 @@ class ListChannelsAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "channels": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse channels
             channels = []
@@ -754,10 +754,10 @@ class ListChannelsAction(ActionHandler):
 
                 channels.append(channel)
 
-            return {"channels": channels, "result": True}
+            return ActionResult(data={"channels": channels, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"channels": [], "result": False, "error": f"Error listing channels: {str(e)}"}
+            return ActionResult(data={"channels": [], "result": False, "error": f"Error listing channels: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("list_inbox_channels")
@@ -774,11 +774,11 @@ class ListInboxChannelsAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "channels": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse channels
             channels = []
@@ -800,10 +800,10 @@ class ListInboxChannelsAction(ActionHandler):
 
                 channels.append(channel)
 
-            return {"channels": channels, "result": True}
+            return ActionResult(data={"channels": channels, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"channels": [], "result": False, "error": f"Error listing inbox channels: {str(e)}"}
+            return ActionResult(data={"channels": [], "result": False, "error": f"Error listing inbox channels: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("get_channel")
@@ -817,11 +817,11 @@ class GetChannelAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "channel": {"id": "", "name": "", "type": ""},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse channel - Note: Front API returns "types" but we standardize to "type"
             channel = {
@@ -840,14 +840,14 @@ class GetChannelAction(ActionHandler):
             if "settings" in response:
                 channel["settings"] = response["settings"]
 
-            return {"channel": channel, "result": True}
+            return ActionResult(data={"channel": channel, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {
+            return ActionResult(data={
                 "channel": {"id": "", "name": "", "type": ""},
                 "result": False,
                 "error": f"Error getting channel: {str(e)}",
-            }
+            }, cost_usd=0.0)
 
 
 @front.action("list_message_templates")
@@ -861,11 +861,11 @@ class ListMessageTemplatesAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "templates": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse templates
             templates = []
@@ -883,10 +883,10 @@ class ListMessageTemplatesAction(ActionHandler):
 
                 templates.append(template)
 
-            return {"templates": templates, "result": True}
+            return ActionResult(data={"templates": templates, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"templates": [], "result": False, "error": f"Error listing message templates: {str(e)}"}
+            return ActionResult(data={"templates": [], "result": False, "error": f"Error listing message templates: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("get_message_template")
@@ -900,11 +900,11 @@ class GetMessageTemplateAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "template": {},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse template
             template = {
@@ -916,10 +916,10 @@ class GetMessageTemplateAction(ActionHandler):
                 "metadata": response.get("metadata", {}),
             }
 
-            return {"template": template, "result": True}
+            return ActionResult(data={"template": template, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"template": {}, "result": False, "error": f"Error getting message template: {str(e)}"}
+            return ActionResult(data={"template": {}, "result": False, "error": f"Error getting message template: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("update_conversation")
@@ -946,7 +946,7 @@ class UpdateConversationAction(ActionHandler):
                 update_data["custom_fields"] = inputs["custom_fields"]
 
             if not update_data:
-                return {"conversation": {}, "result": False, "error": "No valid update fields provided"}
+                return ActionResult(data={"conversation": {}, "result": False, "error": "No valid update fields provided"}, cost_usd=0.0)
 
             # Update conversation
             response = await context.fetch(
@@ -960,33 +960,33 @@ class UpdateConversationAction(ActionHandler):
                 get_response = await context.fetch(f"{FRONT_API_BASE}/conversations/{conversation_id}")
 
                 if get_response is None or "error" in get_response:
-                    return {
+                    return ActionResult(data={
                         "conversation": {},
                         "result": False,
                         "error": (
                             f"Update may have succeeded but failed to fetch updated conversation: "
                             f"{get_response.get('error', 'Unknown error') if get_response else 'No response'}"
                         ),
-                    }
+                    }, cost_usd=0.0)
 
                 conversation = FrontDataParser.parse_conversation(get_response)
-                return {"conversation": conversation, "result": True}
+                return ActionResult(data={"conversation": conversation, "result": True}, cost_usd=0.0)
 
             # Check for API errors in response
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "conversation": {},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse response conversation
             conversation = FrontDataParser.parse_conversation(response)
 
-            return {"conversation": conversation, "result": True}
+            return ActionResult(data={"conversation": conversation, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversation": {}, "result": False, "error": f"Error updating conversation: {str(e)}"}
+            return ActionResult(data={"conversation": {}, "result": False, "error": f"Error updating conversation: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("list_inboxes")
@@ -1000,11 +1000,11 @@ class ListInboxesAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "inboxes": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse inboxes
             inboxes = []
@@ -1024,10 +1024,10 @@ class ListInboxesAction(ActionHandler):
 
                 inboxes.append(inbox)
 
-            return {"inboxes": inboxes, "result": True}
+            return ActionResult(data={"inboxes": inboxes, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"inboxes": [], "result": False, "error": f"Error listing inboxes: {str(e)}"}
+            return ActionResult(data={"inboxes": [], "result": False, "error": f"Error listing inboxes: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("list_teammates")
@@ -1041,11 +1041,11 @@ class ListTeammatesAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "teammates": [],
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse teammates
             teammates = []
@@ -1067,10 +1067,10 @@ class ListTeammatesAction(ActionHandler):
 
                 teammates.append(teammate)
 
-            return {"teammates": teammates, "result": True}
+            return ActionResult(data={"teammates": teammates, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"teammates": [], "result": False, "error": f"Error listing teammates: {str(e)}"}
+            return ActionResult(data={"teammates": [], "result": False, "error": f"Error listing teammates: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("get_teammate")
@@ -1084,11 +1084,11 @@ class GetTeammateAction(ActionHandler):
 
             # Check for API errors
             if "error" in response:
-                return {
+                return ActionResult(data={
                     "teammate": {},
                     "result": False,
                     "error": f"API request failed: {response.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Parse teammate
             teammate = {
@@ -1104,10 +1104,10 @@ class GetTeammateAction(ActionHandler):
                 "custom_fields": response.get("custom_fields", {}),
             }
 
-            return {"teammate": teammate, "result": True}
+            return ActionResult(data={"teammate": teammate, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"teammate": {}, "result": False, "error": f"Error getting teammate: {str(e)}"}
+            return ActionResult(data={"teammate": {}, "result": False, "error": f"Error getting teammate: {str(e)}"}, cost_usd=0.0)
 
 
 # ---- Helper Actions for Name-Based Lookups ----
@@ -1128,11 +1128,11 @@ class FindTeammateAction(ActionHandler):
             list_result = await list_action.execute({"limit": 100}, context)
 
             if not list_result["result"]:
-                return {
+                return ActionResult(data={
                     "teammates": [],
                     "result": False,
                     "error": f"Failed to fetch teammates: {list_result.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Filter teammates by search query (case-insensitive partial match)
             teammates = list_result["teammates"]
@@ -1156,10 +1156,10 @@ class FindTeammateAction(ActionHandler):
                 ):
                     matching_teammates.append(teammate)
 
-            return {"teammates": matching_teammates, "result": True, "count": len(matching_teammates)}
+            return ActionResult(data={"teammates": matching_teammates, "result": True, "count": len(matching_teammates)}, cost_usd=0.0)
 
         except Exception as e:
-            return {"teammates": [], "result": False, "error": f"Error finding teammate: {str(e)}"}
+            return ActionResult(data={"teammates": [], "result": False, "error": f"Error finding teammate: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("find_inbox")
@@ -1177,11 +1177,11 @@ class FindInboxAction(ActionHandler):
             list_result = await list_action.execute({"limit": 100}, context)
 
             if not list_result["result"]:
-                return {
+                return ActionResult(data={
                     "inboxes": [],
                     "result": False,
                     "error": f"Failed to fetch inboxes: {list_result.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Filter inboxes by name (case-insensitive partial match)
             inboxes = list_result["inboxes"]
@@ -1194,10 +1194,10 @@ class FindInboxAction(ActionHandler):
                 if inbox_name in name:
                     matching_inboxes.append(inbox)
 
-            return {"inboxes": matching_inboxes, "result": True, "count": len(matching_inboxes)}
+            return ActionResult(data={"inboxes": matching_inboxes, "result": True, "count": len(matching_inboxes)}, cost_usd=0.0)
 
         except Exception as e:
-            return {"inboxes": [], "result": False, "error": f"Error finding inbox: {str(e)}"}
+            return ActionResult(data={"inboxes": [], "result": False, "error": f"Error finding inbox: {str(e)}"}, cost_usd=0.0)
 
 
 @front.action("find_conversation")
@@ -1216,11 +1216,11 @@ class FindConversationAction(ActionHandler):
             list_result = await list_action.execute({"inbox_id": inbox_id, "limit": 100}, context)
 
             if not list_result["result"]:
-                return {
+                return ActionResult(data={
                     "conversations": [],
                     "result": False,
                     "error": f"Failed to fetch conversations: {list_result.get('error', 'Unknown error')}",
-                }
+                }, cost_usd=0.0)
 
             # Filter conversations by search query (case-insensitive partial match)
             conversations = list_result["conversations"]
@@ -1246,7 +1246,7 @@ class FindConversationAction(ActionHandler):
                 ):
                     matching_conversations.append(conversation)
 
-            return {"conversations": matching_conversations, "result": True, "count": len(matching_conversations)}
+            return ActionResult(data={"conversations": matching_conversations, "result": True, "count": len(matching_conversations)}, cost_usd=0.0)
 
         except Exception as e:
-            return {"conversations": [], "result": False, "error": f"Error finding conversation: {str(e)}"}
+            return ActionResult(data={"conversations": [], "result": False, "error": f"Error finding conversation: {str(e)}"}, cost_usd=0.0)

--- a/front/requirements.txt
+++ b/front/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/google-business-profie/requirements.txt
+++ b/google-business-profie/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/google-business-profie/reviews.py
+++ b/google-business-profie/reviews.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -87,12 +87,12 @@ class ListAccounts(ActionHandler):
                     }
                 )
 
-            return {"accounts": accounts, "result": True}
+            return ActionResult(data={"accounts": accounts, "result": True}, cost_usd=0.0)
 
         except HttpError as e:
-            return {"accounts": [], "result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"accounts": [], "result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0.0)
         except Exception as e:
-            return {"accounts": [], "result": False, "error": str(e)}
+            return ActionResult(data={"accounts": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @reviews.action("list_locations")
@@ -138,12 +138,12 @@ class ListLocations(ActionHandler):
                     }
                 )
 
-            return {"locations": locations, "result": True}
+            return ActionResult(data={"locations": locations, "result": True}, cost_usd=0.0)
 
         except HttpError as e:
-            return {"locations": [], "result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"locations": [], "result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0.0)
         except Exception as e:
-            return {"locations": [], "result": False, "error": str(e)}
+            return ActionResult(data={"locations": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @reviews.action("list_reviews")
@@ -155,14 +155,14 @@ class ListReviews(ActionHandler):
 
             # Validate location_name format
             if not location_name.startswith("accounts/"):
-                return {
+                return ActionResult(data={
                     "reviews": [],
                     "result": False,
                     "error": (
                         f"Invalid location_name format: '{location_name}'. "
                         "Expected format: 'accounts/{account_id}/locations/{location_id}'"
                     ),
-                }
+                }, cost_usd=0.0)
 
             # List reviews for the location
             request = service.accounts().locations().reviews().list(parent=location_name)
@@ -194,12 +194,12 @@ class ListReviews(ActionHandler):
 
                 reviews.append(review_data)
 
-            return {"reviews": reviews, "result": True}
+            return ActionResult(data={"reviews": reviews, "result": True}, cost_usd=0.0)
 
         except HttpError as e:
-            return {"reviews": [], "result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"reviews": [], "result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0.0)
         except Exception as e:
-            return {"reviews": [], "result": False, "error": str(e)}
+            return ActionResult(data={"reviews": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @reviews.action("reply_to_review")
@@ -215,15 +215,15 @@ class ReplyToReview(ActionHandler):
             request = service.accounts().locations().reviews().updateReply(name=review_name, body=reply_body)
             response = request.execute()
 
-            return {
+            return ActionResult(data={
                 "reviewReply": {"comment": response.get("comment", ""), "updateTime": response.get("updateTime", "")},
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except HttpError as e:
-            return {"result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0.0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @reviews.action("delete_review_reply")
@@ -236,9 +236,9 @@ class DeleteReviewReply(ActionHandler):
             request = service.accounts().locations().reviews().deleteReply(name=review_name)
             request.execute()
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except HttpError as e:
-            return {"result": False, "error": f"Google API error: {str(e)}"}
+            return ActionResult(data={"result": False, "error": f"Google API error: {str(e)}"}, cost_usd=0.0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)

--- a/google-calendar/google_calendar.py
+++ b/google-calendar/google_calendar.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -67,10 +67,10 @@ class ListCalendars(ActionHandler):
             for raw_calendar in response.get("items", []):
                 calendars.append(CalendarEventParser.parse_calendar(raw_calendar))
 
-            return {"calendars": calendars, "result": True}
+            return ActionResult(data={"calendars": calendars, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"calendars": [], "result": False, "error": str(e)}
+            return ActionResult(data={"calendars": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_calendar.action("list_events")
@@ -105,10 +105,10 @@ class ListEvents(ActionHandler):
             if "nextPageToken" in response:
                 result["nextPageToken"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"events": [], "result": False, "error": str(e)}
+            return ActionResult(data={"events": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_calendar.action("get_event")
@@ -122,10 +122,10 @@ class GetEvent(ActionHandler):
                 service_endpoint + f"calendars/{calendar_id}/events/{event_id}", method="GET"
             )
 
-            return {"event": CalendarEventParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": CalendarEventParser.parse_event(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_calendar.action("create_event")
@@ -159,10 +159,10 @@ class CreateEvent(ActionHandler):
                 service_endpoint + f"calendars/{calendar_id}/events", method="POST", json=event_data
             )
 
-            return {"event": CalendarEventParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": CalendarEventParser.parse_event(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_calendar.action("update_event")
@@ -208,10 +208,10 @@ class UpdateEvent(ActionHandler):
                 service_endpoint + f"calendars/{calendar_id}/events/{event_id}", method="PUT", json=event_data
             )
 
-            return {"event": CalendarEventParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": CalendarEventParser.parse_event(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_calendar.action("delete_event")
@@ -223,10 +223,10 @@ class DeleteEvent(ActionHandler):
 
             await context.fetch(service_endpoint + f"calendars/{calendar_id}/events/{event_id}", method="DELETE")
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 # ---- Polling Trigger Handlers ----

--- a/google-calendar/requirements.txt
+++ b/google-calendar/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/google-chat/google_chat.py
+++ b/google-chat/google_chat.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -145,10 +145,10 @@ class ListSpaces(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"spaces": [], **handle_api_error(e)}
+            return ActionResult(data={"spaces": [], **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("get_space")
@@ -161,10 +161,10 @@ class GetSpace(ActionHandler):
             request = service.spaces().get(name=space_name)
             response = request.execute()
 
-            return {"space": format_space(response), "result": True}
+            return ActionResult(data={"space": format_space(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"space": {}, **handle_api_error(e)}
+            return ActionResult(data={"space": {}, **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("create_space")
@@ -181,10 +181,10 @@ class CreateSpace(ActionHandler):
             request = service.spaces().create(body=space_body)
             response = request.execute()
 
-            return {"space": format_space(response), "result": True}
+            return ActionResult(data={"space": format_space(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"space": {}, **handle_api_error(e)}
+            return ActionResult(data={"space": {}, **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("send_message")
@@ -208,10 +208,10 @@ class SendMessage(ActionHandler):
             request = service.spaces().messages().create(**params)
             response = request.execute()
 
-            return {"message": format_message(response), "result": True}
+            return ActionResult(data={"message": format_message(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"message": {}, **handle_api_error(e)}
+            return ActionResult(data={"message": {}, **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("list_messages")
@@ -246,10 +246,10 @@ class ListMessages(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"messages": [], **handle_api_error(e)}
+            return ActionResult(data={"messages": [], **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("get_message")
@@ -262,10 +262,10 @@ class GetMessage(ActionHandler):
             request = service.spaces().messages().get(name=message_name)
             response = request.execute()
 
-            return {"message": format_message(response), "result": True}
+            return ActionResult(data={"message": format_message(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"message": {}, **handle_api_error(e)}
+            return ActionResult(data={"message": {}, **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("update_message")
@@ -282,10 +282,10 @@ class UpdateMessage(ActionHandler):
             request = service.spaces().messages().patch(**params)
             response = request.execute()
 
-            return {"message": format_message(response), "result": True}
+            return ActionResult(data={"message": format_message(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"message": {}, **handle_api_error(e)}
+            return ActionResult(data={"message": {}, **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("delete_message")
@@ -302,10 +302,10 @@ class DeleteMessage(ActionHandler):
             request = service.spaces().messages().delete(**params)
             request.execute()
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return handle_api_error(e)
+            return ActionResult(data=handle_api_error(e), cost_usd=0.0)
 
 
 @google_chat.action("list_members")
@@ -336,10 +336,10 @@ class ListMembers(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"members": [], **handle_api_error(e)}
+            return ActionResult(data={"members": [], **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("add_reaction")
@@ -354,10 +354,10 @@ class AddReaction(ActionHandler):
             request = service.spaces().messages().reactions().create(parent=message_name, body=reaction_body)
             response = request.execute()
 
-            return {"reaction": format_reaction(response), "result": True}
+            return ActionResult(data={"reaction": format_reaction(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"reaction": {}, **handle_api_error(e)}
+            return ActionResult(data={"reaction": {}, **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("list_reactions")
@@ -388,10 +388,10 @@ class ListReactions(ActionHandler):
             if "nextPageToken" in response:
                 result["next_page_token"] = response["nextPageToken"]
 
-            return result
+            return ActionResult(data=result, cost_usd=0.0)
 
         except Exception as e:
-            return {"reactions": [], **handle_api_error(e)}
+            return ActionResult(data={"reactions": [], **handle_api_error(e)}, cost_usd=0.0)
 
 
 @google_chat.action("remove_reaction")
@@ -404,10 +404,10 @@ class RemoveReaction(ActionHandler):
             request = service.spaces().messages().reactions().delete(name=reaction_name)
             request.execute()
 
-            return {"result": True}
+            return ActionResult(data={"result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return handle_api_error(e)
+            return ActionResult(data=handle_api_error(e), cost_usd=0.0)
 
 
 @google_chat.action("find_direct_message")
@@ -420,7 +420,7 @@ class FindDirectMessage(ActionHandler):
             request = service.spaces().findDirectMessage(name=user_name)
             response = request.execute()
 
-            return {"space": format_space(response), "result": True}
+            return ActionResult(data={"space": format_space(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"space": {}, **handle_api_error(e)}
+            return ActionResult(data={"space": {}, **handle_api_error(e)}, cost_usd=0.0)

--- a/google-chat/requirements.txt
+++ b/google-chat/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/google-sheets/google_sheets.py
+++ b/google-sheets/google_sheets.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any, List
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -58,15 +58,15 @@ class ListSpreadsheets(ActionHandler):
             next_page = result.get("nextPageToken")
             if isinstance(next_page, str) and next_page:
                 response["nextPageToken"] = next_page
-            return response
+            return ActionResult(data=response, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "files": [],
                 "result": False,
                 "error": f"Google Drive API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"files": [], "result": False, "error": str(e)}
+            return ActionResult(data={"files": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_get_spreadsheet")
@@ -78,15 +78,15 @@ class GetSpreadsheet(ActionHandler):
             include_grid = bool(inputs.get("include_grid_data", False))
             request = service.spreadsheets().get(spreadsheetId=spreadsheet_id, includeGridData=include_grid)
             spreadsheet = request.execute()
-            return {"spreadsheet": spreadsheet, "result": True}
+            return ActionResult(data={"spreadsheet": spreadsheet, "result": True}, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "spreadsheet": {},
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"spreadsheet": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"spreadsheet": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_list_sheets")
@@ -105,15 +105,15 @@ class ListSheets(ActionHandler):
                 .execute()
             )
             sheets_list = [s.get("properties", {}) for s in result.get("sheets", [])]
-            return {"sheets": sheets_list, "result": True}
+            return ActionResult(data={"sheets": sheets_list, "result": True}, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "sheets": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"sheets": [], "result": False, "error": str(e)}
+            return ActionResult(data={"sheets": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_read_range")
@@ -131,25 +131,25 @@ class ReadRange(ActionHandler):
             if dt_render:
                 params["dateTimeRenderOption"] = dt_render
             result = service.spreadsheets().values().get(**params).execute()
-            return {
+            return ActionResult(data={
                 "range": result.get("range", a1),
                 "values": result.get("values", []),
                 "result": True,
-            }
+            }, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "range": inputs.get("range"),
                 "values": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {
+            return ActionResult(data={
                 "range": inputs.get("range"),
                 "values": [],
                 "result": False,
                 "error": str(e),
-            }
+            }, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_write_range")
@@ -169,14 +169,14 @@ class WriteRange(ActionHandler):
                 # Estimate cells
                 rows = len(values)
                 cols = max((len(r) for r in values), default=0)
-                return {
+                return ActionResult(data={
                     "updatedRange": a1,
                     "updatedRows": rows,
                     "updatedColumns": cols,
                     "updatedCells": rows * cols,
                     "dryRun": True,
                     "result": True,
-                }
+                }, cost_usd=0.0)
 
             service = build_sheets_service(context)
             body = {"values": values}
@@ -191,18 +191,18 @@ class WriteRange(ActionHandler):
                 )
                 .execute()
             )
-            return {
+            return ActionResult(data={
                 "updatedRange": result.get("updatedRange", a1),
                 "updatedRows": result.get("updatedRows", 0),
                 "updatedColumns": result.get("updatedColumns", 0),
                 "updatedCells": result.get("updatedCells", 0),
                 "dryRun": False,
                 "result": True,
-            }
+            }, cost_usd=0.0)
         except HttpError as e:
-            return {"result": False, "error": f"Google Sheets API error: {str(e)}"}
+            return ActionResult(data={"result": False, "error": f"Google Sheets API error: {str(e)}"}, cost_usd=0.0)
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_append_rows")
@@ -227,15 +227,15 @@ class AppendRows(ActionHandler):
                 )
                 .execute()
             )
-            return {"updates": result.get("updates", result), "result": True}
+            return ActionResult(data={"updates": result.get("updates", result), "result": True}, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "updates": {},
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"updates": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"updates": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_format_range")
@@ -260,15 +260,15 @@ class FormatRange(ActionHandler):
             result = (
                 service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
             )
-            return {"replies": result.get("replies", []), "result": True}
+            return ActionResult(data={"replies": result.get("replies", []), "result": True}, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "replies": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_freeze")
@@ -302,15 +302,15 @@ class FreezePanes(ActionHandler):
             result = (
                 service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
             )
-            return {"replies": result.get("replies", []), "result": True}
+            return ActionResult(data={"replies": result.get("replies", []), "result": True}, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "replies": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_batch_update")
@@ -323,34 +323,34 @@ class SheetsBatchUpdate(ActionHandler):
 
             # Basic validation: ensure it's a list of dicts
             if not isinstance(requests, list) or not all(isinstance(r, dict) for r in requests):
-                return {
+                return ActionResult(data={
                     "result": False,
                     "error": "requests must be an array of objects",
-                }
+                }, cost_usd=0.0)
 
             if dry_run:
                 # Validate by fetching spreadsheet metadata
                 service = build_sheets_service(context)
                 _ = service.spreadsheets().get(spreadsheetId=spreadsheet_id, includeGridData=False).execute()
-                return {"replies": [], "dryRun": True, "result": True}
+                return ActionResult(data={"replies": [], "dryRun": True, "result": True}, cost_usd=0.0)
 
             service = build_sheets_service(context)
             result = (
                 service.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests}).execute()
             )
-            return {
+            return ActionResult(data={
                 "replies": result.get("replies", []),
                 "dryRun": False,
                 "result": True,
-            }
+            }, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "replies": [],
                 "result": False,
                 "error": f"Google Sheets API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"replies": [], "result": False, "error": str(e)}
+            return ActionResult(data={"replies": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @google_sheets.action("sheets_duplicate_spreadsheet")
@@ -374,12 +374,12 @@ class DuplicateSpreadsheet(ActionHandler):
                 )
                 .execute()
             )
-            return {"file_metadata": result, "result": True}
+            return ActionResult(data={"file_metadata": result, "result": True}, cost_usd=0.0)
         except HttpError as e:
-            return {
+            return ActionResult(data={
                 "file_metadata": {},
                 "result": False,
                 "error": f"Google Drive API error: {str(e)}",
-            }
+            }, cost_usd=0.0)
         except Exception as e:
-            return {"file_metadata": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"file_metadata": {}, "result": False, "error": str(e)}, cost_usd=0.0)

--- a/google-sheets/requirements.txt
+++ b/google-sheets/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -43,10 +43,10 @@ class CreateTimeEntry(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/time_entries", method="POST", json=payload)
 
-            return {"success": True, "time_entry": response}
+            return ActionResult(data={"success": True, "time_entry": response}, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("stop_time_entry")
@@ -59,10 +59,10 @@ class StopTimeEntry(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/time_entries/{time_entry_id}/stop", method="PATCH")
 
-            return {"success": True, "time_entry": response}
+            return ActionResult(data={"success": True, "time_entry": response}, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("list_time_entries")
@@ -109,7 +109,7 @@ class ListTimeEntries(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/time_entries", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "time_entries": response.get("time_entries", []),
                 "per_page": response.get("per_page"),
@@ -119,10 +119,10 @@ class ListTimeEntries(ActionHandler):
                 "previous_page": response.get("previous_page"),
                 "page": response.get("page"),
                 "links": response.get("links"),
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("update_time_entry")
@@ -166,10 +166,10 @@ class UpdateTimeEntry(ActionHandler):
                 json=payload,
             )
 
-            return {"success": True, "time_entry": response}
+            return ActionResult(data={"success": True, "time_entry": response}, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("delete_time_entry")
@@ -182,13 +182,13 @@ class DeleteTimeEntry(ActionHandler):
 
             await context.fetch(f"{HARVEST_API_BASE}/time_entries/{time_entry_id}", method="DELETE")
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "message": f"Time entry {time_entry_id} deleted successfully",
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("list_projects")
@@ -217,7 +217,7 @@ class ListProjects(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/projects", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "projects": response.get("projects", []),
                 "per_page": response.get("per_page"),
@@ -227,10 +227,10 @@ class ListProjects(ActionHandler):
                 "previous_page": response.get("previous_page"),
                 "page": response.get("page"),
                 "links": response.get("links"),
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("get_project")
@@ -243,10 +243,10 @@ class GetProject(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/projects/{project_id}", method="GET")
 
-            return {"success": True, "project": response}
+            return ActionResult(data={"success": True, "project": response}, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("list_clients")
@@ -272,7 +272,7 @@ class ListClients(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/clients", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "clients": response.get("clients", []),
                 "per_page": response.get("per_page"),
@@ -282,10 +282,10 @@ class ListClients(ActionHandler):
                 "previous_page": response.get("previous_page"),
                 "page": response.get("page"),
                 "links": response.get("links"),
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("list_tasks")
@@ -311,7 +311,7 @@ class ListTasks(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/tasks", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "tasks": response.get("tasks", []),
                 "per_page": response.get("per_page"),
@@ -321,10 +321,10 @@ class ListTasks(ActionHandler):
                 "previous_page": response.get("previous_page"),
                 "page": response.get("page"),
                 "links": response.get("links"),
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)
 
 
 @harvest.action("list_users")
@@ -350,7 +350,7 @@ class ListUsers(ActionHandler):
 
             response = await context.fetch(f"{HARVEST_API_BASE}/users", method="GET", params=params)
 
-            return {
+            return ActionResult(data={
                 "success": True,
                 "users": response.get("users", []),
                 "per_page": response.get("per_page"),
@@ -360,7 +360,7 @@ class ListUsers(ActionHandler):
                 "previous_page": response.get("previous_page"),
                 "page": response.get("page"),
                 "links": response.get("links"),
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            return ActionResult(data={"success": False, "error": str(e)}, cost_usd=0.0)

--- a/harvest/requirements.txt
+++ b/harvest/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 urllib3>=2.6.3

--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -149,10 +149,10 @@ class GetChannels(ActionHandler):
             for raw_channel in items:
                 channels.append(HeartbeatDataParser.parse_channel(raw_channel))
 
-            return {"channels": channels, "result": True}
+            return ActionResult(data={"channels": channels, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"channels": [], "result": False, "error": str(e)}
+            return ActionResult(data={"channels": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_channel")
@@ -167,13 +167,13 @@ class GetChannel(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {
+            return ActionResult(data={
                 "channel": HeartbeatDataParser.parse_channel(response),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"channel": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"channel": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_channel_threads")
@@ -194,10 +194,10 @@ class GetChannelThreads(ActionHandler):
             for raw_thread in items:
                 threads.append(HeartbeatDataParser.parse_thread(raw_thread))
 
-            return {"threads": threads, "result": True}
+            return ActionResult(data={"threads": threads, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"threads": [], "result": False, "error": str(e)}
+            return ActionResult(data={"threads": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_thread")
@@ -212,13 +212,13 @@ class GetThread(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {
+            return ActionResult(data={
                 "thread": HeartbeatDataParser.parse_thread(response),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"thread": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"thread": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_users")
@@ -237,10 +237,10 @@ class GetUsers(ActionHandler):
             for raw_user in items:
                 users.append(HeartbeatDataParser.parse_user(raw_user))
 
-            return {"users": users, "result": True}
+            return ActionResult(data={"users": users, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"users": [], "result": False, "error": str(e)}
+            return ActionResult(data={"users": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_user")
@@ -255,10 +255,10 @@ class GetUser(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {"user": HeartbeatDataParser.parse_user(response), "result": True}
+            return ActionResult(data={"user": HeartbeatDataParser.parse_user(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"user": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"user": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_events")
@@ -277,10 +277,10 @@ class GetEvents(ActionHandler):
             for raw_event in items:
                 events.append(HeartbeatDataParser.parse_event(raw_event))
 
-            return {"events": events, "result": True}
+            return ActionResult(data={"events": events, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"events": [], "result": False, "error": str(e)}
+            return ActionResult(data={"events": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("get_heartbeat_event")
@@ -295,10 +295,10 @@ class GetEvent(ActionHandler):
                 headers=get_auth_headers(context),
             )
 
-            return {"event": HeartbeatDataParser.parse_event(response), "result": True}
+            return ActionResult(data={"event": HeartbeatDataParser.parse_event(response), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"event": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"event": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("create_heartbeat_comment")
@@ -331,13 +331,13 @@ class CreateComment(ActionHandler):
                 json=request_body,
             )
 
-            return {
+            return ActionResult(data={
                 "comment": HeartbeatDataParser.parse_comment(response),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"comment": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"comment": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @heartbeat.action("create_heartbeat_thread")
@@ -362,13 +362,13 @@ class CreateThread(ActionHandler):
                 json=request_body,
             )
 
-            return {
+            return ActionResult(data={
                 "thread": HeartbeatDataParser.parse_thread(response),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"thread": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"thread": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 # ---- Polling Trigger Handlers ----

--- a/heartbeat/requirements.txt
+++ b/heartbeat/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/powerbi/powerbi.py
+++ b/powerbi/powerbi.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -36,10 +36,10 @@ class ListWorkspacesAction(ActionHandler):
                     }
                 )
 
-            return {"workspaces": workspaces, "result": True}
+            return ActionResult(data={"workspaces": workspaces, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"workspaces": [], "result": False, "error": str(e)}
+            return ActionResult(data={"workspaces": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_workspace")
@@ -50,10 +50,10 @@ class GetWorkspaceAction(ActionHandler):
 
             response = await context.fetch(f"{POWERBI_API_BASE}/groups/{workspace_id}")
 
-            return {"workspace": response, "result": True}
+            return ActionResult(data={"workspace": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"workspace": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"workspace": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("list_datasets")
@@ -83,10 +83,10 @@ class ListDatasetsAction(ActionHandler):
                     }
                 )
 
-            return {"datasets": datasets, "result": True}
+            return ActionResult(data={"datasets": datasets, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"datasets": [], "result": False, "error": str(e)}
+            return ActionResult(data={"datasets": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_dataset")
@@ -103,10 +103,10 @@ class GetDatasetAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"dataset": response, "result": True}
+            return ActionResult(data={"dataset": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"dataset": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"dataset": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("refresh_dataset")
@@ -164,10 +164,10 @@ class RefreshDatasetAction(ActionHandler):
             if hasattr(response, "headers") and "x-ms-request-id" in response.headers:
                 request_id = response.headers["x-ms-request-id"]
 
-            return {"result": True, "message": "Dataset refresh initiated successfully", "request_id": request_id}
+            return ActionResult(data={"result": True, "message": "Dataset refresh initiated successfully", "request_id": request_id}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_refresh_history")
@@ -199,10 +199,10 @@ class GetRefreshHistoryAction(ActionHandler):
                     }
                 )
 
-            return {"refreshes": refreshes, "result": True}
+            return ActionResult(data={"refreshes": refreshes, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"refreshes": [], "result": False, "error": str(e)}
+            return ActionResult(data={"refreshes": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("list_reports")
@@ -230,10 +230,10 @@ class ListReportsAction(ActionHandler):
                     }
                 )
 
-            return {"reports": reports, "result": True}
+            return ActionResult(data={"reports": reports, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"reports": [], "result": False, "error": str(e)}
+            return ActionResult(data={"reports": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_report")
@@ -250,10 +250,10 @@ class GetReportAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"report": response, "result": True}
+            return ActionResult(data={"report": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"report": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"report": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_report_datasources")
@@ -286,10 +286,10 @@ class GetReportDatasourcesAction(ActionHandler):
 
                 datasources.append(ds_data)
 
-            return {"datasources": datasources, "result": True}
+            return ActionResult(data={"datasources": datasources, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"datasources": [], "result": False, "error": str(e)}
+            return ActionResult(data={"datasources": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("refresh_report")
@@ -310,7 +310,7 @@ class RefreshReportAction(ActionHandler):
             dataset_id = report_response.get("datasetId")
 
             if not dataset_id:
-                return {"result": False, "error": "Report does not have an associated dataset"}
+                return ActionResult(data={"result": False, "error": "Report does not have an associated dataset"}, cost_usd=0.0)
 
             # Now refresh the dataset
             if workspace_id:
@@ -322,14 +322,14 @@ class RefreshReportAction(ActionHandler):
 
             await context.fetch(refresh_url, method="POST", json=refresh_request)
 
-            return {
+            return ActionResult(data={
                 "result": True,
                 "message": f"Dataset refresh initiated successfully for report '{report_response.get('name')}'",
                 "dataset_id": dataset_id,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("clone_report")
@@ -357,16 +357,16 @@ class CloneReportAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=clone_request)
 
-            return {
+            return ActionResult(data={
                 "id": response.get("id"),
                 "name": response.get("name"),
                 "webUrl": response.get("webUrl"),
                 "embedUrl": response.get("embedUrl"),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("export_report")
@@ -386,10 +386,10 @@ class ExportReportAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=export_request)
 
-            return {"export_id": response.get("id"), "result": True, "message": "Export initiated successfully"}
+            return ActionResult(data={"export_id": response.get("id"), "result": True, "message": "Export initiated successfully"}, cost_usd=0.0)
 
         except Exception as e:
-            return {"result": False, "error": str(e)}
+            return ActionResult(data={"result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_export_status")
@@ -407,14 +407,14 @@ class GetExportStatusAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {
+            return ActionResult(data={
                 "status": response.get("status"),
                 "percentComplete": response.get("percentComplete", 0),
                 "result": True,
-            }
+            }, cost_usd=0.0)
 
         except Exception as e:
-            return {"status": "Failed", "percentComplete": 0, "result": False, "error": str(e)}
+            return ActionResult(data={"status": "Failed", "percentComplete": 0, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("list_dashboards")
@@ -441,10 +441,10 @@ class ListDashboardsAction(ActionHandler):
                     }
                 )
 
-            return {"dashboards": dashboards, "result": True}
+            return ActionResult(data={"dashboards": dashboards, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"dashboards": [], "result": False, "error": str(e)}
+            return ActionResult(data={"dashboards": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_dashboard")
@@ -461,10 +461,10 @@ class GetDashboardAction(ActionHandler):
 
             response = await context.fetch(url)
 
-            return {"dashboard": response, "result": True}
+            return ActionResult(data={"dashboard": response, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"dashboard": {}, "result": False, "error": str(e)}
+            return ActionResult(data={"dashboard": {}, "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("get_dashboard_tiles")
@@ -493,10 +493,10 @@ class GetDashboardTilesAction(ActionHandler):
                     }
                 )
 
-            return {"tiles": tiles, "result": True}
+            return ActionResult(data={"tiles": tiles, "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"tiles": [], "result": False, "error": str(e)}
+            return ActionResult(data={"tiles": [], "result": False, "error": str(e)}, cost_usd=0.0)
 
 
 @powerbi.action("execute_queries")
@@ -516,7 +516,7 @@ class ExecuteQueriesAction(ActionHandler):
 
             response = await context.fetch(url, method="POST", json=query_request)
 
-            return {"results": response.get("results", []), "result": True}
+            return ActionResult(data={"results": response.get("results", []), "result": True}, cost_usd=0.0)
 
         except Exception as e:
-            return {"results": [], "result": False, "error": str(e)}
+            return ActionResult(data={"results": [], "result": False, "error": str(e)}, cost_usd=0.0)

--- a/powerbi/requirements.txt
+++ b/powerbi/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0

--- a/rss-reader-feedparser-ah-fetch/requirements.txt
+++ b/rss-reader-feedparser-ah-fetch/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 feedparser

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -1,5 +1,5 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
@@ -76,4 +76,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}, cost_usd=0.0)

--- a/rss-reader-feedparser/requirements.txt
+++ b/rss-reader-feedparser/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.0
 feedparser

--- a/rss-reader-feedparser/rss_reader.py
+++ b/rss-reader-feedparser/rss_reader.py
@@ -1,5 +1,5 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
@@ -34,4 +34,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}, cost_usd=0.0)


### PR DESCRIPTION
## Summary
Wraps all action handler return values in ActionResult(data=..., cost_usd=0.0) for integrations that were returning raw dicts.

## Integrations covered
app-business-reviews, box, coda, doc-maker, elevenlabs, freshdesk, front, google-business-profie, google-calendar, google-chat, google-sheets, harvest, heartbeat, powerbi, rss-reader-feedparser, rss-reader-feedparser-ah-fetch