### PR TITLE
ci: bump tooling action to 2.0.2

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@2.0.1
+        uses: autohive-ai/autohive-integrations-tooling@2.0.2
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Bumps `autohive-ai/autohive-integrations-tooling` from `2.0.1` → `2.0.2` in the CI workflow.\n\nTooling 2.0.2 adds the pytest-based **Tests** step to the validation pipeline — discovers and runs `test_*_unit.py` files with coverage. Integrations without unit tests get a ⚠️ warning, not a failure.