### PR TITLE
fix(google-looker): execute_lookml_query API payload

### DIFF
--- a/google-looker/google_looker.py
+++ b/google-looker/google_looker.py
@@ -167,18 +167,17 @@ class ExecuteLookMLQuery(ActionHandler):
         try:
             helper = build_looker_helper(context)
 
-            query_data = {"model": inputs["model"], "explore": inputs["explore"]}
+            query_data = {"model": inputs["model"], "view": inputs["explore"]}
 
-            if inputs.get("dimensions") is not None:
-                query_data["dimensions"] = inputs.get("dimensions")
-            if inputs.get("measures") is not None:
-                query_data["measures"] = inputs.get("measures")
+            fields = (inputs.get("dimensions") or []) + (inputs.get("measures") or [])
+            if fields:
+                query_data["fields"] = fields
             if inputs.get("filters") is not None:
                 query_data["filters"] = inputs.get("filters")
             if inputs.get("sorts") is not None:
                 query_data["sorts"] = inputs.get("sorts")
             if inputs.get("limit") is not None:
-                query_data["limit"] = inputs.get("limit")
+                query_data["limit"] = str(inputs.get("limit"))
 
             query = await helper.make_request("POST", "/queries", data=query_data)
             query_id = query.get("id")
@@ -204,7 +203,10 @@ class ExecuteLookMLQuery(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(data={"query_results": "[]", "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={"query_results": "[]", "result": False, "error": str(e)},
+                cost_usd=0,
+            )
 
 
 @google_looker.action("list_models")
@@ -287,7 +289,15 @@ class ExecuteSQLQuery(ActionHandler):
             )
 
         except Exception as e:
-            return ActionResult(data={"slug": "", "query_results": "", "result": False, "error": str(e)}, cost_usd=0)
+            return ActionResult(
+                data={
+                    "slug": "",
+                    "query_results": "",
+                    "result": False,
+                    "error": str(e),
+                },
+                cost_usd=0,
+            )
 
 
 @google_looker.action("list_connections")

--- a/google-looker/tests/context.py
+++ b/google-looker/tests/context.py
@@ -4,3 +4,5 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))
+
+from google_looker import google_looker  # noqa: E402, F401

--- a/google-looker/tests/test_google_looker_integration.py
+++ b/google-looker/tests/test_google_looker_integration.py
@@ -5,9 +5,16 @@ import json
 from context import google_looker  # integration instance
 
 
+class MockResponse:
+    """Mimics the production Lambda wrapper's fetch response shape."""
+
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+
 class MockExecutionContext:
     def __init__(self, responses: Dict[str, Any]):
-        # mimic SDK context shape expected by google_looker.py
         self.auth = {
             "credentials": {
                 "base_url": "https://test-looker.looker.com",
@@ -16,6 +23,7 @@ class MockExecutionContext:
             }
         }
         self._responses = responses
+        self._requests = []
 
     async def fetch(
         self,
@@ -27,31 +35,43 @@ class MockExecutionContext:
         headers: Optional[Dict[str, str]] = None,
         **kwargs,
     ):
+        self._requests.append(
+            {
+                "url": url,
+                "method": method,
+                "params": params,
+                "json": json,
+                "data": data,
+                "headers": headers,
+            }
+        )
         # Route by endpoint suffix for simplicity
         if "/api/4.0/login" in url and method == "POST":
-            return self._responses.get(
-                "POST /login",
-                {"access_token": "mock_token_123", "expires_in": 3600},  # nosec B105
+            return MockResponse(
+                self._responses.get(
+                    "POST /login",
+                    {"access_token": "mock_token_123", "expires_in": 3600},  # nosec B105
+                )
             )
         if "/api/4.0/dashboards/" in url and method == "GET":
-            return self._responses.get("GET /dashboard", {"dashboard": {}})
+            return MockResponse(self._responses.get("GET /dashboard", {"dashboard": {}}))
         if "/api/4.0/dashboards" in url and method == "GET":
-            return self._responses.get("GET /dashboards", [])
+            return MockResponse(self._responses.get("GET /dashboards", []))
         if "/api/4.0/lookml_models/" in url and method == "GET":
-            return self._responses.get("GET /model", {"model": {}})
+            return MockResponse(self._responses.get("GET /model", {"model": {}}))
         if "/api/4.0/lookml_models" in url and method == "GET":
-            return self._responses.get("GET /models", [])
+            return MockResponse(self._responses.get("GET /models", []))
         if "/api/4.0/queries" in url and method == "POST":
-            return self._responses.get("POST /queries", {"id": "mock_query_123"})
+            return MockResponse(self._responses.get("POST /queries", {"id": "mock_query_123"}))
         if "/api/4.0/queries/" in url and "/run/" in url and method == "GET":
-            return self._responses.get("GET /query_results", [{"result": "data"}])
+            return MockResponse(self._responses.get("GET /query_results", [{"result": "data"}]))
         if "/api/4.0/sql_queries/" in url and "/run/" in url and method == "POST":
-            return self._responses.get("POST /sql_results", [{"sql_result": "data"}])
+            return MockResponse(self._responses.get("POST /sql_results", [{"sql_result": "data"}]))
         if "/api/4.0/sql_queries" in url and method == "POST":
-            return self._responses.get("POST /sql_queries", {"slug": "mock_sql_123"})
+            return MockResponse(self._responses.get("POST /sql_queries", {"slug": "mock_sql_123"}))
         if "/api/4.0/connections" in url and method == "GET":
-            return self._responses.get("GET /connections", [])
-        return {}
+            return MockResponse(self._responses.get("GET /connections", []))
+        return MockResponse({})
 
 
 async def test_list_dashboards_basic():
@@ -72,11 +92,12 @@ async def test_list_dashboards_basic():
         ]
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("list_dashboards", {}, context)
-    assert result["result"] is True
-    assert "dashboards" in result
-    assert len(result["dashboards"]) == 2
-    assert result["dashboards"][0]["title"] == "Sales Dashboard"
+    integration_result = await google_looker.execute_action("list_dashboards", {}, context)
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert "dashboards" in data
+    assert len(data["dashboards"]) == 2
+    assert data["dashboards"][0]["title"] == "Sales Dashboard"
 
 
 async def test_get_dashboard():
@@ -89,10 +110,11 @@ async def test_get_dashboard():
         }
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("get_dashboard", {"dashboard_id": "123"}, context)
-    assert result["result"] is True
-    assert result["dashboard"]["id"] == "123"
-    assert result["dashboard"]["title"] == "Test Dashboard"
+    integration_result = await google_looker.execute_action("get_dashboard", {"dashboard_id": "123"}, context)
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert data["dashboard"]["id"] == "123"
+    assert data["dashboard"]["title"] == "Test Dashboard"
 
 
 async def test_execute_lookml_query():
@@ -104,7 +126,7 @@ async def test_execute_lookml_query():
         ],
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action(
+    integration_result = await google_looker.execute_action(
         "execute_lookml_query",
         {
             "model": "sales_model",
@@ -115,11 +137,99 @@ async def test_execute_lookml_query():
         },
         context,
     )
-    assert result["result"] is True
-    assert "query_results" in result
-    query_data = json.loads(result["query_results"])
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert "query_results" in data
+    query_data = json.loads(data["query_results"])
     assert len(query_data) == 2
     assert query_data[0]["measure1"] == 100
+
+    # Verify payload sent to POST /queries
+    query_calls = [r for r in context._requests if "/api/4.0/queries" in r["url"] and r["method"] == "POST"]
+    assert len(query_calls) == 1
+    payload = query_calls[0]["json"]
+    assert payload["model"] == "sales_model"
+    assert payload["view"] == "orders"
+    assert "explore" not in payload
+    assert payload["fields"] == ["orders.status", "orders.count"]
+    assert "dimensions" not in payload
+    assert "measures" not in payload
+    assert payload["limit"] == "100"
+    assert isinstance(payload["limit"], str)
+
+
+async def test_execute_lookml_query_dimensions_only():
+    responses = {
+        "POST /queries": {"id": "query_789"},
+        "GET /query_results": [{"dim1": "val1"}],
+    }
+    context = MockExecutionContext(responses)
+    integration_result = await google_looker.execute_action(
+        "execute_lookml_query",
+        {
+            "model": "my_model",
+            "explore": "my_explore",
+            "dimensions": ["view.dim1", "view.dim2"],
+        },
+        context,
+    )
+    data = integration_result.result.data
+    assert data["result"] is True
+
+    query_calls = [r for r in context._requests if "/api/4.0/queries" in r["url"] and r["method"] == "POST"]
+    payload = query_calls[0]["json"]
+    assert payload["fields"] == ["view.dim1", "view.dim2"]
+    assert "dimensions" not in payload
+    assert "measures" not in payload
+
+
+async def test_execute_lookml_query_measures_only():
+    responses = {
+        "POST /queries": {"id": "query_790"},
+        "GET /query_results": [{"count": 42}],
+    }
+    context = MockExecutionContext(responses)
+    integration_result = await google_looker.execute_action(
+        "execute_lookml_query",
+        {
+            "model": "my_model",
+            "explore": "my_explore",
+            "measures": ["view.count"],
+        },
+        context,
+    )
+    data = integration_result.result.data
+    assert data["result"] is True
+
+    query_calls = [r for r in context._requests if "/api/4.0/queries" in r["url"] and r["method"] == "POST"]
+    payload = query_calls[0]["json"]
+    assert payload["fields"] == ["view.count"]
+    assert "dimensions" not in payload
+    assert "measures" not in payload
+
+
+async def test_execute_lookml_query_no_fields():
+    responses = {
+        "POST /queries": {"id": "query_791"},
+        "GET /query_results": [],
+    }
+    context = MockExecutionContext(responses)
+    integration_result = await google_looker.execute_action(
+        "execute_lookml_query",
+        {
+            "model": "my_model",
+            "explore": "my_explore",
+        },
+        context,
+    )
+    data = integration_result.result.data
+    assert data["result"] is True
+
+    query_calls = [r for r in context._requests if "/api/4.0/queries" in r["url"] and r["method"] == "POST"]
+    payload = query_calls[0]["json"]
+    assert "fields" not in payload
+    assert "dimensions" not in payload
+    assert "measures" not in payload
 
 
 async def test_list_models():
@@ -138,10 +248,11 @@ async def test_list_models():
         ]
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("list_models", {}, context)
-    assert result["result"] is True
-    assert len(result["models"]) == 2
-    assert result["models"][0]["name"] == "sales"
+    integration_result = await google_looker.execute_action("list_models", {}, context)
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert len(data["models"]) == 2
+    assert data["models"][0]["name"] == "sales"
 
 
 async def test_get_model():
@@ -156,10 +267,11 @@ async def test_get_model():
         }
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("get_model", {"model_name": "sales"}, context)
-    assert result["result"] is True
-    assert result["model"]["name"] == "sales"
-    assert len(result["model"]["explores"]) == 2
+    integration_result = await google_looker.execute_action("get_model", {"model_name": "sales"}, context)
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert data["model"]["name"] == "sales"
+    assert len(data["model"]["explores"]) == 2
 
 
 async def test_execute_sql_query():
@@ -171,14 +283,15 @@ async def test_execute_sql_query():
         ],
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action(
+    integration_result = await google_looker.execute_action(
         "execute_sql_query",
         {"sql": "SELECT * FROM orders LIMIT 10", "connection_name": "warehouse"},
         context,
     )
-    assert result["result"] is True
-    assert result["slug"] == "sql_789"
-    query_data = json.loads(result["query_results"]) if result["query_results"] else []
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert data["slug"] == "sql_789"
+    query_data = json.loads(data["query_results"]) if data["query_results"] else []
     assert len(query_data) == 2
 
 
@@ -190,58 +303,62 @@ async def test_list_connections():
         ]
     }
     context = MockExecutionContext(responses)
-    result = await google_looker.execute_action("list_connections", {}, context)
-    assert result["result"] is True
-    assert len(result["connections"]) == 2
-    assert result["connections"][0]["name"] == "warehouse"
+    integration_result = await google_looker.execute_action("list_connections", {}, context)
+    data = integration_result.result.data
+    assert data["result"] is True
+    assert len(data["connections"]) == 2
+    assert data["connections"][0]["name"] == "warehouse"
 
 
 async def test_authentication_error():
-    # Test when authentication fails
     class FailAuthContext(MockExecutionContext):
         async def fetch(self, url: str, method: str = "GET", **kwargs):
             if "/api/4.0/login" in url:
                 raise Exception("Invalid credentials")
-            return super().fetch(url, method, **kwargs)
+            return await super().fetch(url, method, **kwargs)
 
     context = FailAuthContext({})
-    result = await google_looker.execute_action("list_dashboards", {}, context)
-    assert result["result"] is False
-    assert "error" in result
-    assert "Invalid credentials" in result["error"]
+    integration_result = await google_looker.execute_action("list_dashboards", {}, context)
+    data = integration_result.result.data
+    assert data["result"] is False
+    assert "error" in data
+    assert "Invalid credentials" in data["error"]
 
 
 async def test_missing_credentials():
-    # Test when no auth credentials provided
     class NoAuthContext:
         def __init__(self):
             self.auth = {}
 
     context = NoAuthContext()
-    result = await google_looker.execute_action("list_dashboards", {}, context)
-    assert result["result"] is False
-    assert "error" in result
-    assert "authentication credentials" in result["error"].lower()
+    integration_result = await google_looker.execute_action("list_dashboards", {}, context)
+    data = integration_result.result.data
+    assert data["result"] is False
+    assert "error" in data
+    assert "authentication credentials" in data["error"].lower()
 
 
 async def test_execute_lookml_query_missing_required_fields():
     context = MockExecutionContext({})
-    # Missing required model and explore fields - should raise ValidationError
-    try:
-        await google_looker.execute_action("execute_lookml_query", {"dimensions": ["orders.status"]}, context)
-        assert False, "Should have raised ValidationError"
-    except Exception as e:
-        assert "required" in str(e).lower()
-        assert "model" in str(e) or "explore" in str(e)
+    integration_result = await google_looker.execute_action(
+        "execute_lookml_query", {"dimensions": ["orders.status"]}, context
+    )
+    # SDK returns a validation error dict (not ActionResult) for schema violations
+    error_data = integration_result.result
+    assert isinstance(error_data, dict)
+    assert "model" in error_data["message"] or "explore" in error_data["message"]
+    assert error_data["source"] == "input"
 
 
 async def test_execute_sql_query_missing_connection():
     context = MockExecutionContext({})
-    # Missing both connection_name and model_name
-    result = await google_looker.execute_action("execute_sql_query", {"sql": "SELECT * FROM orders"}, context)
-    assert result["result"] is False
-    assert "error" in result
-    assert "connection_name" in result["error"] or "model_name" in result["error"]
+    integration_result = await google_looker.execute_action(
+        "execute_sql_query", {"sql": "SELECT * FROM orders"}, context
+    )
+    data = integration_result.result.data
+    assert data["result"] is False
+    assert "error" in data
+    assert "connection_name" in data["error"] or "model_name" in data["error"]
 
 
 def _run(coro):
@@ -252,6 +369,9 @@ if __name__ == "__main__":
     _run(test_list_dashboards_basic())
     _run(test_get_dashboard())
     _run(test_execute_lookml_query())
+    _run(test_execute_lookml_query_dimensions_only())
+    _run(test_execute_lookml_query_measures_only())
+    _run(test_execute_lookml_query_no_fields())
     _run(test_list_models())
     _run(test_get_model())
     _run(test_execute_sql_query())


### PR DESCRIPTION
## Summary

The `execute_lookml_query` action was sending an incorrect payload to the Looker API `POST /queries` endpoint, causing all LookML queries to fail with **HTTP 422: Validation Failed — field `view` is not present**. This blocked querying any dashboard that uses LookML models (including `system__activity` for login security monitoring).

---

## Root Cause

Three field-mapping bugs in the API payload construction:

| Field | Was Sending | Looker API Expects |
|---|---|---|
| explore/view | `"explore": "..."` | `"view": "..."` |
| dimensions + measures | `"dimensions": [...], "measures": [...]` (separate) | `"fields": [...]` (unified array) |
| limit | `100` (integer) | `"100"` (string) |

---

## Changes

- **`google-looker/google_looker.py`** — Fix `ExecuteLookMLQuery` payload: map `explore` input to `view` key, merge `dimensions` + `measures` into single `fields` array, cast `limit` to string
- **`google-looker/tests/context.py`** — Add integration instance re-export so tests can import it
- **`google-looker/tests/test_google_looker_integration.py`** — Add `MockResponse` wrapper matching production fetch shape, add request payload capture, add payload verification assertions (`view` / `fields` / `limit`), add edge-case tests (`dimensions-only`, `measures-only`, `no-fields`), fix result access to use `IntegrationResult` wrapping

> **No changes to `config.json`** — `dimensions` and `measures` remain as user-facing inputs and are merged into `fields` internally.