### PR TITLE
ci: bump tooling action to 2.0.3

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@2.0.2
+        uses: autohive-ai/autohive-integrations-tooling@2.0.3
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Bumps `autohive-ai/autohive-integrations-tooling` from `2.0.2` → `2.0.3` in the CI workflow.

Tooling 2.0.3 includes:
- **Version check fix** — test/doc-only changes no longer require a version bump (PR #28)
- **Per-integration test runner** — `run_tests.py` installs each integration's own `requirements.txt` before running its tests, respecting SDK version pins (PR #29)

⚠️ **Do not merge until tag `2.0.3` exists on the tooling repo.**