### PR TITLE
chore: pin tooling action to floating @v2 tag

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
-        uses: autohive-ai/autohive-integrations-tooling@2.0.3
+        uses: autohive-ai/autohive-integrations-tooling@v2
         with:
           base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
## What

Updates the tooling action reference from a pinned exact version to the floating major tag.

```yaml
# Before
uses: autohive-ai/autohive-integrations-tooling@2.0.3

# After
uses: autohive-ai/autohive-integrations-tooling@v2
```

## Why

With a pinned exact version, every tooling release requires a manual PR here to bump the version. The floating `@v2` tag always points to the latest `2.x.x` release — no more manual bumps needed until a major version change.

## Related

- `autohive-integrations-tooling` PR #31 — adds the release workflow that auto-moves the `v2` tag on each publish