### PR TITLE
chore: bump integrations-tooling to 2.0.1

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@2.0.0
+        uses: autohive-ai/autohive-integrations-tooling@2.0.1
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Bumps `autohive-integrations-tooling` from 2.0.0 to 2.0.1 in the CI validation workflow.