### PR TITLE
fix(xero): fix attachment 404 errors, add retry logic and input validation

### DIFF
--- a/xero/config.json
+++ b/xero/config.json
@@ -1324,7 +1324,6 @@
                             }
                         },
                         "required": [
-                            "content",
                             "name",
                             "contentType"
                         ]
@@ -1349,7 +1348,6 @@
                                 }
                             },
                             "required": [
-                                "content",
                                 "name",
                                 "contentType"
                             ]
@@ -1409,7 +1407,6 @@
                             }
                         },
                         "required": [
-                            "content",
                             "name",
                             "contentType"
                         ]
@@ -1434,7 +1431,6 @@
                                 }
                             },
                             "required": [
-                                "content",
                                 "name",
                                 "contentType"
                             ]

--- a/xero/config.json
+++ b/xero/config.json
@@ -1,2000 +1,2002 @@
 {
-    "name": "Xero",
-    "version": "1.5.0",
-    "description": "Xero accounting integration for invoice and bill management, purchase orders, reporting, file attachments, and PDF invoice retrieval",
-    "entry_point": "xero.py",
-    "supports_connected_account": true,
-    "auth": {
-        "type": "platform",
-        "provider": "Xero",
-        "scopes": [
-            "accounting.reports.read",
-            "accounting.contacts.read",
-            "accounting.settings.read",
-            "accounting.transactions.read",
-            "accounting.transactions",
-            "accounting.attachments",
-            "offline_access"
+  "name": "Xero",
+  "version": "1.5.0",
+  "description": "Xero accounting integration for invoice and bill management, purchase orders, reporting, file attachments, and PDF invoice retrieval",
+  "entry_point": "xero.py",
+  "supports_connected_account": true,
+  "auth": {
+    "type": "platform",
+    "provider": "Xero",
+    "scopes": [
+      "accounting.reports.read",
+      "accounting.contacts.read",
+      "accounting.settings.read",
+      "accounting.transactions.read",
+      "accounting.transactions",
+      "accounting.attachments",
+      "offline_access"
+    ]
+  },
+  "actions": {
+    "get_available_connections": {
+      "display_name": "Get Available Connections",
+      "description": "Gets all available Xero tenant connections and returns company names with tenant IDs",
+      "input_schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the request was successful"
+          },
+          "companies": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tenant_id": {
+                  "type": "string",
+                  "description": "Xero tenant ID"
+                },
+                "company_name": {
+                  "type": "string",
+                  "description": "Xero tenant/company name"
+                }
+              },
+              "required": [
+                "tenant_id",
+                "company_name"
+              ]
+            }
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message if success is false"
+          }
+        },
+        "required": [
+          "success",
+          "companies"
         ]
+      }
     },
-    "actions": {
-        "get_available_connections": {
-            "display_name": "Get Available Connections",
-            "description": "Gets all available Xero tenant connections and returns company names with tenant IDs",
-            "input_schema": {
-                "type": "object",
-                "properties": {},
-                "required": []
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "success": {
-                        "type": "boolean",
-                        "description": "Whether the request was successful"
-                    },
-                    "companies": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "tenant_id": {
-                                    "type": "string",
-                                    "description": "Xero tenant ID"
-                                },
-                                "company_name": {
-                                    "type": "string",
-                                    "description": "Xero tenant/company name"
-                                }
-                            },
-                            "required": [
-                                "tenant_id",
-                                "company_name"
-                            ]
-                        }
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Error message if success is false"
-                    }
-                },
-                "required": [
-                    "success",
-                    "companies"
-                ]
-            }
+    "find_contact_by_name": {
+      "display_name": "Find Contact by Name",
+      "description": "Finds contacts with matching name in Xero and returns comprehensive contact details including email, phone, address, and other information",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "contact_name": {
+            "type": "string",
+            "description": "Contact/organization name to search for (will match against Name field)"
+          }
         },
-        "find_contact_by_name": {
-            "display_name": "Find Contact by Name",
-            "description": "Finds contacts with matching name in Xero and returns comprehensive contact details including email, phone, address, and other information",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "contact_name": {
-                        "type": "string",
-                        "description": "Contact/organization name to search for (will match against Name field)"
-                    }
+        "required": [
+          "tenant_id",
+          "contact_name"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "contacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "contact_id": {
+                  "type": "string",
+                  "description": "Contact ID (GUID)"
                 },
-                "required": [
-                    "tenant_id",
-                    "contact_name"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "contacts": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "contact_id": {
-                                    "type": "string",
-                                    "description": "Contact ID (GUID)"
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "Contact name from Name field"
-                                },
-                                "contact_number": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Contact number"
-                                },
-                                "account_number": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Account number"
-                                },
-                                "contact_status": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Contact status"
-                                },
-                                "first_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "First name"
-                                },
-                                "last_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Last name"
-                                },
-                                "email_address": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Email address"
-                                },
-                                "skype_user_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Skype username"
-                                },
-                                "bank_account_details": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Bank account details"
-                                },
-                                "tax_number": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Tax number"
-                                },
-                                "accounts_receivable_tax_type": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Accounts receivable tax type"
-                                },
-                                "accounts_payable_tax_type": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Accounts payable tax type"
-                                },
-                                "addresses": {
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ],
-                                    "description": "Array of contact addresses"
-                                },
-                                "phones": {
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ],
-                                    "description": "Array of contact phone numbers"
-                                },
-                                "updated_date_utc": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Last updated date in UTC"
-                                },
-                                "contact_groups": {
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ],
-                                    "description": "Array of contact groups"
-                                },
-                                "website": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Website URL"
-                                },
-                                "branding_theme": {
-                                    "type": [
-                                        "object",
-                                        "null"
-                                    ],
-                                    "description": "Branding theme information"
-                                },
-                                "batch_payments": {
-                                    "type": [
-                                        "object",
-                                        "null"
-                                    ],
-                                    "description": "Batch payment information"
-                                },
-                                "discount": {
-                                    "type": [
-                                        "number",
-                                        "null"
-                                    ],
-                                    "description": "Discount percentage"
-                                },
-                                "balances": {
-                                    "type": [
-                                        "object",
-                                        "null"
-                                    ],
-                                    "description": "Account balances"
-                                },
-                                "attachments": {
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ],
-                                    "description": "Array of attachments"
-                                },
-                                "has_attachments": {
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ],
-                                    "description": "Whether contact has attachments"
-                                },
-                                "contact_persons": {
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ],
-                                    "description": "Array of contact persons"
-                                }
-                            },
-                            "required": [
-                                "contact_id",
-                                "name"
-                            ]
-                        }
-                    }
+                "name": {
+                  "type": "string",
+                  "description": "Contact name from Name field"
                 },
-                "required": [
-                    "contacts"
-                ]
+                "contact_number": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Contact number"
+                },
+                "account_number": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Account number"
+                },
+                "contact_status": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Contact status"
+                },
+                "first_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "First name"
+                },
+                "last_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Last name"
+                },
+                "email_address": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Email address"
+                },
+                "skype_user_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Skype username"
+                },
+                "bank_account_details": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Bank account details"
+                },
+                "tax_number": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Tax number"
+                },
+                "accounts_receivable_tax_type": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Accounts receivable tax type"
+                },
+                "accounts_payable_tax_type": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Accounts payable tax type"
+                },
+                "addresses": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "description": "Array of contact addresses"
+                },
+                "phones": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "description": "Array of contact phone numbers"
+                },
+                "updated_date_utc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Last updated date in UTC"
+                },
+                "contact_groups": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "description": "Array of contact groups"
+                },
+                "website": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Website URL"
+                },
+                "branding_theme": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Branding theme information"
+                },
+                "batch_payments": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Batch payment information"
+                },
+                "discount": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "description": "Discount percentage"
+                },
+                "balances": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "Account balances"
+                },
+                "attachments": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "description": "Array of attachments"
+                },
+                "has_attachments": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Whether contact has attachments"
+                },
+                "contact_persons": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "description": "Array of contact persons"
+                }
+              },
+              "required": [
+                "contact_id",
+                "name"
+              ]
             }
+          }
         },
-        "get_aged_payables": {
-            "display_name": "Get Aged Payables",
-            "description": "Retrieves aged payables report from Xero for a specific contact",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "contact_id": {
-                        "type": "string",
-                        "description": "Contact ID (GUID) for which to retrieve aged payables"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "contact_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "reports": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "report_id": {
-                                    "type": "string",
-                                    "description": "Report identifier"
-                                },
-                                "report_name": {
-                                    "type": "string",
-                                    "description": "Report name"
-                                },
-                                "report_date": {
-                                    "type": "string",
-                                    "description": "Report date"
-                                },
-                                "rows": {
-                                    "type": "array",
-                                    "description": "Report data rows"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Raw Xero API response for Aged Payables report"
-            }
-        },
-        "get_aged_receivables": {
-            "display_name": "Get Aged Receivables",
-            "description": "Retrieves aged receivables report from Xero for a specific contact",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "contact_id": {
-                        "type": "string",
-                        "description": "Contact ID (GUID) for which to retrieve aged receivables"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "contact_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "reports": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "report_id": {
-                                    "type": "string",
-                                    "description": "Report identifier"
-                                },
-                                "report_name": {
-                                    "type": "string",
-                                    "description": "Report name"
-                                },
-                                "report_date": {
-                                    "type": "string",
-                                    "description": "Report date"
-                                },
-                                "rows": {
-                                    "type": "array",
-                                    "description": "Report data rows"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Raw Xero API response for Aged Receivables report"
-            }
-        },
-        "get_balance_sheet": {
-            "display_name": "Get Balance Sheet",
-            "description": "Retrieves balance sheet report from Xero",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-                    },
-                    "periods": {
-                        "type": "integer",
-                        "description": "Number of periods to compare (optional)",
-                        "minimum": 1,
-                        "maximum": 12
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "reports": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "report_id": {
-                                    "type": "string",
-                                    "description": "Report identifier"
-                                },
-                                "report_name": {
-                                    "type": "string",
-                                    "description": "Report name"
-                                },
-                                "report_date": {
-                                    "type": "string",
-                                    "description": "Report date"
-                                },
-                                "rows": {
-                                    "type": "array",
-                                    "description": "Report data rows"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Raw Xero API response for Balance Sheet report"
-            }
-        },
-        "get_profit_and_loss": {
-            "display_name": "Get Profit and Loss",
-            "description": "Retrieves profit and loss statement from Xero",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-                    },
-                    "from_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Start date for the report period (YYYY-MM-DD)"
-                    },
-                    "to_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "End date for the report period (YYYY-MM-DD)"
-                    },
-                    "timeframe": {
-                        "type": "string",
-                        "enum": [
-                            "MONTH",
-                            "QUARTER",
-                            "YEAR"
-                        ],
-                        "description": "Timeframe for period comparisons (optional)"
-                    },
-                    "periods": {
-                        "type": "integer",
-                        "description": "Number of periods to compare (optional)",
-                        "minimum": 1,
-                        "maximum": 12
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "reports": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "report_id": {
-                                    "type": "string",
-                                    "description": "Report identifier"
-                                },
-                                "report_name": {
-                                    "type": "string",
-                                    "description": "Report name"
-                                },
-                                "report_date": {
-                                    "type": "string",
-                                    "description": "Report date"
-                                },
-                                "rows": {
-                                    "type": "array",
-                                    "description": "Report data rows"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Raw Xero API response for Profit and Loss statement"
-            }
-        },
-        "get_trial_balance": {
-            "display_name": "Get Trial Balance",
-            "description": "Retrieves trial balance report from Xero",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Report date (YYYY-MM-DD). Defaults to last date of last calendar month if not specified"
-                    },
-                    "payments_only": {
-                        "type": "boolean",
-                        "description": "Whether to include only payments (optional, defaults to false)"
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "reports": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "report_id": {
-                                    "type": "string",
-                                    "description": "Report identifier"
-                                },
-                                "report_name": {
-                                    "type": "string",
-                                    "description": "Report name"
-                                },
-                                "report_date": {
-                                    "type": "string",
-                                    "description": "Report date"
-                                },
-                                "rows": {
-                                    "type": "array",
-                                    "description": "Report data rows"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Raw Xero API response for Trial Balance report"
-            }
-        },
-        "get_accounts": {
-            "display_name": "Get Accounts",
-            "description": "Retrieves accounts from Xero to classify line items (revenue, expenses, fixed assets, loans, equity/dividends, GST)",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "where": {
-                        "type": "string",
-                        "description": "Optional Xero where filter clause. Filter by any element using Xero syntax. Examples: Status=\"ACTIVE\", Type=\"REVENUE\", Code>=\"4000\". Use range operators (>, >=, <, <=) and combine with AND/OR operators."
-                    },
-                    "order": {
-                        "type": "string",
-                        "description": "Optional Xero orderby parameter. Order by any element returned. Examples: \"Code ASC\", \"Name DESC\", \"Type ASC\". Multi-field sorting: \"Type ASC, Code ASC\". Note: Some fields are optimized for better performance."
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "accounts": {
-                        "type": "array",
-                        "description": "Array of Xero accounts"
-                    }
-                },
-                "description": "Raw Xero API response for Accounts"
-            }
-        },
-        "get_payments": {
-            "display_name": "Get Payments",
-            "description": "Retrieves payments from Xero for cash on invoices/bills (customer receipts, supplier payments, cash refunds)",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "where": {
-                        "type": "string",
-                        "description": "Optional Xero where filter clause. Optimized fields include PaymentType, Status, Date, Invoice.InvoiceId, Reference. Examples: PaymentType=\"ACCRECPAYMENT\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Reference=\"INV-0001\". Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
-                    },
-                    "order": {
-                        "type": "string",
-                        "description": "Optional Xero orderby parameter. Optimized fields for ordering: UpdatedDateUTC, Date, PaymentId. Examples: \"UpdatedDateUTC ASC\", \"Date DESC\", \"PaymentId ASC\". Multi-field sorting: \"Date DESC, PaymentId ASC\". Default order is UpdatedDateUTC ASC, PaymentId ASC."
-                    },
-                    "page": {
-                        "type": "integer",
-                        "description": "Optional page number for pagination. Default is 100 payments per page when used alone."
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "description": "Optional page size for pagination (1-1000). Used with page parameter. Examples: page=1&pageSize=250."
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "payments": {
-                        "type": "array",
-                        "description": "Array of Xero payments"
-                    }
-                },
-                "description": "Raw Xero API response for Payments"
-            }
-        },
-        "get_invoices": {
-            "display_name": "Get Invoices",
-            "description": "Retrieves invoices from Xero API with optimized filtering. Can fetch all invoices or a specific invoice by ID. Supports sales invoices (ACCREC) and purchase invoices (ACCPAY)",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "description": "Optional specific invoice ID (GUID) to fetch. When provided, fetches only this invoice and ignores other filter parameters"
-                    },
-                    "where": {
-                        "type": "string",
-                        "description": "Optional Xero where filter clause with optimized fields. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01) AND Date<=DateTime(2020,12,31), Contact.ContactID==guid(\"contact-id\"), Type==\"ACCREC\", Total>=100.00 AND Total<=1000.00. Combine with AND/OR operators."
-                    },
-                    "order": {
-                        "type": "string",
-                        "description": "Optional Xero orderby parameter. Optimized fields: InvoiceNumber, Date, DueDate, Total, UpdatedDateUTC. Examples: \"Date DESC\", \"InvoiceNumber ASC\", \"Total DESC,Date ASC\". Multi-field sorting supported."
-                    },
-                    "page": {
-                        "type": "integer",
-                        "description": "Optional page number for pagination"
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "description": "Optional page size for pagination (max 100)"
-                    },
-                    "statuses": {
-                        "type": "string",
-                        "description": "Optional comma-separated list of invoice statuses for bulk filtering. Examples: \"DRAFT,SUBMITTED,AUTHORISED\", \"VOIDED,DELETED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, PAID, VOIDED, DELETED"
-                    },
-                    "invoice_numbers": {
-                        "type": "string",
-                        "description": "Optional comma-separated list of invoice numbers for bulk retrieval by invoice number"
-                    },
-                    "contact_ids": {
-                        "type": "string",
-                        "description": "Optional comma-separated list of contact IDs (GUIDs) to filter invoices by specific contacts"
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "invoices": {
-                        "type": "array",
-                        "description": "Array of Xero invoices with details including invoice number, date, due date, contact, line items, amounts, and status"
-                    }
-                },
-                "description": "Raw Xero API response for Invoices"
-            }
-        },
-        "get_invoice_pdf": {
-            "display_name": "Get Invoice PDF",
-            "description": "Retrieves a specific invoice as a PDF file from Xero API. Works with both sales invoices (ACCREC) and purchase bills (ACCPAY)",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "description": "Invoice ID (GUID) to retrieve as PDF. Example: 97c2dc5-cc47-4afd-8ec8-74990b8761e9"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "invoice_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "File name of the PDF"
-                            },
-                            "content": {
-                                "type": "string",
-                                "description": "Base64 encoded PDF content"
-                            },
-                            "contentType": {
-                                "type": "string",
-                                "description": "MIME type of the file (application/pdf)"
-                            }
-                        },
-                        "required": [
-                            "name",
-                            "content",
-                            "contentType"
-                        ]
-                    },
-                    "success": {
-                        "type": "boolean",
-                        "description": "Whether the PDF download was successful"
-                    },
-                    "error": {
-                        "type": "string",
-                        "description": "Error message if download failed"
-                    }
-                },
-                "required": [
-                    "file",
-                    "success"
-                ]
-            }
-        },
-        "get_bank_transactions": {
-            "display_name": "Get Bank Transactions",
-            "description": "Retrieves bank transactions from Xero for Receive/Spend Money not tied to invoices (CapEx, financing, other operating)",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "where": {
-                        "type": "string",
-                        "description": "Optional Xero where filter clause. Optimized fields include Type, Status, Date, Contact.ContactID. Examples: Type=\"RECEIVE\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID=guid(\"96988e67-ecf9-466d-bfbf-0afa1725a649\"). Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
-                    },
-                    "order": {
-                        "type": "string",
-                        "description": "Optional Xero orderby parameter. Optimized fields for ordering: BankTransactionID, UpdatedDateUTC, Date. Examples: \"Date ASC\", \"UpdatedDateUTC DESC\", \"BankTransactionID ASC\". Multi-field sorting: \"Date DESC, BankTransactionID ASC\". Default order is UpdatedDateUTC ASC, BankTransactionID ASC."
-                    },
-                    "page": {
-                        "type": "integer",
-                        "description": "Optional page number for pagination"
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "bank_transactions": {
-                        "type": "array",
-                        "description": "Array of Xero bank transactions"
-                    }
-                },
-                "description": "Raw Xero API response for Bank Transactions"
-            }
-        },
-        "create_sales_invoice": {
-            "display_name": "Create Sales Invoice",
-            "description": "Creates a new sales invoice (ACCREC) in Xero for billing customers",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "contact": {
-                        "type": "object",
-                        "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
-                        "properties": {
-                            "ContactID": {
-                                "type": "string",
-                                "description": "Contact ID (GUID)"
-                            },
-                            "Name": {
-                                "type": "string",
-                                "description": "Contact name"
-                            }
-                        }
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "description": "Array of line items for the invoice",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "Description": {
-                                    "type": "string",
-                                    "description": "Line item description"
-                                },
-                                "Quantity": {
-                                    "type": "number",
-                                    "description": "Quantity"
-                                },
-                                "UnitAmount": {
-                                    "type": "number",
-                                    "description": "Unit amount/price"
-                                },
-                                "AccountCode": {
-                                    "type": "string",
-                                    "description": "Account code for the line item"
-                                },
-                                "TaxType": {
-                                    "type": "string",
-                                    "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
-                                }
-                            },
-                            "required": [
-                                "Description",
-                                "UnitAmount",
-                                "AccountCode"
-                            ]
-                        }
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Invoice date (YYYY-MM-DD). Defaults to today if not specified"
-                    },
-                    "due_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Due date for payment (YYYY-MM-DD)"
-                    },
-                    "invoice_number": {
-                        "type": "string",
-                        "description": "Custom invoice number"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "description": "Invoice reference"
-                    },
-                    "branding_theme_id": {
-                        "type": "string",
-                        "description": "Branding theme ID (GUID)"
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "SUBMITTED",
-                            "AUTHORISED"
-                        ],
-                        "description": "Invoice status. Defaults to DRAFT"
-                    },
-                    "line_amount_types": {
-                        "type": "string",
-                        "enum": [
-                            "Exclusive",
-                            "Inclusive",
-                            "NoTax"
-                        ],
-                        "description": "Line amount types for tax calculation"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "contact",
-                    "line_items"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Invoices": {
-                        "type": "array",
-                        "description": "Array containing the created invoice with full details"
-                    }
-                },
-                "description": "Raw Xero API response for created sales invoice"
-            }
-        },
-        "create_purchase_bill": {
-            "display_name": "Create Purchase Bill",
-            "description": "Creates a new purchase bill (ACCPAY) in Xero for recording supplier invoices",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "contact": {
-                        "type": "object",
-                        "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-                        "properties": {
-                            "ContactID": {
-                                "type": "string",
-                                "description": "Contact ID (GUID)"
-                            },
-                            "Name": {
-                                "type": "string",
-                                "description": "Contact name"
-                            }
-                        }
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "description": "Array of line items for the bill",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "Description": {
-                                    "type": "string",
-                                    "description": "Line item description"
-                                },
-                                "Quantity": {
-                                    "type": "number",
-                                    "description": "Quantity"
-                                },
-                                "UnitAmount": {
-                                    "type": "number",
-                                    "description": "Unit amount/price"
-                                },
-                                "AccountCode": {
-                                    "type": "string",
-                                    "description": "Account code for the line item"
-                                },
-                                "TaxType": {
-                                    "type": "string",
-                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                                }
-                            },
-                            "required": [
-                                "Description",
-                                "UnitAmount",
-                                "AccountCode"
-                            ]
-                        }
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Bill date (YYYY-MM-DD). Defaults to today if not specified"
-                    },
-                    "due_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Due date for payment (YYYY-MM-DD)"
-                    },
-                    "invoice_number": {
-                        "type": "string",
-                        "description": "Supplier's invoice/bill number"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "description": "Bill reference"
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "SUBMITTED",
-                            "AUTHORISED"
-                        ],
-                        "description": "Bill status. Defaults to DRAFT"
-                    },
-                    "line_amount_types": {
-                        "type": "string",
-                        "enum": [
-                            "Exclusive",
-                            "Inclusive",
-                            "NoTax"
-                        ],
-                        "description": "Line amount types for tax calculation"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "contact",
-                    "line_items"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Invoices": {
-                        "type": "array",
-                        "description": "Array containing the created purchase bill with full details"
-                    }
-                },
-                "description": "Raw Xero API response for created purchase bill"
-            }
-        },
-        "update_sales_invoice": {
-            "display_name": "Update Sales Invoice",
-            "description": "Updates an existing sales invoice (ACCREC) in Xero. Only DRAFT and SUBMITTED invoices can be updated",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "description": "ID of the invoice to update (GUID)"
-                    },
-                    "contact": {
-                        "type": "object",
-                        "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
-                        "properties": {
-                            "ContactID": {
-                                "type": "string",
-                                "description": "Contact ID (GUID)"
-                            },
-                            "Name": {
-                                "type": "string",
-                                "description": "Contact name"
-                            }
-                        }
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating invoices: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "LineItemID": {
-                                    "type": "string",
-                                    "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
-                                },
-                                "Description": {
-                                    "type": "string",
-                                    "description": "Line item description"
-                                },
-                                "Quantity": {
-                                    "type": "number",
-                                    "description": "Quantity"
-                                },
-                                "UnitAmount": {
-                                    "type": "number",
-                                    "description": "Unit amount/price"
-                                },
-                                "AccountCode": {
-                                    "type": "string",
-                                    "description": "Account code for the line item"
-                                },
-                                "TaxType": {
-                                    "type": "string",
-                                    "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
-                                }
-                            },
-                            "required": [
-                                "Description",
-                                "UnitAmount",
-                                "AccountCode"
-                            ]
-                        }
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Invoice date (YYYY-MM-DD)"
-                    },
-                    "due_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Due date for payment (YYYY-MM-DD)"
-                    },
-                    "invoice_number": {
-                        "type": "string",
-                        "description": "Custom invoice number"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "description": "Invoice reference"
-                    },
-                    "branding_theme_id": {
-                        "type": "string",
-                        "description": "Branding theme ID (GUID)"
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD, EUR)"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "SUBMITTED",
-                            "AUTHORISED"
-                        ],
-                        "description": "Invoice status"
-                    },
-                    "line_amount_types": {
-                        "type": "string",
-                        "enum": [
-                            "Exclusive",
-                            "Inclusive",
-                            "NoTax"
-                        ],
-                        "description": "Line amount types for tax calculation"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "invoice_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Invoices": {
-                        "type": "array",
-                        "description": "Array containing the updated invoice with full details"
-                    }
-                },
-                "description": "Raw Xero API response for updated sales invoice"
-            }
-        },
-        "update_purchase_bill": {
-            "display_name": "Update Purchase Bill",
-            "description": "Updates an existing purchase bill (ACCPAY) in Xero. Only DRAFT and SUBMITTED bills can be updated",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "description": "ID of the bill to update (GUID) - bills use InvoiceID in Xero API"
-                    },
-                    "contact": {
-                        "type": "object",
-                        "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-                        "properties": {
-                            "ContactID": {
-                                "type": "string",
-                                "description": "Contact ID (GUID)"
-                            },
-                            "Name": {
-                                "type": "string",
-                                "description": "Contact name"
-                            }
-                        }
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating bills: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "LineItemID": {
-                                    "type": "string",
-                                    "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
-                                },
-                                "Description": {
-                                    "type": "string",
-                                    "description": "Line item description"
-                                },
-                                "Quantity": {
-                                    "type": "number",
-                                    "description": "Quantity"
-                                },
-                                "UnitAmount": {
-                                    "type": "number",
-                                    "description": "Unit amount/price"
-                                },
-                                "AccountCode": {
-                                    "type": "string",
-                                    "description": "Account code for the line item"
-                                },
-                                "TaxType": {
-                                    "type": "string",
-                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                                }
-                            },
-                            "required": [
-                                "Description",
-                                "UnitAmount",
-                                "AccountCode"
-                            ]
-                        }
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Bill date (YYYY-MM-DD)"
-                    },
-                    "due_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Due date for payment (YYYY-MM-DD)"
-                    },
-                    "invoice_number": {
-                        "type": "string",
-                        "description": "Supplier's invoice/bill number"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "description": "Bill reference"
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD, EUR)"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "SUBMITTED",
-                            "AUTHORISED"
-                        ],
-                        "description": "Bill status"
-                    },
-                    "line_amount_types": {
-                        "type": "string",
-                        "enum": [
-                            "Exclusive",
-                            "Inclusive",
-                            "NoTax"
-                        ],
-                        "description": "Line amount types for tax calculation"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "invoice_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Invoices": {
-                        "type": "array",
-                        "description": "Array containing the updated purchase bill with full details"
-                    }
-                },
-                "description": "Raw Xero API response for updated purchase bill"
-            }
-        },
-        "attach_file_to_invoice": {
-            "display_name": "Attach File to Invoice",
-            "description": "Attaches a file to an existing sales invoice or purchase bill in Xero",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "description": "ID of the invoice/bill to attach file to (GUID)"
-                    },
-                    "file": {
-                        "type": "object",
-                        "description": "File object from chat: base64 content, name, contentType.",
-                        "properties": {
-                            "content": {
-                                "type": "string",
-                                "description": "Base64 encoded file content"
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "File name including extension"
-                            },
-                            "contentType": {
-                                "type": "string",
-                                "description": "MIME type of the file"
-                            }
-                        },
-                        "required": [
-                            "content",
-                            "name",
-                            "contentType"
-                        ]
-                    },
-                    "files": {
-                        "type": "array",
-                        "description": "Alternate input: array of file objects; the first will be used.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "content": {
-                                    "type": "string",
-                                    "description": "Base64 encoded file content"
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "File name including extension"
-                                },
-                                "contentType": {
-                                    "type": "string",
-                                    "description": "MIME type of the file"
-                                }
-                            },
-                            "required": [
-                                "content",
-                                "name",
-                                "contentType"
-                            ]
-                        }
-                    },
-                    "include_online": {
-                        "type": "boolean",
-                        "description": "Whether to include the attachment in online invoice (default: true)"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "invoice_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Attachments": {
-                        "type": "array",
-                        "description": "Array containing the attachment details"
-                    }
-                },
-                "description": "Raw Xero API response for file attachment"
-            }
-        },
-        "attach_file_to_bill": {
-            "display_name": "Attach File to Bill",
-            "description": "Attaches a file to an existing purchase bill in Xero",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "bill_id": {
-                        "type": "string",
-                        "description": "ID of the bill to attach file to (GUID) - same as invoice_id in Xero API"
-                    },
-                    "file": {
-                        "type": "object",
-                        "description": "File object from chat: base64 content, name, contentType.",
-                        "properties": {
-                            "content": {
-                                "type": "string",
-                                "description": "Base64 encoded file content"
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "File name including extension"
-                            },
-                            "contentType": {
-                                "type": "string",
-                                "description": "MIME type of the file"
-                            }
-                        },
-                        "required": [
-                            "content",
-                            "name",
-                            "contentType"
-                        ]
-                    },
-                    "files": {
-                        "type": "array",
-                        "description": "Alternate input: array of file objects; the first will be used.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "content": {
-                                    "type": "string",
-                                    "description": "Base64 encoded file content"
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "File name including extension"
-                                },
-                                "contentType": {
-                                    "type": "string",
-                                    "description": "MIME type of the file"
-                                }
-                            },
-                            "required": [
-                                "content",
-                                "name",
-                                "contentType"
-                            ]
-                        }
-                    },
-                    "include_online": {
-                        "type": "boolean",
-                        "description": "Whether to include the attachment in online bill (default: true)"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "bill_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Attachments": {
-                        "type": "array",
-                        "description": "Array containing the attachment details"
-                    }
-                },
-                "description": "Raw Xero API response for file attachment"
-            }
-        },
-        "get_attachments": {
-            "display_name": "Get Attachments",
-            "description": "Gets all attachments for a specific invoice, bill, or bank transaction from Xero API",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "endpoint": {
-                        "type": "string",
-                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
-                        "enum": [
-                            "Invoices",
-                            "Bills",
-                            "BankTransactions"
-                        ]
-                    },
-                    "guid": {
-                        "type": "string",
-                        "description": "The GUID of the invoice/bill/transaction"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "endpoint",
-                    "guid"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "Attachments": {
-                        "type": "array",
-                        "description": "Array of attachment metadata including file names, IDs, sizes, and MIME types"
-                    }
-                },
-                "description": "Raw Xero API response for attachments list"
-            }
-        },
-        "get_attachment_content": {
-            "display_name": "Get Attachment Content",
-            "description": "Downloads the actual content of a specific attachment from Xero API for agent analysis",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "endpoint": {
-                        "type": "string",
-                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
-                        "enum": [
-                            "Invoices",
-                            "Bills",
-                            "BankTransactions"
-                        ]
-                    },
-                    "guid": {
-                        "type": "string",
-                        "description": "The GUID of the invoice/bill/transaction"
-                    },
-                    "file_name": {
-                        "type": "string",
-                        "description": "The filename of the attachment to download"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "endpoint",
-                    "guid",
-                    "file_name"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "File name"
-                            },
-                            "content": {
-                                "type": "string",
-                                "description": "Base64 encoded file content for agent analysis"
-                            },
-                            "contentType": {
-                                "type": "string",
-                                "description": "MIME type of the file"
-                            }
-                        },
-                        "required": [
-                            "name",
-                            "content",
-                            "contentType"
-                        ]
-                    },
-                    "success": {
-                        "type": "boolean",
-                        "description": "Whether the download was successful"
-                    },
-                    "error": {
-                        "type": "string",
-                        "description": "Error message if download failed"
-                    }
-                },
-                "required": [
-                    "file",
-                    "success"
-                ]
-            }
-        },
-        "get_purchase_orders": {
-            "display_name": "Get Purchase Orders",
-            "description": "Retrieves purchase orders from Xero API with filtering. Can fetch all purchase orders or a specific one by ID",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "purchase_order_id": {
-                        "type": "string",
-                        "description": "Optional specific purchase order ID (GUID) to fetch. When provided, fetches only this purchase order"
-                    },
-                    "where": {
-                        "type": "string",
-                        "description": "Optional Xero where filter clause. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID==guid(\"contact-id\"). Combine with AND/OR operators."
-                    },
-                    "order": {
-                        "type": "string",
-                        "description": "Optional Xero orderby parameter. Examples: \"Date DESC\", \"PurchaseOrderNumber ASC\". Multi-field sorting supported."
-                    },
-                    "page": {
-                        "type": "integer",
-                        "description": "Optional page number for pagination"
-                    },
-                    "statuses": {
-                        "type": "string",
-                        "description": "Optional comma-separated list of statuses. Examples: \"DRAFT,SUBMITTED,AUTHORISED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, BILLED, DELETED"
-                    }
-                },
-                "required": [
-                    "tenant_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "PurchaseOrders": {
-                        "type": "array",
-                        "description": "Array of Xero purchase orders with details"
-                    }
-                },
-                "description": "Raw Xero API response for Purchase Orders"
-            }
-        },
-        "create_purchase_order": {
-            "display_name": "Create Purchase Order",
-            "description": "Creates a new purchase order in Xero for ordering goods or services from suppliers",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "contact": {
-                        "type": "object",
-                        "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-                        "properties": {
-                            "ContactID": {
-                                "type": "string",
-                                "description": "Contact ID (GUID)"
-                            },
-                            "Name": {
-                                "type": "string",
-                                "description": "Contact name"
-                            }
-                        }
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "description": "Array of line items for the purchase order",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "Description": {
-                                    "type": "string",
-                                    "description": "Line item description"
-                                },
-                                "Quantity": {
-                                    "type": "number",
-                                    "description": "Quantity"
-                                },
-                                "UnitAmount": {
-                                    "type": "number",
-                                    "description": "Unit amount/price"
-                                },
-                                "AccountCode": {
-                                    "type": "string",
-                                    "description": "Account code for the line item"
-                                },
-                                "TaxType": {
-                                    "type": "string",
-                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                                }
-                            },
-                            "required": [
-                                "Description",
-                                "UnitAmount",
-                                "AccountCode"
-                            ]
-                        }
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Purchase order date (YYYY-MM-DD). Defaults to today if not specified"
-                    },
-                    "delivery_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Expected delivery date (YYYY-MM-DD)"
-                    },
-                    "purchase_order_number": {
-                        "type": "string",
-                        "description": "Custom purchase order number"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "description": "Purchase order reference"
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "SUBMITTED",
-                            "AUTHORISED",
-                            "BILLED",
-                            "DELETED"
-                        ],
-                        "description": "Purchase order status. Defaults to DRAFT"
-                    },
-                    "line_amount_types": {
-                        "type": "string",
-                        "enum": [
-                            "Exclusive",
-                            "Inclusive",
-                            "NoTax"
-                        ],
-                        "description": "Line amount types for tax calculation"
-                    },
-                    "delivery_address": {
-                        "type": "string",
-                        "description": "Delivery address"
-                    },
-                    "attention_to": {
-                        "type": "string",
-                        "description": "Name of person to be contacted"
-                    },
-                    "telephone": {
-                        "type": "string",
-                        "description": "Phone number for contact"
-                    },
-                    "delivery_instructions": {
-                        "type": "string",
-                        "description": "Delivery instructions"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "contact",
-                    "line_items"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "PurchaseOrders": {
-                        "type": "array",
-                        "description": "Array containing the created purchase order with full details"
-                    }
-                },
-                "description": "Raw Xero API response for created purchase order"
-            }
-        },
-        "update_purchase_order": {
-            "display_name": "Update Purchase Order",
-            "description": "Updates an existing purchase order in Xero. Only DRAFT and SUBMITTED purchase orders can be updated",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "purchase_order_id": {
-                        "type": "string",
-                        "description": "ID of the purchase order to update (GUID)"
-                    },
-                    "contact": {
-                        "type": "object",
-                        "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-                        "properties": {
-                            "ContactID": {
-                                "type": "string",
-                                "description": "Contact ID (GUID)"
-                            },
-                            "Name": {
-                                "type": "string",
-                                "description": "Contact name"
-                            }
-                        }
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating purchase orders: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "LineItemID": {
-                                    "type": "string",
-                                    "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
-                                },
-                                "Description": {
-                                    "type": "string",
-                                    "description": "Line item description"
-                                },
-                                "Quantity": {
-                                    "type": "number",
-                                    "description": "Quantity"
-                                },
-                                "UnitAmount": {
-                                    "type": "number",
-                                    "description": "Unit amount/price"
-                                },
-                                "AccountCode": {
-                                    "type": "string",
-                                    "description": "Account code for the line item"
-                                },
-                                "TaxType": {
-                                    "type": "string",
-                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                                }
-                            },
-                            "required": [
-                                "Description",
-                                "UnitAmount",
-                                "AccountCode"
-                            ]
-                        }
-                    },
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Purchase order date (YYYY-MM-DD)"
-                    },
-                    "delivery_date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Expected delivery date (YYYY-MM-DD)"
-                    },
-                    "purchase_order_number": {
-                        "type": "string",
-                        "description": "Custom purchase order number"
-                    },
-                    "reference": {
-                        "type": "string",
-                        "description": "Purchase order reference"
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD, EUR)"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "SUBMITTED",
-                            "AUTHORISED",
-                            "BILLED",
-                            "DELETED"
-                        ],
-                        "description": "Purchase order status"
-                    },
-                    "line_amount_types": {
-                        "type": "string",
-                        "enum": [
-                            "Exclusive",
-                            "Inclusive",
-                            "NoTax"
-                        ],
-                        "description": "Line amount types for tax calculation"
-                    },
-                    "delivery_address": {
-                        "type": "string",
-                        "description": "Delivery address"
-                    },
-                    "attention_to": {
-                        "type": "string",
-                        "description": "Name of person to be contacted"
-                    },
-                    "telephone": {
-                        "type": "string",
-                        "description": "Phone number for contact"
-                    },
-                    "delivery_instructions": {
-                        "type": "string",
-                        "description": "Delivery instructions"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "purchase_order_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "PurchaseOrders": {
-                        "type": "array",
-                        "description": "Array containing the updated purchase order with full details"
-                    }
-                },
-                "description": "Raw Xero API response for updated purchase order"
-            }
-        },
-        "delete_purchase_order": {
-            "display_name": "Delete Purchase Order",
-            "description": "Deletes a purchase order in Xero by updating its status to DELETED",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "purchase_order_id": {
-                        "type": "string",
-                        "description": "ID of the purchase order to delete (GUID)"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "purchase_order_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "PurchaseOrders": {
-                        "type": "array",
-                        "description": "Array containing the deleted purchase order with updated status"
-                    }
-                },
-                "description": "Raw Xero API response for deleted purchase order"
-            }
-        },
-        "get_purchase_order_history": {
-            "display_name": "Get Purchase Order History",
-            "description": "Retrieves the history and notes for a specific purchase order from Xero API",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "purchase_order_id": {
-                        "type": "string",
-                        "description": "ID of the purchase order to get history for (GUID)"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "purchase_order_id"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "HistoryRecords": {
-                        "type": "array",
-                        "description": "Array of history records including notes and changes"
-                    }
-                },
-                "description": "Raw Xero API response for purchase order history"
-            }
-        },
-        "add_note_to_purchase_order": {
-            "display_name": "Add Note to Purchase Order",
-            "description": "Adds a note to a purchase order's history in Xero",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Xero tenant ID"
-                    },
-                    "purchase_order_id": {
-                        "type": "string",
-                        "description": "ID of the purchase order to add note to (GUID)"
-                    },
-                    "note": {
-                        "type": "string",
-                        "description": "The note text to add to the purchase order history"
-                    }
-                },
-                "required": [
-                    "tenant_id",
-                    "purchase_order_id",
-                    "note"
-                ]
-            },
-            "output_schema": {
-                "type": "object",
-                "properties": {
-                    "HistoryRecords": {
-                        "type": "array",
-                        "description": "Array containing the added history record"
-                    }
-                },
-                "description": "Raw Xero API response for added note"
-            }
-        }
+        "required": [
+          "contacts"
+        ]
+      }
     },
-    "display_name": "Xero"
+    "get_aged_payables": {
+      "display_name": "Get Aged Payables",
+      "description": "Retrieves aged payables report from Xero for a specific contact",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "contact_id": {
+            "type": "string",
+            "description": "Contact ID (GUID) for which to retrieve aged payables"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "contact_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "reports": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "report_id": {
+                  "type": "string",
+                  "description": "Report identifier"
+                },
+                "report_name": {
+                  "type": "string",
+                  "description": "Report name"
+                },
+                "report_date": {
+                  "type": "string",
+                  "description": "Report date"
+                },
+                "rows": {
+                  "type": "array",
+                  "description": "Report data rows"
+                }
+              }
+            }
+          }
+        },
+        "description": "Raw Xero API response for Aged Payables report"
+      }
+    },
+    "get_aged_receivables": {
+      "display_name": "Get Aged Receivables",
+      "description": "Retrieves aged receivables report from Xero for a specific contact",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "contact_id": {
+            "type": "string",
+            "description": "Contact ID (GUID) for which to retrieve aged receivables"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "contact_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "reports": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "report_id": {
+                  "type": "string",
+                  "description": "Report identifier"
+                },
+                "report_name": {
+                  "type": "string",
+                  "description": "Report name"
+                },
+                "report_date": {
+                  "type": "string",
+                  "description": "Report date"
+                },
+                "rows": {
+                  "type": "array",
+                  "description": "Report data rows"
+                }
+              }
+            }
+          }
+        },
+        "description": "Raw Xero API response for Aged Receivables report"
+      }
+    },
+    "get_balance_sheet": {
+      "display_name": "Get Balance Sheet",
+      "description": "Retrieves balance sheet report from Xero",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+          },
+          "periods": {
+            "type": "integer",
+            "description": "Number of periods to compare (optional)",
+            "minimum": 1,
+            "maximum": 12
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "reports": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "report_id": {
+                  "type": "string",
+                  "description": "Report identifier"
+                },
+                "report_name": {
+                  "type": "string",
+                  "description": "Report name"
+                },
+                "report_date": {
+                  "type": "string",
+                  "description": "Report date"
+                },
+                "rows": {
+                  "type": "array",
+                  "description": "Report data rows"
+                }
+              }
+            }
+          }
+        },
+        "description": "Raw Xero API response for Balance Sheet report"
+      }
+    },
+    "get_profit_and_loss": {
+      "display_name": "Get Profit and Loss",
+      "description": "Retrieves profit and loss statement from Xero",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+          },
+          "from_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Start date for the report period (YYYY-MM-DD)"
+          },
+          "to_date": {
+            "type": "string",
+            "format": "date",
+            "description": "End date for the report period (YYYY-MM-DD)"
+          },
+          "timeframe": {
+            "type": "string",
+            "enum": [
+              "MONTH",
+              "QUARTER",
+              "YEAR"
+            ],
+            "description": "Timeframe for period comparisons (optional)"
+          },
+          "periods": {
+            "type": "integer",
+            "description": "Number of periods to compare (optional)",
+            "minimum": 1,
+            "maximum": 12
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "reports": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "report_id": {
+                  "type": "string",
+                  "description": "Report identifier"
+                },
+                "report_name": {
+                  "type": "string",
+                  "description": "Report name"
+                },
+                "report_date": {
+                  "type": "string",
+                  "description": "Report date"
+                },
+                "rows": {
+                  "type": "array",
+                  "description": "Report data rows"
+                }
+              }
+            }
+          }
+        },
+        "description": "Raw Xero API response for Profit and Loss statement"
+      }
+    },
+    "get_trial_balance": {
+      "display_name": "Get Trial Balance",
+      "description": "Retrieves trial balance report from Xero",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Report date (YYYY-MM-DD). Defaults to last date of last calendar month if not specified"
+          },
+          "payments_only": {
+            "type": "boolean",
+            "description": "Whether to include only payments (optional, defaults to false)"
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "reports": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "report_id": {
+                  "type": "string",
+                  "description": "Report identifier"
+                },
+                "report_name": {
+                  "type": "string",
+                  "description": "Report name"
+                },
+                "report_date": {
+                  "type": "string",
+                  "description": "Report date"
+                },
+                "rows": {
+                  "type": "array",
+                  "description": "Report data rows"
+                }
+              }
+            }
+          }
+        },
+        "description": "Raw Xero API response for Trial Balance report"
+      }
+    },
+    "get_accounts": {
+      "display_name": "Get Accounts",
+      "description": "Retrieves accounts from Xero to classify line items (revenue, expenses, fixed assets, loans, equity/dividends, GST)",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "where": {
+            "type": "string",
+            "description": "Optional Xero where filter clause. Filter by any element using Xero syntax. Examples: Status=\"ACTIVE\", Type=\"REVENUE\", Code>=\"4000\". Use range operators (>, >=, <, <=) and combine with AND/OR operators."
+          },
+          "order": {
+            "type": "string",
+            "description": "Optional Xero orderby parameter. Order by any element returned. Examples: \"Code ASC\", \"Name DESC\", \"Type ASC\". Multi-field sorting: \"Type ASC, Code ASC\". Note: Some fields are optimized for better performance."
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "accounts": {
+            "type": "array",
+            "description": "Array of Xero accounts"
+          }
+        },
+        "description": "Raw Xero API response for Accounts"
+      }
+    },
+    "get_payments": {
+      "display_name": "Get Payments",
+      "description": "Retrieves payments from Xero for cash on invoices/bills (customer receipts, supplier payments, cash refunds)",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "where": {
+            "type": "string",
+            "description": "Optional Xero where filter clause. Optimized fields include PaymentType, Status, Date, Invoice.InvoiceId, Reference. Examples: PaymentType=\"ACCRECPAYMENT\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Reference=\"INV-0001\". Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
+          },
+          "order": {
+            "type": "string",
+            "description": "Optional Xero orderby parameter. Optimized fields for ordering: UpdatedDateUTC, Date, PaymentId. Examples: \"UpdatedDateUTC ASC\", \"Date DESC\", \"PaymentId ASC\". Multi-field sorting: \"Date DESC, PaymentId ASC\". Default order is UpdatedDateUTC ASC, PaymentId ASC."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Optional page number for pagination. Default is 100 payments per page when used alone."
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "Optional page size for pagination (1-1000). Used with page parameter. Examples: page=1&pageSize=250."
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "payments": {
+            "type": "array",
+            "description": "Array of Xero payments"
+          }
+        },
+        "description": "Raw Xero API response for Payments"
+      }
+    },
+    "get_invoices": {
+      "display_name": "Get Invoices",
+      "description": "Retrieves invoices from Xero API with optimized filtering. Can fetch all invoices or a specific invoice by ID. Supports sales invoices (ACCREC) and purchase invoices (ACCPAY)",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "invoice_id": {
+            "type": "string",
+            "description": "Optional specific invoice ID (GUID) to fetch. When provided, fetches only this invoice and ignores other filter parameters"
+          },
+          "where": {
+            "type": "string",
+            "description": "Optional Xero where filter clause with optimized fields. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01) AND Date<=DateTime(2020,12,31), Contact.ContactID==guid(\"contact-id\"), Type==\"ACCREC\", Total>=100.00 AND Total<=1000.00. Combine with AND/OR operators."
+          },
+          "order": {
+            "type": "string",
+            "description": "Optional Xero orderby parameter. Optimized fields: InvoiceNumber, Date, DueDate, Total, UpdatedDateUTC. Examples: \"Date DESC\", \"InvoiceNumber ASC\", \"Total DESC,Date ASC\". Multi-field sorting supported."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Optional page number for pagination"
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "Optional page size for pagination (max 100)"
+          },
+          "statuses": {
+            "type": "string",
+            "description": "Optional comma-separated list of invoice statuses for bulk filtering. Examples: \"DRAFT,SUBMITTED,AUTHORISED\", \"VOIDED,DELETED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, PAID, VOIDED, DELETED"
+          },
+          "invoice_numbers": {
+            "type": "string",
+            "description": "Optional comma-separated list of invoice numbers for bulk retrieval by invoice number"
+          },
+          "contact_ids": {
+            "type": "string",
+            "description": "Optional comma-separated list of contact IDs (GUIDs) to filter invoices by specific contacts"
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "invoices": {
+            "type": "array",
+            "description": "Array of Xero invoices with details including invoice number, date, due date, contact, line items, amounts, and status"
+          }
+        },
+        "description": "Raw Xero API response for Invoices"
+      }
+    },
+    "get_invoice_pdf": {
+      "display_name": "Get Invoice PDF",
+      "description": "Retrieves a specific invoice as a PDF file from Xero API. Works with both sales invoices (ACCREC) and purchase bills (ACCPAY)",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "invoice_id": {
+            "type": "string",
+            "description": "Invoice ID (GUID) to retrieve as PDF. Example: 97c2dc5-cc47-4afd-8ec8-74990b8761e9"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "invoice_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "File name of the PDF"
+              },
+              "content": {
+                "type": "string",
+                "description": "Base64 encoded PDF content"
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the file (application/pdf)"
+              }
+            },
+            "required": [
+              "name",
+              "content",
+              "contentType"
+            ]
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Whether the PDF download was successful"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message if download failed"
+          }
+        },
+        "required": [
+          "file",
+          "success"
+        ]
+      }
+    },
+    "get_bank_transactions": {
+      "display_name": "Get Bank Transactions",
+      "description": "Retrieves bank transactions from Xero for Receive/Spend Money not tied to invoices (CapEx, financing, other operating)",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "where": {
+            "type": "string",
+            "description": "Optional Xero where filter clause. Optimized fields include Type, Status, Date, Contact.ContactID. Examples: Type=\"RECEIVE\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID=guid(\"96988e67-ecf9-466d-bfbf-0afa1725a649\"). Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
+          },
+          "order": {
+            "type": "string",
+            "description": "Optional Xero orderby parameter. Optimized fields for ordering: BankTransactionID, UpdatedDateUTC, Date. Examples: \"Date ASC\", \"UpdatedDateUTC DESC\", \"BankTransactionID ASC\". Multi-field sorting: \"Date DESC, BankTransactionID ASC\". Default order is UpdatedDateUTC ASC, BankTransactionID ASC."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Optional page number for pagination"
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "bank_transactions": {
+            "type": "array",
+            "description": "Array of Xero bank transactions"
+          }
+        },
+        "description": "Raw Xero API response for Bank Transactions"
+      }
+    },
+    "create_sales_invoice": {
+      "display_name": "Create Sales Invoice",
+      "description": "Creates a new sales invoice (ACCREC) in Xero for billing customers",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "contact": {
+            "type": "object",
+            "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
+            "properties": {
+              "ContactID": {
+                "type": "string",
+                "description": "Contact ID (GUID)"
+              },
+              "Name": {
+                "type": "string",
+                "description": "Contact name"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "description": "Array of line items for the invoice",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Description": {
+                  "type": "string",
+                  "description": "Line item description"
+                },
+                "Quantity": {
+                  "type": "number",
+                  "description": "Quantity"
+                },
+                "UnitAmount": {
+                  "type": "number",
+                  "description": "Unit amount/price"
+                },
+                "AccountCode": {
+                  "type": "string",
+                  "description": "Account code for the line item"
+                },
+                "TaxType": {
+                  "type": "string",
+                  "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
+                }
+              },
+              "required": [
+                "Description",
+                "UnitAmount",
+                "AccountCode"
+              ]
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Invoice date (YYYY-MM-DD). Defaults to today if not specified"
+          },
+          "due_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Due date for payment (YYYY-MM-DD)"
+          },
+          "invoice_number": {
+            "type": "string",
+            "description": "Custom invoice number"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Invoice reference"
+          },
+          "branding_theme_id": {
+            "type": "string",
+            "description": "Branding theme ID (GUID)"
+          },
+          "currency_code": {
+            "type": "string",
+            "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED"
+            ],
+            "description": "Invoice status. Defaults to DRAFT"
+          },
+          "line_amount_types": {
+            "type": "string",
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
+            "description": "Line amount types for tax calculation"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "contact",
+          "line_items"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Invoices": {
+            "type": "array",
+            "description": "Array containing the created invoice with full details"
+          }
+        },
+        "description": "Raw Xero API response for created sales invoice"
+      }
+    },
+    "create_purchase_bill": {
+      "display_name": "Create Purchase Bill",
+      "description": "Creates a new purchase bill (ACCPAY) in Xero for recording supplier invoices",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "contact": {
+            "type": "object",
+            "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+            "properties": {
+              "ContactID": {
+                "type": "string",
+                "description": "Contact ID (GUID)"
+              },
+              "Name": {
+                "type": "string",
+                "description": "Contact name"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "description": "Array of line items for the bill",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Description": {
+                  "type": "string",
+                  "description": "Line item description"
+                },
+                "Quantity": {
+                  "type": "number",
+                  "description": "Quantity"
+                },
+                "UnitAmount": {
+                  "type": "number",
+                  "description": "Unit amount/price"
+                },
+                "AccountCode": {
+                  "type": "string",
+                  "description": "Account code for the line item"
+                },
+                "TaxType": {
+                  "type": "string",
+                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                }
+              },
+              "required": [
+                "Description",
+                "UnitAmount",
+                "AccountCode"
+              ]
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Bill date (YYYY-MM-DD). Defaults to today if not specified"
+          },
+          "due_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Due date for payment (YYYY-MM-DD)"
+          },
+          "invoice_number": {
+            "type": "string",
+            "description": "Supplier's invoice/bill number"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Bill reference"
+          },
+          "currency_code": {
+            "type": "string",
+            "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED"
+            ],
+            "description": "Bill status. Defaults to DRAFT"
+          },
+          "line_amount_types": {
+            "type": "string",
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
+            "description": "Line amount types for tax calculation"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "contact",
+          "line_items"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Invoices": {
+            "type": "array",
+            "description": "Array containing the created purchase bill with full details"
+          }
+        },
+        "description": "Raw Xero API response for created purchase bill"
+      }
+    },
+    "update_sales_invoice": {
+      "display_name": "Update Sales Invoice",
+      "description": "Updates an existing sales invoice (ACCREC) in Xero. Only DRAFT and SUBMITTED invoices can be updated",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "invoice_id": {
+            "type": "string",
+            "description": "ID of the invoice to update (GUID)"
+          },
+          "contact": {
+            "type": "object",
+            "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
+            "properties": {
+              "ContactID": {
+                "type": "string",
+                "description": "Contact ID (GUID)"
+              },
+              "Name": {
+                "type": "string",
+                "description": "Contact name"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating invoices: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "LineItemID": {
+                  "type": "string",
+                  "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+                },
+                "Description": {
+                  "type": "string",
+                  "description": "Line item description"
+                },
+                "Quantity": {
+                  "type": "number",
+                  "description": "Quantity"
+                },
+                "UnitAmount": {
+                  "type": "number",
+                  "description": "Unit amount/price"
+                },
+                "AccountCode": {
+                  "type": "string",
+                  "description": "Account code for the line item"
+                },
+                "TaxType": {
+                  "type": "string",
+                  "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
+                }
+              },
+              "required": [
+                "Description",
+                "UnitAmount",
+                "AccountCode"
+              ]
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Invoice date (YYYY-MM-DD)"
+          },
+          "due_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Due date for payment (YYYY-MM-DD)"
+          },
+          "invoice_number": {
+            "type": "string",
+            "description": "Custom invoice number"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Invoice reference"
+          },
+          "branding_theme_id": {
+            "type": "string",
+            "description": "Branding theme ID (GUID)"
+          },
+          "currency_code": {
+            "type": "string",
+            "description": "Currency code (e.g., USD, EUR)"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED"
+            ],
+            "description": "Invoice status"
+          },
+          "line_amount_types": {
+            "type": "string",
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
+            "description": "Line amount types for tax calculation"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "invoice_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Invoices": {
+            "type": "array",
+            "description": "Array containing the updated invoice with full details"
+          }
+        },
+        "description": "Raw Xero API response for updated sales invoice"
+      }
+    },
+    "update_purchase_bill": {
+      "display_name": "Update Purchase Bill",
+      "description": "Updates an existing purchase bill (ACCPAY) in Xero. Only DRAFT and SUBMITTED bills can be updated",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "invoice_id": {
+            "type": "string",
+            "description": "ID of the bill to update (GUID) - bills use InvoiceID in Xero API"
+          },
+          "contact": {
+            "type": "object",
+            "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+            "properties": {
+              "ContactID": {
+                "type": "string",
+                "description": "Contact ID (GUID)"
+              },
+              "Name": {
+                "type": "string",
+                "description": "Contact name"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating bills: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "LineItemID": {
+                  "type": "string",
+                  "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+                },
+                "Description": {
+                  "type": "string",
+                  "description": "Line item description"
+                },
+                "Quantity": {
+                  "type": "number",
+                  "description": "Quantity"
+                },
+                "UnitAmount": {
+                  "type": "number",
+                  "description": "Unit amount/price"
+                },
+                "AccountCode": {
+                  "type": "string",
+                  "description": "Account code for the line item"
+                },
+                "TaxType": {
+                  "type": "string",
+                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                }
+              },
+              "required": [
+                "Description",
+                "UnitAmount",
+                "AccountCode"
+              ]
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Bill date (YYYY-MM-DD)"
+          },
+          "due_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Due date for payment (YYYY-MM-DD)"
+          },
+          "invoice_number": {
+            "type": "string",
+            "description": "Supplier's invoice/bill number"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Bill reference"
+          },
+          "currency_code": {
+            "type": "string",
+            "description": "Currency code (e.g., USD, EUR)"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED"
+            ],
+            "description": "Bill status"
+          },
+          "line_amount_types": {
+            "type": "string",
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
+            "description": "Line amount types for tax calculation"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "invoice_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Invoices": {
+            "type": "array",
+            "description": "Array containing the updated purchase bill with full details"
+          }
+        },
+        "description": "Raw Xero API response for updated purchase bill"
+      }
+    },
+    "attach_file_to_invoice": {
+      "display_name": "Attach File to Invoice",
+      "description": "Attaches a file to an existing sales invoice or purchase bill in Xero",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "invoice_id": {
+            "type": "string",
+            "description": "ID of the invoice/bill to attach file to (GUID)"
+          },
+          "file": {
+            "type": "object",
+            "description": "File object from chat: base64 content, name, contentType.",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Base64 encoded file content"
+              },
+              "name": {
+                "type": "string",
+                "description": "File name including extension"
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the file"
+              }
+            },
+            "required": [
+              "content",
+              "name",
+              "contentType"
+            ]
+          },
+          "files": {
+            "type": "array",
+            "description": "Alternate input: array of file objects; the first will be used.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "Base64 encoded file content"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "File name including extension"
+                },
+                "contentType": {
+                  "type": "string",
+                  "description": "MIME type of the file"
+                }
+              },
+              "required": [
+                "content",
+                "name",
+                "contentType"
+              ]
+            }
+          },
+          "include_online": {
+            "type": "boolean",
+            "description": "Whether to include the attachment in online invoice (default: true)"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "invoice_id",
+          "file"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Attachments": {
+            "type": "array",
+            "description": "Array containing the attachment details"
+          }
+        },
+        "description": "Raw Xero API response for file attachment"
+      }
+    },
+    "attach_file_to_bill": {
+      "display_name": "Attach File to Bill",
+      "description": "Attaches a file to an existing purchase bill in Xero",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "bill_id": {
+            "type": "string",
+            "description": "ID of the bill to attach file to (GUID) - same as invoice_id in Xero API"
+          },
+          "file": {
+            "type": "object",
+            "description": "File object from chat: base64 content, name, contentType.",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Base64 encoded file content"
+              },
+              "name": {
+                "type": "string",
+                "description": "File name including extension"
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the file"
+              }
+            },
+            "required": [
+              "content",
+              "name",
+              "contentType"
+            ]
+          },
+          "files": {
+            "type": "array",
+            "description": "Alternate input: array of file objects; the first will be used.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "Base64 encoded file content"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "File name including extension"
+                },
+                "contentType": {
+                  "type": "string",
+                  "description": "MIME type of the file"
+                }
+              },
+              "required": [
+                "content",
+                "name",
+                "contentType"
+              ]
+            }
+          },
+          "include_online": {
+            "type": "boolean",
+            "description": "Whether to include the attachment in online bill (default: true)"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "bill_id",
+          "file"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Attachments": {
+            "type": "array",
+            "description": "Array containing the attachment details"
+          }
+        },
+        "description": "Raw Xero API response for file attachment"
+      }
+    },
+    "get_attachments": {
+      "display_name": "Get Attachments",
+      "description": "Gets all attachments for a specific invoice, bill, or bank transaction from Xero API",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "endpoint": {
+            "type": "string",
+            "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
+            "enum": [
+              "Invoices",
+              "Bills",
+              "BankTransactions"
+            ]
+          },
+          "guid": {
+            "type": "string",
+            "description": "The GUID of the invoice/bill/transaction"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "endpoint",
+          "guid"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "Attachments": {
+            "type": "array",
+            "description": "Array of attachment metadata including file names, IDs, sizes, and MIME types"
+          }
+        },
+        "description": "Raw Xero API response for attachments list"
+      }
+    },
+    "get_attachment_content": {
+      "display_name": "Get Attachment Content",
+      "description": "Downloads the actual content of a specific attachment from Xero API for agent analysis",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "endpoint": {
+            "type": "string",
+            "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
+            "enum": [
+              "Invoices",
+              "Bills",
+              "BankTransactions"
+            ]
+          },
+          "guid": {
+            "type": "string",
+            "description": "The GUID of the invoice/bill/transaction"
+          },
+          "file_name": {
+            "type": "string",
+            "description": "The filename of the attachment to download"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "endpoint",
+          "guid",
+          "file_name"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "File name"
+              },
+              "content": {
+                "type": "string",
+                "description": "Base64 encoded file content for agent analysis"
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the file"
+              }
+            },
+            "required": [
+              "name",
+              "content",
+              "contentType"
+            ]
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Whether the download was successful"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message if download failed"
+          }
+        },
+        "required": [
+          "file",
+          "success"
+        ]
+      }
+    },
+    "get_purchase_orders": {
+      "display_name": "Get Purchase Orders",
+      "description": "Retrieves purchase orders from Xero API with filtering. Can fetch all purchase orders or a specific one by ID",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "purchase_order_id": {
+            "type": "string",
+            "description": "Optional specific purchase order ID (GUID) to fetch. When provided, fetches only this purchase order"
+          },
+          "where": {
+            "type": "string",
+            "description": "Optional Xero where filter clause. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID==guid(\"contact-id\"). Combine with AND/OR operators."
+          },
+          "order": {
+            "type": "string",
+            "description": "Optional Xero orderby parameter. Examples: \"Date DESC\", \"PurchaseOrderNumber ASC\". Multi-field sorting supported."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Optional page number for pagination"
+          },
+          "statuses": {
+            "type": "string",
+            "description": "Optional comma-separated list of statuses. Examples: \"DRAFT,SUBMITTED,AUTHORISED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, BILLED, DELETED"
+          }
+        },
+        "required": [
+          "tenant_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "PurchaseOrders": {
+            "type": "array",
+            "description": "Array of Xero purchase orders with details"
+          }
+        },
+        "description": "Raw Xero API response for Purchase Orders"
+      }
+    },
+    "create_purchase_order": {
+      "display_name": "Create Purchase Order",
+      "description": "Creates a new purchase order in Xero for ordering goods or services from suppliers",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "contact": {
+            "type": "object",
+            "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+            "properties": {
+              "ContactID": {
+                "type": "string",
+                "description": "Contact ID (GUID)"
+              },
+              "Name": {
+                "type": "string",
+                "description": "Contact name"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "description": "Array of line items for the purchase order",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Description": {
+                  "type": "string",
+                  "description": "Line item description"
+                },
+                "Quantity": {
+                  "type": "number",
+                  "description": "Quantity"
+                },
+                "UnitAmount": {
+                  "type": "number",
+                  "description": "Unit amount/price"
+                },
+                "AccountCode": {
+                  "type": "string",
+                  "description": "Account code for the line item"
+                },
+                "TaxType": {
+                  "type": "string",
+                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                }
+              },
+              "required": [
+                "Description",
+                "UnitAmount",
+                "AccountCode"
+              ]
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Purchase order date (YYYY-MM-DD). Defaults to today if not specified"
+          },
+          "delivery_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Expected delivery date (YYYY-MM-DD)"
+          },
+          "purchase_order_number": {
+            "type": "string",
+            "description": "Custom purchase order number"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Purchase order reference"
+          },
+          "currency_code": {
+            "type": "string",
+            "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED",
+              "BILLED",
+              "DELETED"
+            ],
+            "description": "Purchase order status. Defaults to DRAFT"
+          },
+          "line_amount_types": {
+            "type": "string",
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
+            "description": "Line amount types for tax calculation"
+          },
+          "delivery_address": {
+            "type": "string",
+            "description": "Delivery address"
+          },
+          "attention_to": {
+            "type": "string",
+            "description": "Name of person to be contacted"
+          },
+          "telephone": {
+            "type": "string",
+            "description": "Phone number for contact"
+          },
+          "delivery_instructions": {
+            "type": "string",
+            "description": "Delivery instructions"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "contact",
+          "line_items"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "PurchaseOrders": {
+            "type": "array",
+            "description": "Array containing the created purchase order with full details"
+          }
+        },
+        "description": "Raw Xero API response for created purchase order"
+      }
+    },
+    "update_purchase_order": {
+      "display_name": "Update Purchase Order",
+      "description": "Updates an existing purchase order in Xero. Only DRAFT and SUBMITTED purchase orders can be updated",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "purchase_order_id": {
+            "type": "string",
+            "description": "ID of the purchase order to update (GUID)"
+          },
+          "contact": {
+            "type": "object",
+            "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+            "properties": {
+              "ContactID": {
+                "type": "string",
+                "description": "Contact ID (GUID)"
+              },
+              "Name": {
+                "type": "string",
+                "description": "Contact name"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating purchase orders: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "LineItemID": {
+                  "type": "string",
+                  "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+                },
+                "Description": {
+                  "type": "string",
+                  "description": "Line item description"
+                },
+                "Quantity": {
+                  "type": "number",
+                  "description": "Quantity"
+                },
+                "UnitAmount": {
+                  "type": "number",
+                  "description": "Unit amount/price"
+                },
+                "AccountCode": {
+                  "type": "string",
+                  "description": "Account code for the line item"
+                },
+                "TaxType": {
+                  "type": "string",
+                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                }
+              },
+              "required": [
+                "Description",
+                "UnitAmount",
+                "AccountCode"
+              ]
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Purchase order date (YYYY-MM-DD)"
+          },
+          "delivery_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Expected delivery date (YYYY-MM-DD)"
+          },
+          "purchase_order_number": {
+            "type": "string",
+            "description": "Custom purchase order number"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Purchase order reference"
+          },
+          "currency_code": {
+            "type": "string",
+            "description": "Currency code (e.g., USD, EUR)"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED",
+              "BILLED",
+              "DELETED"
+            ],
+            "description": "Purchase order status"
+          },
+          "line_amount_types": {
+            "type": "string",
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
+            "description": "Line amount types for tax calculation"
+          },
+          "delivery_address": {
+            "type": "string",
+            "description": "Delivery address"
+          },
+          "attention_to": {
+            "type": "string",
+            "description": "Name of person to be contacted"
+          },
+          "telephone": {
+            "type": "string",
+            "description": "Phone number for contact"
+          },
+          "delivery_instructions": {
+            "type": "string",
+            "description": "Delivery instructions"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "purchase_order_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "PurchaseOrders": {
+            "type": "array",
+            "description": "Array containing the updated purchase order with full details"
+          }
+        },
+        "description": "Raw Xero API response for updated purchase order"
+      }
+    },
+    "delete_purchase_order": {
+      "display_name": "Delete Purchase Order",
+      "description": "Deletes a purchase order in Xero by updating its status to DELETED",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "purchase_order_id": {
+            "type": "string",
+            "description": "ID of the purchase order to delete (GUID)"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "purchase_order_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "PurchaseOrders": {
+            "type": "array",
+            "description": "Array containing the deleted purchase order with updated status"
+          }
+        },
+        "description": "Raw Xero API response for deleted purchase order"
+      }
+    },
+    "get_purchase_order_history": {
+      "display_name": "Get Purchase Order History",
+      "description": "Retrieves the history and notes for a specific purchase order from Xero API",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "purchase_order_id": {
+            "type": "string",
+            "description": "ID of the purchase order to get history for (GUID)"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "purchase_order_id"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "HistoryRecords": {
+            "type": "array",
+            "description": "Array of history records including notes and changes"
+          }
+        },
+        "description": "Raw Xero API response for purchase order history"
+      }
+    },
+    "add_note_to_purchase_order": {
+      "display_name": "Add Note to Purchase Order",
+      "description": "Adds a note to a purchase order's history in Xero",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "description": "Xero tenant ID"
+          },
+          "purchase_order_id": {
+            "type": "string",
+            "description": "ID of the purchase order to add note to (GUID)"
+          },
+          "note": {
+            "type": "string",
+            "description": "The note text to add to the purchase order history"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "purchase_order_id",
+          "note"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "HistoryRecords": {
+            "type": "array",
+            "description": "Array containing the added history record"
+          }
+        },
+        "description": "Raw Xero API response for added note"
+      }
+    }
+  },
+  "display_name": "Xero"
 }

--- a/xero/config.json
+++ b/xero/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Xero",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Xero accounting integration for invoice and bill management, purchase orders, reporting, file attachments, and PDF invoice retrieval",
     "entry_point": "xero.py",
     "supports_connected_account": true,
@@ -1472,7 +1472,7 @@
                     },
                     "endpoint": {
                         "type": "string",
-                        "description": "The endpoint type (e.g., 'Invoices', 'Bills', 'BankTransactions')",
+                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
                         "enum": [
                             "Invoices",
                             "Bills",
@@ -1513,7 +1513,7 @@
                     },
                     "endpoint": {
                         "type": "string",
-                        "description": "The endpoint type (e.g., 'Invoices', 'Bills', 'BankTransactions')",
+                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
                         "enum": [
                             "Invoices",
                             "Bills",

--- a/xero/config.json
+++ b/xero/config.json
@@ -1,2002 +1,2002 @@
 {
-  "name": "Xero",
-  "version": "1.5.0",
-  "description": "Xero accounting integration for invoice and bill management, purchase orders, reporting, file attachments, and PDF invoice retrieval",
-  "entry_point": "xero.py",
-  "supports_connected_account": true,
-  "auth": {
-    "type": "platform",
-    "provider": "Xero",
-    "scopes": [
-      "accounting.reports.read",
-      "accounting.contacts.read",
-      "accounting.settings.read",
-      "accounting.transactions.read",
-      "accounting.transactions",
-      "accounting.attachments",
-      "offline_access"
-    ]
-  },
-  "actions": {
-    "get_available_connections": {
-      "display_name": "Get Available Connections",
-      "description": "Gets all available Xero tenant connections and returns company names with tenant IDs",
-      "input_schema": {
-        "type": "object",
-        "properties": {},
-        "required": []
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "description": "Whether the request was successful"
-          },
-          "companies": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "tenant_id": {
-                  "type": "string",
-                  "description": "Xero tenant ID"
-                },
-                "company_name": {
-                  "type": "string",
-                  "description": "Xero tenant/company name"
-                }
-              },
-              "required": [
-                "tenant_id",
-                "company_name"
-              ]
-            }
-          },
-          "message": {
-            "type": "string",
-            "description": "Error message if success is false"
-          }
-        },
-        "required": [
-          "success",
-          "companies"
+    "name": "Xero",
+    "version": "1.5.0",
+    "description": "Xero accounting integration for invoice and bill management, purchase orders, reporting, file attachments, and PDF invoice retrieval",
+    "entry_point": "xero.py",
+    "supports_connected_account": true,
+    "auth": {
+        "type": "platform",
+        "provider": "Xero",
+        "scopes": [
+            "accounting.reports.read",
+            "accounting.contacts.read",
+            "accounting.settings.read",
+            "accounting.transactions.read",
+            "accounting.transactions",
+            "accounting.attachments",
+            "offline_access"
         ]
-      }
     },
-    "find_contact_by_name": {
-      "display_name": "Find Contact by Name",
-      "description": "Finds contacts with matching name in Xero and returns comprehensive contact details including email, phone, address, and other information",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "contact_name": {
-            "type": "string",
-            "description": "Contact/organization name to search for (will match against Name field)"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "contact_name"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "contacts": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "contact_id": {
-                  "type": "string",
-                  "description": "Contact ID (GUID)"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Contact name from Name field"
-                },
-                "contact_number": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Contact number"
-                },
-                "account_number": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Account number"
-                },
-                "contact_status": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Contact status"
-                },
-                "first_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "First name"
-                },
-                "last_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Last name"
-                },
-                "email_address": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Email address"
-                },
-                "skype_user_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Skype username"
-                },
-                "bank_account_details": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Bank account details"
-                },
-                "tax_number": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Tax number"
-                },
-                "accounts_receivable_tax_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Accounts receivable tax type"
-                },
-                "accounts_payable_tax_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Accounts payable tax type"
-                },
-                "addresses": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Array of contact addresses"
-                },
-                "phones": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Array of contact phone numbers"
-                },
-                "updated_date_utc": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Last updated date in UTC"
-                },
-                "contact_groups": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Array of contact groups"
-                },
-                "website": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Website URL"
-                },
-                "branding_theme": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "description": "Branding theme information"
-                },
-                "batch_payments": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "description": "Batch payment information"
-                },
-                "discount": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Discount percentage"
-                },
-                "balances": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "description": "Account balances"
-                },
-                "attachments": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Array of attachments"
-                },
-                "has_attachments": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "description": "Whether contact has attachments"
-                },
-                "contact_persons": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Array of contact persons"
-                }
-              },
-              "required": [
-                "contact_id",
-                "name"
-              ]
-            }
-          }
-        },
-        "required": [
-          "contacts"
-        ]
-      }
-    },
-    "get_aged_payables": {
-      "display_name": "Get Aged Payables",
-      "description": "Retrieves aged payables report from Xero for a specific contact",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "contact_id": {
-            "type": "string",
-            "description": "Contact ID (GUID) for which to retrieve aged payables"
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "contact_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "reports": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "report_id": {
-                  "type": "string",
-                  "description": "Report identifier"
-                },
-                "report_name": {
-                  "type": "string",
-                  "description": "Report name"
-                },
-                "report_date": {
-                  "type": "string",
-                  "description": "Report date"
-                },
-                "rows": {
-                  "type": "array",
-                  "description": "Report data rows"
-                }
-              }
-            }
-          }
-        },
-        "description": "Raw Xero API response for Aged Payables report"
-      }
-    },
-    "get_aged_receivables": {
-      "display_name": "Get Aged Receivables",
-      "description": "Retrieves aged receivables report from Xero for a specific contact",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "contact_id": {
-            "type": "string",
-            "description": "Contact ID (GUID) for which to retrieve aged receivables"
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "contact_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "reports": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "report_id": {
-                  "type": "string",
-                  "description": "Report identifier"
-                },
-                "report_name": {
-                  "type": "string",
-                  "description": "Report name"
-                },
-                "report_date": {
-                  "type": "string",
-                  "description": "Report date"
-                },
-                "rows": {
-                  "type": "array",
-                  "description": "Report data rows"
-                }
-              }
-            }
-          }
-        },
-        "description": "Raw Xero API response for Aged Receivables report"
-      }
-    },
-    "get_balance_sheet": {
-      "display_name": "Get Balance Sheet",
-      "description": "Retrieves balance sheet report from Xero",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-          },
-          "periods": {
-            "type": "integer",
-            "description": "Number of periods to compare (optional)",
-            "minimum": 1,
-            "maximum": 12
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "reports": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "report_id": {
-                  "type": "string",
-                  "description": "Report identifier"
-                },
-                "report_name": {
-                  "type": "string",
-                  "description": "Report name"
-                },
-                "report_date": {
-                  "type": "string",
-                  "description": "Report date"
-                },
-                "rows": {
-                  "type": "array",
-                  "description": "Report data rows"
-                }
-              }
-            }
-          }
-        },
-        "description": "Raw Xero API response for Balance Sheet report"
-      }
-    },
-    "get_profit_and_loss": {
-      "display_name": "Get Profit and Loss",
-      "description": "Retrieves profit and loss statement from Xero",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
-          },
-          "from_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Start date for the report period (YYYY-MM-DD)"
-          },
-          "to_date": {
-            "type": "string",
-            "format": "date",
-            "description": "End date for the report period (YYYY-MM-DD)"
-          },
-          "timeframe": {
-            "type": "string",
-            "enum": [
-              "MONTH",
-              "QUARTER",
-              "YEAR"
-            ],
-            "description": "Timeframe for period comparisons (optional)"
-          },
-          "periods": {
-            "type": "integer",
-            "description": "Number of periods to compare (optional)",
-            "minimum": 1,
-            "maximum": 12
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "reports": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "report_id": {
-                  "type": "string",
-                  "description": "Report identifier"
-                },
-                "report_name": {
-                  "type": "string",
-                  "description": "Report name"
-                },
-                "report_date": {
-                  "type": "string",
-                  "description": "Report date"
-                },
-                "rows": {
-                  "type": "array",
-                  "description": "Report data rows"
-                }
-              }
-            }
-          }
-        },
-        "description": "Raw Xero API response for Profit and Loss statement"
-      }
-    },
-    "get_trial_balance": {
-      "display_name": "Get Trial Balance",
-      "description": "Retrieves trial balance report from Xero",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Report date (YYYY-MM-DD). Defaults to last date of last calendar month if not specified"
-          },
-          "payments_only": {
-            "type": "boolean",
-            "description": "Whether to include only payments (optional, defaults to false)"
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "reports": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "report_id": {
-                  "type": "string",
-                  "description": "Report identifier"
-                },
-                "report_name": {
-                  "type": "string",
-                  "description": "Report name"
-                },
-                "report_date": {
-                  "type": "string",
-                  "description": "Report date"
-                },
-                "rows": {
-                  "type": "array",
-                  "description": "Report data rows"
-                }
-              }
-            }
-          }
-        },
-        "description": "Raw Xero API response for Trial Balance report"
-      }
-    },
-    "get_accounts": {
-      "display_name": "Get Accounts",
-      "description": "Retrieves accounts from Xero to classify line items (revenue, expenses, fixed assets, loans, equity/dividends, GST)",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "where": {
-            "type": "string",
-            "description": "Optional Xero where filter clause. Filter by any element using Xero syntax. Examples: Status=\"ACTIVE\", Type=\"REVENUE\", Code>=\"4000\". Use range operators (>, >=, <, <=) and combine with AND/OR operators."
-          },
-          "order": {
-            "type": "string",
-            "description": "Optional Xero orderby parameter. Order by any element returned. Examples: \"Code ASC\", \"Name DESC\", \"Type ASC\". Multi-field sorting: \"Type ASC, Code ASC\". Note: Some fields are optimized for better performance."
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "accounts": {
-            "type": "array",
-            "description": "Array of Xero accounts"
-          }
-        },
-        "description": "Raw Xero API response for Accounts"
-      }
-    },
-    "get_payments": {
-      "display_name": "Get Payments",
-      "description": "Retrieves payments from Xero for cash on invoices/bills (customer receipts, supplier payments, cash refunds)",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "where": {
-            "type": "string",
-            "description": "Optional Xero where filter clause. Optimized fields include PaymentType, Status, Date, Invoice.InvoiceId, Reference. Examples: PaymentType=\"ACCRECPAYMENT\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Reference=\"INV-0001\". Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
-          },
-          "order": {
-            "type": "string",
-            "description": "Optional Xero orderby parameter. Optimized fields for ordering: UpdatedDateUTC, Date, PaymentId. Examples: \"UpdatedDateUTC ASC\", \"Date DESC\", \"PaymentId ASC\". Multi-field sorting: \"Date DESC, PaymentId ASC\". Default order is UpdatedDateUTC ASC, PaymentId ASC."
-          },
-          "page": {
-            "type": "integer",
-            "description": "Optional page number for pagination. Default is 100 payments per page when used alone."
-          },
-          "pageSize": {
-            "type": "integer",
-            "description": "Optional page size for pagination (1-1000). Used with page parameter. Examples: page=1&pageSize=250."
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "payments": {
-            "type": "array",
-            "description": "Array of Xero payments"
-          }
-        },
-        "description": "Raw Xero API response for Payments"
-      }
-    },
-    "get_invoices": {
-      "display_name": "Get Invoices",
-      "description": "Retrieves invoices from Xero API with optimized filtering. Can fetch all invoices or a specific invoice by ID. Supports sales invoices (ACCREC) and purchase invoices (ACCPAY)",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "invoice_id": {
-            "type": "string",
-            "description": "Optional specific invoice ID (GUID) to fetch. When provided, fetches only this invoice and ignores other filter parameters"
-          },
-          "where": {
-            "type": "string",
-            "description": "Optional Xero where filter clause with optimized fields. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01) AND Date<=DateTime(2020,12,31), Contact.ContactID==guid(\"contact-id\"), Type==\"ACCREC\", Total>=100.00 AND Total<=1000.00. Combine with AND/OR operators."
-          },
-          "order": {
-            "type": "string",
-            "description": "Optional Xero orderby parameter. Optimized fields: InvoiceNumber, Date, DueDate, Total, UpdatedDateUTC. Examples: \"Date DESC\", \"InvoiceNumber ASC\", \"Total DESC,Date ASC\". Multi-field sorting supported."
-          },
-          "page": {
-            "type": "integer",
-            "description": "Optional page number for pagination"
-          },
-          "pageSize": {
-            "type": "integer",
-            "description": "Optional page size for pagination (max 100)"
-          },
-          "statuses": {
-            "type": "string",
-            "description": "Optional comma-separated list of invoice statuses for bulk filtering. Examples: \"DRAFT,SUBMITTED,AUTHORISED\", \"VOIDED,DELETED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, PAID, VOIDED, DELETED"
-          },
-          "invoice_numbers": {
-            "type": "string",
-            "description": "Optional comma-separated list of invoice numbers for bulk retrieval by invoice number"
-          },
-          "contact_ids": {
-            "type": "string",
-            "description": "Optional comma-separated list of contact IDs (GUIDs) to filter invoices by specific contacts"
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "invoices": {
-            "type": "array",
-            "description": "Array of Xero invoices with details including invoice number, date, due date, contact, line items, amounts, and status"
-          }
-        },
-        "description": "Raw Xero API response for Invoices"
-      }
-    },
-    "get_invoice_pdf": {
-      "display_name": "Get Invoice PDF",
-      "description": "Retrieves a specific invoice as a PDF file from Xero API. Works with both sales invoices (ACCREC) and purchase bills (ACCPAY)",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "invoice_id": {
-            "type": "string",
-            "description": "Invoice ID (GUID) to retrieve as PDF. Example: 97c2dc5-cc47-4afd-8ec8-74990b8761e9"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "invoice_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "file": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "File name of the PDF"
-              },
-              "content": {
-                "type": "string",
-                "description": "Base64 encoded PDF content"
-              },
-              "contentType": {
-                "type": "string",
-                "description": "MIME type of the file (application/pdf)"
-              }
+    "actions": {
+        "get_available_connections": {
+            "display_name": "Get Available Connections",
+            "description": "Gets all available Xero tenant connections and returns company names with tenant IDs",
+            "input_schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
             },
-            "required": [
-              "name",
-              "content",
-              "contentType"
-            ]
-          },
-          "success": {
-            "type": "boolean",
-            "description": "Whether the PDF download was successful"
-          },
-          "error": {
-            "type": "string",
-            "description": "Error message if download failed"
-          }
-        },
-        "required": [
-          "file",
-          "success"
-        ]
-      }
-    },
-    "get_bank_transactions": {
-      "display_name": "Get Bank Transactions",
-      "description": "Retrieves bank transactions from Xero for Receive/Spend Money not tied to invoices (CapEx, financing, other operating)",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "where": {
-            "type": "string",
-            "description": "Optional Xero where filter clause. Optimized fields include Type, Status, Date, Contact.ContactID. Examples: Type=\"RECEIVE\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID=guid(\"96988e67-ecf9-466d-bfbf-0afa1725a649\"). Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
-          },
-          "order": {
-            "type": "string",
-            "description": "Optional Xero orderby parameter. Optimized fields for ordering: BankTransactionID, UpdatedDateUTC, Date. Examples: \"Date ASC\", \"UpdatedDateUTC DESC\", \"BankTransactionID ASC\". Multi-field sorting: \"Date DESC, BankTransactionID ASC\". Default order is UpdatedDateUTC ASC, BankTransactionID ASC."
-          },
-          "page": {
-            "type": "integer",
-            "description": "Optional page number for pagination"
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "bank_transactions": {
-            "type": "array",
-            "description": "Array of Xero bank transactions"
-          }
-        },
-        "description": "Raw Xero API response for Bank Transactions"
-      }
-    },
-    "create_sales_invoice": {
-      "display_name": "Create Sales Invoice",
-      "description": "Creates a new sales invoice (ACCREC) in Xero for billing customers",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "contact": {
-            "type": "object",
-            "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
-            "properties": {
-              "ContactID": {
-                "type": "string",
-                "description": "Contact ID (GUID)"
-              },
-              "Name": {
-                "type": "string",
-                "description": "Contact name"
-              }
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "description": "Whether the request was successful"
+                    },
+                    "companies": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "tenant_id": {
+                                    "type": "string",
+                                    "description": "Xero tenant ID"
+                                },
+                                "company_name": {
+                                    "type": "string",
+                                    "description": "Xero tenant/company name"
+                                }
+                            },
+                            "required": [
+                                "tenant_id",
+                                "company_name"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Error message if success is false"
+                    }
+                },
+                "required": [
+                    "success",
+                    "companies"
+                ]
             }
-          },
-          "line_items": {
-            "type": "array",
-            "description": "Array of line items for the invoice",
-            "items": {
-              "type": "object",
-              "properties": {
-                "Description": {
-                  "type": "string",
-                  "description": "Line item description"
-                },
-                "Quantity": {
-                  "type": "number",
-                  "description": "Quantity"
-                },
-                "UnitAmount": {
-                  "type": "number",
-                  "description": "Unit amount/price"
-                },
-                "AccountCode": {
-                  "type": "string",
-                  "description": "Account code for the line item"
-                },
-                "TaxType": {
-                  "type": "string",
-                  "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
-                }
-              },
-              "required": [
-                "Description",
-                "UnitAmount",
-                "AccountCode"
-              ]
-            }
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Invoice date (YYYY-MM-DD). Defaults to today if not specified"
-          },
-          "due_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Due date for payment (YYYY-MM-DD)"
-          },
-          "invoice_number": {
-            "type": "string",
-            "description": "Custom invoice number"
-          },
-          "reference": {
-            "type": "string",
-            "description": "Invoice reference"
-          },
-          "branding_theme_id": {
-            "type": "string",
-            "description": "Branding theme ID (GUID)"
-          },
-          "currency_code": {
-            "type": "string",
-            "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "SUBMITTED",
-              "AUTHORISED"
-            ],
-            "description": "Invoice status. Defaults to DRAFT"
-          },
-          "line_amount_types": {
-            "type": "string",
-            "enum": [
-              "Exclusive",
-              "Inclusive",
-              "NoTax"
-            ],
-            "description": "Line amount types for tax calculation"
-          }
         },
-        "required": [
-          "tenant_id",
-          "contact",
-          "line_items"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Invoices": {
-            "type": "array",
-            "description": "Array containing the created invoice with full details"
-          }
-        },
-        "description": "Raw Xero API response for created sales invoice"
-      }
-    },
-    "create_purchase_bill": {
-      "display_name": "Create Purchase Bill",
-      "description": "Creates a new purchase bill (ACCPAY) in Xero for recording supplier invoices",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "contact": {
-            "type": "object",
-            "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-            "properties": {
-              "ContactID": {
-                "type": "string",
-                "description": "Contact ID (GUID)"
-              },
-              "Name": {
-                "type": "string",
-                "description": "Contact name"
-              }
-            }
-          },
-          "line_items": {
-            "type": "array",
-            "description": "Array of line items for the bill",
-            "items": {
-              "type": "object",
-              "properties": {
-                "Description": {
-                  "type": "string",
-                  "description": "Line item description"
+        "find_contact_by_name": {
+            "display_name": "Find Contact by Name",
+            "description": "Finds contacts with matching name in Xero and returns comprehensive contact details including email, phone, address, and other information",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "contact_name": {
+                        "type": "string",
+                        "description": "Contact/organization name to search for (will match against Name field)"
+                    }
                 },
-                "Quantity": {
-                  "type": "number",
-                  "description": "Quantity"
-                },
-                "UnitAmount": {
-                  "type": "number",
-                  "description": "Unit amount/price"
-                },
-                "AccountCode": {
-                  "type": "string",
-                  "description": "Account code for the line item"
-                },
-                "TaxType": {
-                  "type": "string",
-                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                }
-              },
-              "required": [
-                "Description",
-                "UnitAmount",
-                "AccountCode"
-              ]
-            }
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Bill date (YYYY-MM-DD). Defaults to today if not specified"
-          },
-          "due_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Due date for payment (YYYY-MM-DD)"
-          },
-          "invoice_number": {
-            "type": "string",
-            "description": "Supplier's invoice/bill number"
-          },
-          "reference": {
-            "type": "string",
-            "description": "Bill reference"
-          },
-          "currency_code": {
-            "type": "string",
-            "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "SUBMITTED",
-              "AUTHORISED"
-            ],
-            "description": "Bill status. Defaults to DRAFT"
-          },
-          "line_amount_types": {
-            "type": "string",
-            "enum": [
-              "Exclusive",
-              "Inclusive",
-              "NoTax"
-            ],
-            "description": "Line amount types for tax calculation"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "contact",
-          "line_items"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Invoices": {
-            "type": "array",
-            "description": "Array containing the created purchase bill with full details"
-          }
-        },
-        "description": "Raw Xero API response for created purchase bill"
-      }
-    },
-    "update_sales_invoice": {
-      "display_name": "Update Sales Invoice",
-      "description": "Updates an existing sales invoice (ACCREC) in Xero. Only DRAFT and SUBMITTED invoices can be updated",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "invoice_id": {
-            "type": "string",
-            "description": "ID of the invoice to update (GUID)"
-          },
-          "contact": {
-            "type": "object",
-            "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
-            "properties": {
-              "ContactID": {
-                "type": "string",
-                "description": "Contact ID (GUID)"
-              },
-              "Name": {
-                "type": "string",
-                "description": "Contact name"
-              }
-            }
-          },
-          "line_items": {
-            "type": "array",
-            "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating invoices: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "LineItemID": {
-                  "type": "string",
-                  "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
-                },
-                "Description": {
-                  "type": "string",
-                  "description": "Line item description"
-                },
-                "Quantity": {
-                  "type": "number",
-                  "description": "Quantity"
-                },
-                "UnitAmount": {
-                  "type": "number",
-                  "description": "Unit amount/price"
-                },
-                "AccountCode": {
-                  "type": "string",
-                  "description": "Account code for the line item"
-                },
-                "TaxType": {
-                  "type": "string",
-                  "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
-                }
-              },
-              "required": [
-                "Description",
-                "UnitAmount",
-                "AccountCode"
-              ]
-            }
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Invoice date (YYYY-MM-DD)"
-          },
-          "due_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Due date for payment (YYYY-MM-DD)"
-          },
-          "invoice_number": {
-            "type": "string",
-            "description": "Custom invoice number"
-          },
-          "reference": {
-            "type": "string",
-            "description": "Invoice reference"
-          },
-          "branding_theme_id": {
-            "type": "string",
-            "description": "Branding theme ID (GUID)"
-          },
-          "currency_code": {
-            "type": "string",
-            "description": "Currency code (e.g., USD, EUR)"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "SUBMITTED",
-              "AUTHORISED"
-            ],
-            "description": "Invoice status"
-          },
-          "line_amount_types": {
-            "type": "string",
-            "enum": [
-              "Exclusive",
-              "Inclusive",
-              "NoTax"
-            ],
-            "description": "Line amount types for tax calculation"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "invoice_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Invoices": {
-            "type": "array",
-            "description": "Array containing the updated invoice with full details"
-          }
-        },
-        "description": "Raw Xero API response for updated sales invoice"
-      }
-    },
-    "update_purchase_bill": {
-      "display_name": "Update Purchase Bill",
-      "description": "Updates an existing purchase bill (ACCPAY) in Xero. Only DRAFT and SUBMITTED bills can be updated",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "invoice_id": {
-            "type": "string",
-            "description": "ID of the bill to update (GUID) - bills use InvoiceID in Xero API"
-          },
-          "contact": {
-            "type": "object",
-            "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-            "properties": {
-              "ContactID": {
-                "type": "string",
-                "description": "Contact ID (GUID)"
-              },
-              "Name": {
-                "type": "string",
-                "description": "Contact name"
-              }
-            }
-          },
-          "line_items": {
-            "type": "array",
-            "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating bills: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "LineItemID": {
-                  "type": "string",
-                  "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
-                },
-                "Description": {
-                  "type": "string",
-                  "description": "Line item description"
-                },
-                "Quantity": {
-                  "type": "number",
-                  "description": "Quantity"
-                },
-                "UnitAmount": {
-                  "type": "number",
-                  "description": "Unit amount/price"
-                },
-                "AccountCode": {
-                  "type": "string",
-                  "description": "Account code for the line item"
-                },
-                "TaxType": {
-                  "type": "string",
-                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                }
-              },
-              "required": [
-                "Description",
-                "UnitAmount",
-                "AccountCode"
-              ]
-            }
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Bill date (YYYY-MM-DD)"
-          },
-          "due_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Due date for payment (YYYY-MM-DD)"
-          },
-          "invoice_number": {
-            "type": "string",
-            "description": "Supplier's invoice/bill number"
-          },
-          "reference": {
-            "type": "string",
-            "description": "Bill reference"
-          },
-          "currency_code": {
-            "type": "string",
-            "description": "Currency code (e.g., USD, EUR)"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "SUBMITTED",
-              "AUTHORISED"
-            ],
-            "description": "Bill status"
-          },
-          "line_amount_types": {
-            "type": "string",
-            "enum": [
-              "Exclusive",
-              "Inclusive",
-              "NoTax"
-            ],
-            "description": "Line amount types for tax calculation"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "invoice_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Invoices": {
-            "type": "array",
-            "description": "Array containing the updated purchase bill with full details"
-          }
-        },
-        "description": "Raw Xero API response for updated purchase bill"
-      }
-    },
-    "attach_file_to_invoice": {
-      "display_name": "Attach File to Invoice",
-      "description": "Attaches a file to an existing sales invoice or purchase bill in Xero",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "invoice_id": {
-            "type": "string",
-            "description": "ID of the invoice/bill to attach file to (GUID)"
-          },
-          "file": {
-            "type": "object",
-            "description": "File object from chat: base64 content, name, contentType.",
-            "properties": {
-              "content": {
-                "type": "string",
-                "description": "Base64 encoded file content"
-              },
-              "name": {
-                "type": "string",
-                "description": "File name including extension"
-              },
-              "contentType": {
-                "type": "string",
-                "description": "MIME type of the file"
-              }
+                "required": [
+                    "tenant_id",
+                    "contact_name"
+                ]
             },
-            "required": [
-              "content",
-              "name",
-              "contentType"
-            ]
-          },
-          "files": {
-            "type": "array",
-            "description": "Alternate input: array of file objects; the first will be used.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "content": {
-                  "type": "string",
-                  "description": "Base64 encoded file content"
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "contacts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "contact_id": {
+                                    "type": "string",
+                                    "description": "Contact ID (GUID)"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Contact name from Name field"
+                                },
+                                "contact_number": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Contact number"
+                                },
+                                "account_number": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Account number"
+                                },
+                                "contact_status": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Contact status"
+                                },
+                                "first_name": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "First name"
+                                },
+                                "last_name": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Last name"
+                                },
+                                "email_address": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Email address"
+                                },
+                                "skype_user_name": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Skype username"
+                                },
+                                "bank_account_details": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Bank account details"
+                                },
+                                "tax_number": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Tax number"
+                                },
+                                "accounts_receivable_tax_type": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Accounts receivable tax type"
+                                },
+                                "accounts_payable_tax_type": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Accounts payable tax type"
+                                },
+                                "addresses": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "description": "Array of contact addresses"
+                                },
+                                "phones": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "description": "Array of contact phone numbers"
+                                },
+                                "updated_date_utc": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Last updated date in UTC"
+                                },
+                                "contact_groups": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "description": "Array of contact groups"
+                                },
+                                "website": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Website URL"
+                                },
+                                "branding_theme": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "description": "Branding theme information"
+                                },
+                                "batch_payments": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "description": "Batch payment information"
+                                },
+                                "discount": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ],
+                                    "description": "Discount percentage"
+                                },
+                                "balances": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "description": "Account balances"
+                                },
+                                "attachments": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "description": "Array of attachments"
+                                },
+                                "has_attachments": {
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "description": "Whether contact has attachments"
+                                },
+                                "contact_persons": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "description": "Array of contact persons"
+                                }
+                            },
+                            "required": [
+                                "contact_id",
+                                "name"
+                            ]
+                        }
+                    }
                 },
-                "name": {
-                  "type": "string",
-                  "description": "File name including extension"
-                },
-                "contentType": {
-                  "type": "string",
-                  "description": "MIME type of the file"
-                }
-              },
-              "required": [
-                "content",
-                "name",
-                "contentType"
-              ]
+                "required": [
+                    "contacts"
+                ]
             }
-          },
-          "include_online": {
-            "type": "boolean",
-            "description": "Whether to include the attachment in online invoice (default: true)"
-          }
         },
-        "required": [
-          "tenant_id",
-          "invoice_id",
-          "file"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Attachments": {
-            "type": "array",
-            "description": "Array containing the attachment details"
-          }
-        },
-        "description": "Raw Xero API response for file attachment"
-      }
-    },
-    "attach_file_to_bill": {
-      "display_name": "Attach File to Bill",
-      "description": "Attaches a file to an existing purchase bill in Xero",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "bill_id": {
-            "type": "string",
-            "description": "ID of the bill to attach file to (GUID) - same as invoice_id in Xero API"
-          },
-          "file": {
-            "type": "object",
-            "description": "File object from chat: base64 content, name, contentType.",
-            "properties": {
-              "content": {
-                "type": "string",
-                "description": "Base64 encoded file content"
-              },
-              "name": {
-                "type": "string",
-                "description": "File name including extension"
-              },
-              "contentType": {
-                "type": "string",
-                "description": "MIME type of the file"
-              }
+        "get_aged_payables": {
+            "display_name": "Get Aged Payables",
+            "description": "Retrieves aged payables report from Xero for a specific contact",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "contact_id": {
+                        "type": "string",
+                        "description": "Contact ID (GUID) for which to retrieve aged payables"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "contact_id"
+                ]
             },
-            "required": [
-              "content",
-              "name",
-              "contentType"
-            ]
-          },
-          "files": {
-            "type": "array",
-            "description": "Alternate input: array of file objects; the first will be used.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "content": {
-                  "type": "string",
-                  "description": "Base64 encoded file content"
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "reports": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "report_id": {
+                                    "type": "string",
+                                    "description": "Report identifier"
+                                },
+                                "report_name": {
+                                    "type": "string",
+                                    "description": "Report name"
+                                },
+                                "report_date": {
+                                    "type": "string",
+                                    "description": "Report date"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "description": "Report data rows"
+                                }
+                            }
+                        }
+                    }
                 },
-                "name": {
-                  "type": "string",
-                  "description": "File name including extension"
-                },
-                "contentType": {
-                  "type": "string",
-                  "description": "MIME type of the file"
-                }
-              },
-              "required": [
-                "content",
-                "name",
-                "contentType"
-              ]
+                "description": "Raw Xero API response for Aged Payables report"
             }
-          },
-          "include_online": {
-            "type": "boolean",
-            "description": "Whether to include the attachment in online bill (default: true)"
-          }
         },
-        "required": [
-          "tenant_id",
-          "bill_id",
-          "file"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Attachments": {
-            "type": "array",
-            "description": "Array containing the attachment details"
-          }
-        },
-        "description": "Raw Xero API response for file attachment"
-      }
-    },
-    "get_attachments": {
-      "display_name": "Get Attachments",
-      "description": "Gets all attachments for a specific invoice, bill, or bank transaction from Xero API",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "endpoint": {
-            "type": "string",
-            "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
-            "enum": [
-              "Invoices",
-              "Bills",
-              "BankTransactions"
-            ]
-          },
-          "guid": {
-            "type": "string",
-            "description": "The GUID of the invoice/bill/transaction"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "endpoint",
-          "guid"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "Attachments": {
-            "type": "array",
-            "description": "Array of attachment metadata including file names, IDs, sizes, and MIME types"
-          }
-        },
-        "description": "Raw Xero API response for attachments list"
-      }
-    },
-    "get_attachment_content": {
-      "display_name": "Get Attachment Content",
-      "description": "Downloads the actual content of a specific attachment from Xero API for agent analysis",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "endpoint": {
-            "type": "string",
-            "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
-            "enum": [
-              "Invoices",
-              "Bills",
-              "BankTransactions"
-            ]
-          },
-          "guid": {
-            "type": "string",
-            "description": "The GUID of the invoice/bill/transaction"
-          },
-          "file_name": {
-            "type": "string",
-            "description": "The filename of the attachment to download"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "endpoint",
-          "guid",
-          "file_name"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "file": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "File name"
-              },
-              "content": {
-                "type": "string",
-                "description": "Base64 encoded file content for agent analysis"
-              },
-              "contentType": {
-                "type": "string",
-                "description": "MIME type of the file"
-              }
+        "get_aged_receivables": {
+            "display_name": "Get Aged Receivables",
+            "description": "Retrieves aged receivables report from Xero for a specific contact",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "contact_id": {
+                        "type": "string",
+                        "description": "Contact ID (GUID) for which to retrieve aged receivables"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "contact_id"
+                ]
             },
-            "required": [
-              "name",
-              "content",
-              "contentType"
-            ]
-          },
-          "success": {
-            "type": "boolean",
-            "description": "Whether the download was successful"
-          },
-          "error": {
-            "type": "string",
-            "description": "Error message if download failed"
-          }
-        },
-        "required": [
-          "file",
-          "success"
-        ]
-      }
-    },
-    "get_purchase_orders": {
-      "display_name": "Get Purchase Orders",
-      "description": "Retrieves purchase orders from Xero API with filtering. Can fetch all purchase orders or a specific one by ID",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "purchase_order_id": {
-            "type": "string",
-            "description": "Optional specific purchase order ID (GUID) to fetch. When provided, fetches only this purchase order"
-          },
-          "where": {
-            "type": "string",
-            "description": "Optional Xero where filter clause. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID==guid(\"contact-id\"). Combine with AND/OR operators."
-          },
-          "order": {
-            "type": "string",
-            "description": "Optional Xero orderby parameter. Examples: \"Date DESC\", \"PurchaseOrderNumber ASC\". Multi-field sorting supported."
-          },
-          "page": {
-            "type": "integer",
-            "description": "Optional page number for pagination"
-          },
-          "statuses": {
-            "type": "string",
-            "description": "Optional comma-separated list of statuses. Examples: \"DRAFT,SUBMITTED,AUTHORISED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, BILLED, DELETED"
-          }
-        },
-        "required": [
-          "tenant_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "PurchaseOrders": {
-            "type": "array",
-            "description": "Array of Xero purchase orders with details"
-          }
-        },
-        "description": "Raw Xero API response for Purchase Orders"
-      }
-    },
-    "create_purchase_order": {
-      "display_name": "Create Purchase Order",
-      "description": "Creates a new purchase order in Xero for ordering goods or services from suppliers",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "contact": {
-            "type": "object",
-            "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-            "properties": {
-              "ContactID": {
-                "type": "string",
-                "description": "Contact ID (GUID)"
-              },
-              "Name": {
-                "type": "string",
-                "description": "Contact name"
-              }
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "reports": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "report_id": {
+                                    "type": "string",
+                                    "description": "Report identifier"
+                                },
+                                "report_name": {
+                                    "type": "string",
+                                    "description": "Report name"
+                                },
+                                "report_date": {
+                                    "type": "string",
+                                    "description": "Report date"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "description": "Report data rows"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Raw Xero API response for Aged Receivables report"
             }
-          },
-          "line_items": {
-            "type": "array",
-            "description": "Array of line items for the purchase order",
-            "items": {
-              "type": "object",
-              "properties": {
-                "Description": {
-                  "type": "string",
-                  "description": "Line item description"
+        },
+        "get_balance_sheet": {
+            "display_name": "Get Balance Sheet",
+            "description": "Retrieves balance sheet report from Xero",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+                    },
+                    "periods": {
+                        "type": "integer",
+                        "description": "Number of periods to compare (optional)",
+                        "minimum": 1,
+                        "maximum": 12
+                    }
                 },
-                "Quantity": {
-                  "type": "number",
-                  "description": "Quantity"
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "reports": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "report_id": {
+                                    "type": "string",
+                                    "description": "Report identifier"
+                                },
+                                "report_name": {
+                                    "type": "string",
+                                    "description": "Report name"
+                                },
+                                "report_date": {
+                                    "type": "string",
+                                    "description": "Report date"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "description": "Report data rows"
+                                }
+                            }
+                        }
+                    }
                 },
-                "UnitAmount": {
-                  "type": "number",
-                  "description": "Unit amount/price"
-                },
-                "AccountCode": {
-                  "type": "string",
-                  "description": "Account code for the line item"
-                },
-                "TaxType": {
-                  "type": "string",
-                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                }
-              },
-              "required": [
-                "Description",
-                "UnitAmount",
-                "AccountCode"
-              ]
+                "description": "Raw Xero API response for Balance Sheet report"
             }
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Purchase order date (YYYY-MM-DD). Defaults to today if not specified"
-          },
-          "delivery_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Expected delivery date (YYYY-MM-DD)"
-          },
-          "purchase_order_number": {
-            "type": "string",
-            "description": "Custom purchase order number"
-          },
-          "reference": {
-            "type": "string",
-            "description": "Purchase order reference"
-          },
-          "currency_code": {
-            "type": "string",
-            "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "SUBMITTED",
-              "AUTHORISED",
-              "BILLED",
-              "DELETED"
-            ],
-            "description": "Purchase order status. Defaults to DRAFT"
-          },
-          "line_amount_types": {
-            "type": "string",
-            "enum": [
-              "Exclusive",
-              "Inclusive",
-              "NoTax"
-            ],
-            "description": "Line amount types for tax calculation"
-          },
-          "delivery_address": {
-            "type": "string",
-            "description": "Delivery address"
-          },
-          "attention_to": {
-            "type": "string",
-            "description": "Name of person to be contacted"
-          },
-          "telephone": {
-            "type": "string",
-            "description": "Phone number for contact"
-          },
-          "delivery_instructions": {
-            "type": "string",
-            "description": "Delivery instructions"
-          }
         },
-        "required": [
-          "tenant_id",
-          "contact",
-          "line_items"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "PurchaseOrders": {
-            "type": "array",
-            "description": "Array containing the created purchase order with full details"
-          }
-        },
-        "description": "Raw Xero API response for created purchase order"
-      }
-    },
-    "update_purchase_order": {
-      "display_name": "Update Purchase Order",
-      "description": "Updates an existing purchase order in Xero. Only DRAFT and SUBMITTED purchase orders can be updated",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "purchase_order_id": {
-            "type": "string",
-            "description": "ID of the purchase order to update (GUID)"
-          },
-          "contact": {
-            "type": "object",
-            "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
-            "properties": {
-              "ContactID": {
-                "type": "string",
-                "description": "Contact ID (GUID)"
-              },
-              "Name": {
-                "type": "string",
-                "description": "Contact name"
-              }
+        "get_profit_and_loss": {
+            "display_name": "Get Profit and Loss",
+            "description": "Retrieves profit and loss statement from Xero",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Report date (YYYY-MM-DD). Defaults to today if not specified"
+                    },
+                    "from_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Start date for the report period (YYYY-MM-DD)"
+                    },
+                    "to_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "End date for the report period (YYYY-MM-DD)"
+                    },
+                    "timeframe": {
+                        "type": "string",
+                        "enum": [
+                            "MONTH",
+                            "QUARTER",
+                            "YEAR"
+                        ],
+                        "description": "Timeframe for period comparisons (optional)"
+                    },
+                    "periods": {
+                        "type": "integer",
+                        "description": "Number of periods to compare (optional)",
+                        "minimum": 1,
+                        "maximum": 12
+                    }
+                },
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "reports": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "report_id": {
+                                    "type": "string",
+                                    "description": "Report identifier"
+                                },
+                                "report_name": {
+                                    "type": "string",
+                                    "description": "Report name"
+                                },
+                                "report_date": {
+                                    "type": "string",
+                                    "description": "Report date"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "description": "Report data rows"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Raw Xero API response for Profit and Loss statement"
             }
-          },
-          "line_items": {
-            "type": "array",
-            "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating purchase orders: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "LineItemID": {
-                  "type": "string",
-                  "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+        },
+        "get_trial_balance": {
+            "display_name": "Get Trial Balance",
+            "description": "Retrieves trial balance report from Xero",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Report date (YYYY-MM-DD). Defaults to last date of last calendar month if not specified"
+                    },
+                    "payments_only": {
+                        "type": "boolean",
+                        "description": "Whether to include only payments (optional, defaults to false)"
+                    }
                 },
-                "Description": {
-                  "type": "string",
-                  "description": "Line item description"
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "reports": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "report_id": {
+                                    "type": "string",
+                                    "description": "Report identifier"
+                                },
+                                "report_name": {
+                                    "type": "string",
+                                    "description": "Report name"
+                                },
+                                "report_date": {
+                                    "type": "string",
+                                    "description": "Report date"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "description": "Report data rows"
+                                }
+                            }
+                        }
+                    }
                 },
-                "Quantity": {
-                  "type": "number",
-                  "description": "Quantity"
-                },
-                "UnitAmount": {
-                  "type": "number",
-                  "description": "Unit amount/price"
-                },
-                "AccountCode": {
-                  "type": "string",
-                  "description": "Account code for the line item"
-                },
-                "TaxType": {
-                  "type": "string",
-                  "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
-                }
-              },
-              "required": [
-                "Description",
-                "UnitAmount",
-                "AccountCode"
-              ]
+                "description": "Raw Xero API response for Trial Balance report"
             }
-          },
-          "date": {
-            "type": "string",
-            "format": "date",
-            "description": "Purchase order date (YYYY-MM-DD)"
-          },
-          "delivery_date": {
-            "type": "string",
-            "format": "date",
-            "description": "Expected delivery date (YYYY-MM-DD)"
-          },
-          "purchase_order_number": {
-            "type": "string",
-            "description": "Custom purchase order number"
-          },
-          "reference": {
-            "type": "string",
-            "description": "Purchase order reference"
-          },
-          "currency_code": {
-            "type": "string",
-            "description": "Currency code (e.g., USD, EUR)"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "SUBMITTED",
-              "AUTHORISED",
-              "BILLED",
-              "DELETED"
-            ],
-            "description": "Purchase order status"
-          },
-          "line_amount_types": {
-            "type": "string",
-            "enum": [
-              "Exclusive",
-              "Inclusive",
-              "NoTax"
-            ],
-            "description": "Line amount types for tax calculation"
-          },
-          "delivery_address": {
-            "type": "string",
-            "description": "Delivery address"
-          },
-          "attention_to": {
-            "type": "string",
-            "description": "Name of person to be contacted"
-          },
-          "telephone": {
-            "type": "string",
-            "description": "Phone number for contact"
-          },
-          "delivery_instructions": {
-            "type": "string",
-            "description": "Delivery instructions"
-          }
         },
-        "required": [
-          "tenant_id",
-          "purchase_order_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "PurchaseOrders": {
-            "type": "array",
-            "description": "Array containing the updated purchase order with full details"
-          }
+        "get_accounts": {
+            "display_name": "Get Accounts",
+            "description": "Retrieves accounts from Xero to classify line items (revenue, expenses, fixed assets, loans, equity/dividends, GST)",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "where": {
+                        "type": "string",
+                        "description": "Optional Xero where filter clause. Filter by any element using Xero syntax. Examples: Status=\"ACTIVE\", Type=\"REVENUE\", Code>=\"4000\". Use range operators (>, >=, <, <=) and combine with AND/OR operators."
+                    },
+                    "order": {
+                        "type": "string",
+                        "description": "Optional Xero orderby parameter. Order by any element returned. Examples: \"Code ASC\", \"Name DESC\", \"Type ASC\". Multi-field sorting: \"Type ASC, Code ASC\". Note: Some fields are optimized for better performance."
+                    }
+                },
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "accounts": {
+                        "type": "array",
+                        "description": "Array of Xero accounts"
+                    }
+                },
+                "description": "Raw Xero API response for Accounts"
+            }
         },
-        "description": "Raw Xero API response for updated purchase order"
-      }
+        "get_payments": {
+            "display_name": "Get Payments",
+            "description": "Retrieves payments from Xero for cash on invoices/bills (customer receipts, supplier payments, cash refunds)",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "where": {
+                        "type": "string",
+                        "description": "Optional Xero where filter clause. Optimized fields include PaymentType, Status, Date, Invoice.InvoiceId, Reference. Examples: PaymentType=\"ACCRECPAYMENT\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Reference=\"INV-0001\". Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
+                    },
+                    "order": {
+                        "type": "string",
+                        "description": "Optional Xero orderby parameter. Optimized fields for ordering: UpdatedDateUTC, Date, PaymentId. Examples: \"UpdatedDateUTC ASC\", \"Date DESC\", \"PaymentId ASC\". Multi-field sorting: \"Date DESC, PaymentId ASC\". Default order is UpdatedDateUTC ASC, PaymentId ASC."
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Optional page number for pagination. Default is 100 payments per page when used alone."
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "description": "Optional page size for pagination (1-1000). Used with page parameter. Examples: page=1&pageSize=250."
+                    }
+                },
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "payments": {
+                        "type": "array",
+                        "description": "Array of Xero payments"
+                    }
+                },
+                "description": "Raw Xero API response for Payments"
+            }
+        },
+        "get_invoices": {
+            "display_name": "Get Invoices",
+            "description": "Retrieves invoices from Xero API with optimized filtering. Can fetch all invoices or a specific invoice by ID. Supports sales invoices (ACCREC) and purchase invoices (ACCPAY)",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "description": "Optional specific invoice ID (GUID) to fetch. When provided, fetches only this invoice and ignores other filter parameters"
+                    },
+                    "where": {
+                        "type": "string",
+                        "description": "Optional Xero where filter clause with optimized fields. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01) AND Date<=DateTime(2020,12,31), Contact.ContactID==guid(\"contact-id\"), Type==\"ACCREC\", Total>=100.00 AND Total<=1000.00. Combine with AND/OR operators."
+                    },
+                    "order": {
+                        "type": "string",
+                        "description": "Optional Xero orderby parameter. Optimized fields: InvoiceNumber, Date, DueDate, Total, UpdatedDateUTC. Examples: \"Date DESC\", \"InvoiceNumber ASC\", \"Total DESC,Date ASC\". Multi-field sorting supported."
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Optional page number for pagination"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "description": "Optional page size for pagination (max 100)"
+                    },
+                    "statuses": {
+                        "type": "string",
+                        "description": "Optional comma-separated list of invoice statuses for bulk filtering. Examples: \"DRAFT,SUBMITTED,AUTHORISED\", \"VOIDED,DELETED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, PAID, VOIDED, DELETED"
+                    },
+                    "invoice_numbers": {
+                        "type": "string",
+                        "description": "Optional comma-separated list of invoice numbers for bulk retrieval by invoice number"
+                    },
+                    "contact_ids": {
+                        "type": "string",
+                        "description": "Optional comma-separated list of contact IDs (GUIDs) to filter invoices by specific contacts"
+                    }
+                },
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "invoices": {
+                        "type": "array",
+                        "description": "Array of Xero invoices with details including invoice number, date, due date, contact, line items, amounts, and status"
+                    }
+                },
+                "description": "Raw Xero API response for Invoices"
+            }
+        },
+        "get_invoice_pdf": {
+            "display_name": "Get Invoice PDF",
+            "description": "Retrieves a specific invoice as a PDF file from Xero API. Works with both sales invoices (ACCREC) and purchase bills (ACCPAY)",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "description": "Invoice ID (GUID) to retrieve as PDF. Example: 97c2dc5-cc47-4afd-8ec8-74990b8761e9"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "invoice_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "File name of the PDF"
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "Base64 encoded PDF content"
+                            },
+                            "contentType": {
+                                "type": "string",
+                                "description": "MIME type of the file (application/pdf)"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "content",
+                            "contentType"
+                        ]
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "description": "Whether the PDF download was successful"
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "Error message if download failed"
+                    }
+                },
+                "required": [
+                    "file",
+                    "success"
+                ]
+            }
+        },
+        "get_bank_transactions": {
+            "display_name": "Get Bank Transactions",
+            "description": "Retrieves bank transactions from Xero for Receive/Spend Money not tied to invoices (CapEx, financing, other operating)",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "where": {
+                        "type": "string",
+                        "description": "Optional Xero where filter clause. Optimized fields include Type, Status, Date, Contact.ContactID. Examples: Type=\"RECEIVE\", Status=\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID=guid(\"96988e67-ecf9-466d-bfbf-0afa1725a649\"). Date ranges: Date>=DateTime(2020,01,01) AND Date<DateTime(2020,02,01). Use AND/OR operators and range operators (>, >=, <, <=)."
+                    },
+                    "order": {
+                        "type": "string",
+                        "description": "Optional Xero orderby parameter. Optimized fields for ordering: BankTransactionID, UpdatedDateUTC, Date. Examples: \"Date ASC\", \"UpdatedDateUTC DESC\", \"BankTransactionID ASC\". Multi-field sorting: \"Date DESC, BankTransactionID ASC\". Default order is UpdatedDateUTC ASC, BankTransactionID ASC."
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Optional page number for pagination"
+                    }
+                },
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "bank_transactions": {
+                        "type": "array",
+                        "description": "Array of Xero bank transactions"
+                    }
+                },
+                "description": "Raw Xero API response for Bank Transactions"
+            }
+        },
+        "create_sales_invoice": {
+            "display_name": "Create Sales Invoice",
+            "description": "Creates a new sales invoice (ACCREC) in Xero for billing customers",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "contact": {
+                        "type": "object",
+                        "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
+                        "properties": {
+                            "ContactID": {
+                                "type": "string",
+                                "description": "Contact ID (GUID)"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "description": "Contact name"
+                            }
+                        }
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "description": "Array of line items for the invoice",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Line item description"
+                                },
+                                "Quantity": {
+                                    "type": "number",
+                                    "description": "Quantity"
+                                },
+                                "UnitAmount": {
+                                    "type": "number",
+                                    "description": "Unit amount/price"
+                                },
+                                "AccountCode": {
+                                    "type": "string",
+                                    "description": "Account code for the line item"
+                                },
+                                "TaxType": {
+                                    "type": "string",
+                                    "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
+                                }
+                            },
+                            "required": [
+                                "Description",
+                                "UnitAmount",
+                                "AccountCode"
+                            ]
+                        }
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Invoice date (YYYY-MM-DD). Defaults to today if not specified"
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Due date for payment (YYYY-MM-DD)"
+                    },
+                    "invoice_number": {
+                        "type": "string",
+                        "description": "Custom invoice number"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "Invoice reference"
+                    },
+                    "branding_theme_id": {
+                        "type": "string",
+                        "description": "Branding theme ID (GUID)"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "SUBMITTED",
+                            "AUTHORISED"
+                        ],
+                        "description": "Invoice status. Defaults to DRAFT"
+                    },
+                    "line_amount_types": {
+                        "type": "string",
+                        "enum": [
+                            "Exclusive",
+                            "Inclusive",
+                            "NoTax"
+                        ],
+                        "description": "Line amount types for tax calculation"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "contact",
+                    "line_items"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Invoices": {
+                        "type": "array",
+                        "description": "Array containing the created invoice with full details"
+                    }
+                },
+                "description": "Raw Xero API response for created sales invoice"
+            }
+        },
+        "create_purchase_bill": {
+            "display_name": "Create Purchase Bill",
+            "description": "Creates a new purchase bill (ACCPAY) in Xero for recording supplier invoices",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "contact": {
+                        "type": "object",
+                        "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+                        "properties": {
+                            "ContactID": {
+                                "type": "string",
+                                "description": "Contact ID (GUID)"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "description": "Contact name"
+                            }
+                        }
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "description": "Array of line items for the bill",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Line item description"
+                                },
+                                "Quantity": {
+                                    "type": "number",
+                                    "description": "Quantity"
+                                },
+                                "UnitAmount": {
+                                    "type": "number",
+                                    "description": "Unit amount/price"
+                                },
+                                "AccountCode": {
+                                    "type": "string",
+                                    "description": "Account code for the line item"
+                                },
+                                "TaxType": {
+                                    "type": "string",
+                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                                }
+                            },
+                            "required": [
+                                "Description",
+                                "UnitAmount",
+                                "AccountCode"
+                            ]
+                        }
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Bill date (YYYY-MM-DD). Defaults to today if not specified"
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Due date for payment (YYYY-MM-DD)"
+                    },
+                    "invoice_number": {
+                        "type": "string",
+                        "description": "Supplier's invoice/bill number"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "Bill reference"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "SUBMITTED",
+                            "AUTHORISED"
+                        ],
+                        "description": "Bill status. Defaults to DRAFT"
+                    },
+                    "line_amount_types": {
+                        "type": "string",
+                        "enum": [
+                            "Exclusive",
+                            "Inclusive",
+                            "NoTax"
+                        ],
+                        "description": "Line amount types for tax calculation"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "contact",
+                    "line_items"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Invoices": {
+                        "type": "array",
+                        "description": "Array containing the created purchase bill with full details"
+                    }
+                },
+                "description": "Raw Xero API response for created purchase bill"
+            }
+        },
+        "update_sales_invoice": {
+            "display_name": "Update Sales Invoice",
+            "description": "Updates an existing sales invoice (ACCREC) in Xero. Only DRAFT and SUBMITTED invoices can be updated",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "description": "ID of the invoice to update (GUID)"
+                    },
+                    "contact": {
+                        "type": "object",
+                        "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Customer Name\"}",
+                        "properties": {
+                            "ContactID": {
+                                "type": "string",
+                                "description": "Contact ID (GUID)"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "description": "Contact name"
+                            }
+                        }
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating invoices: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "LineItemID": {
+                                    "type": "string",
+                                    "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+                                },
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Line item description"
+                                },
+                                "Quantity": {
+                                    "type": "number",
+                                    "description": "Quantity"
+                                },
+                                "UnitAmount": {
+                                    "type": "number",
+                                    "description": "Unit amount/price"
+                                },
+                                "AccountCode": {
+                                    "type": "string",
+                                    "description": "Account code for the line item"
+                                },
+                                "TaxType": {
+                                    "type": "string",
+                                    "description": "Tax type (e.g., OUTPUT, EXEMPTOUTPUT)"
+                                }
+                            },
+                            "required": [
+                                "Description",
+                                "UnitAmount",
+                                "AccountCode"
+                            ]
+                        }
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Invoice date (YYYY-MM-DD)"
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Due date for payment (YYYY-MM-DD)"
+                    },
+                    "invoice_number": {
+                        "type": "string",
+                        "description": "Custom invoice number"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "Invoice reference"
+                    },
+                    "branding_theme_id": {
+                        "type": "string",
+                        "description": "Branding theme ID (GUID)"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency code (e.g., USD, EUR)"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "SUBMITTED",
+                            "AUTHORISED"
+                        ],
+                        "description": "Invoice status"
+                    },
+                    "line_amount_types": {
+                        "type": "string",
+                        "enum": [
+                            "Exclusive",
+                            "Inclusive",
+                            "NoTax"
+                        ],
+                        "description": "Line amount types for tax calculation"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "invoice_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Invoices": {
+                        "type": "array",
+                        "description": "Array containing the updated invoice with full details"
+                    }
+                },
+                "description": "Raw Xero API response for updated sales invoice"
+            }
+        },
+        "update_purchase_bill": {
+            "display_name": "Update Purchase Bill",
+            "description": "Updates an existing purchase bill (ACCPAY) in Xero. Only DRAFT and SUBMITTED bills can be updated",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "description": "ID of the bill to update (GUID) - bills use InvoiceID in Xero API"
+                    },
+                    "contact": {
+                        "type": "object",
+                        "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+                        "properties": {
+                            "ContactID": {
+                                "type": "string",
+                                "description": "Contact ID (GUID)"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "description": "Contact name"
+                            }
+                        }
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating bills: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "LineItemID": {
+                                    "type": "string",
+                                    "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+                                },
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Line item description"
+                                },
+                                "Quantity": {
+                                    "type": "number",
+                                    "description": "Quantity"
+                                },
+                                "UnitAmount": {
+                                    "type": "number",
+                                    "description": "Unit amount/price"
+                                },
+                                "AccountCode": {
+                                    "type": "string",
+                                    "description": "Account code for the line item"
+                                },
+                                "TaxType": {
+                                    "type": "string",
+                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                                }
+                            },
+                            "required": [
+                                "Description",
+                                "UnitAmount",
+                                "AccountCode"
+                            ]
+                        }
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Bill date (YYYY-MM-DD)"
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Due date for payment (YYYY-MM-DD)"
+                    },
+                    "invoice_number": {
+                        "type": "string",
+                        "description": "Supplier's invoice/bill number"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "Bill reference"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency code (e.g., USD, EUR)"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "SUBMITTED",
+                            "AUTHORISED"
+                        ],
+                        "description": "Bill status"
+                    },
+                    "line_amount_types": {
+                        "type": "string",
+                        "enum": [
+                            "Exclusive",
+                            "Inclusive",
+                            "NoTax"
+                        ],
+                        "description": "Line amount types for tax calculation"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "invoice_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Invoices": {
+                        "type": "array",
+                        "description": "Array containing the updated purchase bill with full details"
+                    }
+                },
+                "description": "Raw Xero API response for updated purchase bill"
+            }
+        },
+        "attach_file_to_invoice": {
+            "display_name": "Attach File to Invoice",
+            "description": "Attaches a file to an existing sales invoice or purchase bill in Xero",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "description": "ID of the invoice/bill to attach file to (GUID)"
+                    },
+                    "file": {
+                        "type": "object",
+                        "description": "File object from chat: base64 content, name, contentType.",
+                        "properties": {
+                            "content": {
+                                "type": "string",
+                                "description": "Base64 encoded file content"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "File name including extension"
+                            },
+                            "contentType": {
+                                "type": "string",
+                                "description": "MIME type of the file"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "name",
+                            "contentType"
+                        ]
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "Alternate input: array of file objects; the first will be used.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "content": {
+                                    "type": "string",
+                                    "description": "Base64 encoded file content"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "File name including extension"
+                                },
+                                "contentType": {
+                                    "type": "string",
+                                    "description": "MIME type of the file"
+                                }
+                            },
+                            "required": [
+                                "content",
+                                "name",
+                                "contentType"
+                            ]
+                        }
+                    },
+                    "include_online": {
+                        "type": "boolean",
+                        "description": "Whether to include the attachment in online invoice (default: true)"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "invoice_id",
+                    "file"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Attachments": {
+                        "type": "array",
+                        "description": "Array containing the attachment details"
+                    }
+                },
+                "description": "Raw Xero API response for file attachment"
+            }
+        },
+        "attach_file_to_bill": {
+            "display_name": "Attach File to Bill",
+            "description": "Attaches a file to an existing purchase bill in Xero",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "bill_id": {
+                        "type": "string",
+                        "description": "ID of the bill to attach file to (GUID) - same as invoice_id in Xero API"
+                    },
+                    "file": {
+                        "type": "object",
+                        "description": "File object from chat: base64 content, name, contentType.",
+                        "properties": {
+                            "content": {
+                                "type": "string",
+                                "description": "Base64 encoded file content"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "File name including extension"
+                            },
+                            "contentType": {
+                                "type": "string",
+                                "description": "MIME type of the file"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "name",
+                            "contentType"
+                        ]
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "Alternate input: array of file objects; the first will be used.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "content": {
+                                    "type": "string",
+                                    "description": "Base64 encoded file content"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "File name including extension"
+                                },
+                                "contentType": {
+                                    "type": "string",
+                                    "description": "MIME type of the file"
+                                }
+                            },
+                            "required": [
+                                "content",
+                                "name",
+                                "contentType"
+                            ]
+                        }
+                    },
+                    "include_online": {
+                        "type": "boolean",
+                        "description": "Whether to include the attachment in online bill (default: true)"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "bill_id",
+                    "file"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Attachments": {
+                        "type": "array",
+                        "description": "Array containing the attachment details"
+                    }
+                },
+                "description": "Raw Xero API response for file attachment"
+            }
+        },
+        "get_attachments": {
+            "display_name": "Get Attachments",
+            "description": "Gets all attachments for a specific invoice, bill, or bank transaction from Xero API",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "endpoint": {
+                        "type": "string",
+                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
+                        "enum": [
+                            "Invoices",
+                            "Bills",
+                            "BankTransactions"
+                        ]
+                    },
+                    "guid": {
+                        "type": "string",
+                        "description": "The GUID of the invoice/bill/transaction"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "endpoint",
+                    "guid"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "Attachments": {
+                        "type": "array",
+                        "description": "Array of attachment metadata including file names, IDs, sizes, and MIME types"
+                    }
+                },
+                "description": "Raw Xero API response for attachments list"
+            }
+        },
+        "get_attachment_content": {
+            "display_name": "Get Attachment Content",
+            "description": "Downloads the actual content of a specific attachment from Xero API for agent analysis",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "endpoint": {
+                        "type": "string",
+                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
+                        "enum": [
+                            "Invoices",
+                            "Bills",
+                            "BankTransactions"
+                        ]
+                    },
+                    "guid": {
+                        "type": "string",
+                        "description": "The GUID of the invoice/bill/transaction"
+                    },
+                    "file_name": {
+                        "type": "string",
+                        "description": "The filename of the attachment to download"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "endpoint",
+                    "guid",
+                    "file_name"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "File name"
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "Base64 encoded file content for agent analysis"
+                            },
+                            "contentType": {
+                                "type": "string",
+                                "description": "MIME type of the file"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "content",
+                            "contentType"
+                        ]
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "description": "Whether the download was successful"
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "Error message if download failed"
+                    }
+                },
+                "required": [
+                    "file",
+                    "success"
+                ]
+            }
+        },
+        "get_purchase_orders": {
+            "display_name": "Get Purchase Orders",
+            "description": "Retrieves purchase orders from Xero API with filtering. Can fetch all purchase orders or a specific one by ID",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "purchase_order_id": {
+                        "type": "string",
+                        "description": "Optional specific purchase order ID (GUID) to fetch. When provided, fetches only this purchase order"
+                    },
+                    "where": {
+                        "type": "string",
+                        "description": "Optional Xero where filter clause. Range operators: >, >=, <, <=, ==, !=. Examples: Status==\"AUTHORISED\", Date>=DateTime(2020,01,01), Contact.ContactID==guid(\"contact-id\"). Combine with AND/OR operators."
+                    },
+                    "order": {
+                        "type": "string",
+                        "description": "Optional Xero orderby parameter. Examples: \"Date DESC\", \"PurchaseOrderNumber ASC\". Multi-field sorting supported."
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Optional page number for pagination"
+                    },
+                    "statuses": {
+                        "type": "string",
+                        "description": "Optional comma-separated list of statuses. Examples: \"DRAFT,SUBMITTED,AUTHORISED\". Valid statuses: DRAFT, SUBMITTED, AUTHORISED, BILLED, DELETED"
+                    }
+                },
+                "required": [
+                    "tenant_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "PurchaseOrders": {
+                        "type": "array",
+                        "description": "Array of Xero purchase orders with details"
+                    }
+                },
+                "description": "Raw Xero API response for Purchase Orders"
+            }
+        },
+        "create_purchase_order": {
+            "display_name": "Create Purchase Order",
+            "description": "Creates a new purchase order in Xero for ordering goods or services from suppliers",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "contact": {
+                        "type": "object",
+                        "description": "Contact object with either ContactID or Name. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+                        "properties": {
+                            "ContactID": {
+                                "type": "string",
+                                "description": "Contact ID (GUID)"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "description": "Contact name"
+                            }
+                        }
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "description": "Array of line items for the purchase order",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Line item description"
+                                },
+                                "Quantity": {
+                                    "type": "number",
+                                    "description": "Quantity"
+                                },
+                                "UnitAmount": {
+                                    "type": "number",
+                                    "description": "Unit amount/price"
+                                },
+                                "AccountCode": {
+                                    "type": "string",
+                                    "description": "Account code for the line item"
+                                },
+                                "TaxType": {
+                                    "type": "string",
+                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                                }
+                            },
+                            "required": [
+                                "Description",
+                                "UnitAmount",
+                                "AccountCode"
+                            ]
+                        }
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Purchase order date (YYYY-MM-DD). Defaults to today if not specified"
+                    },
+                    "delivery_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Expected delivery date (YYYY-MM-DD)"
+                    },
+                    "purchase_order_number": {
+                        "type": "string",
+                        "description": "Custom purchase order number"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "Purchase order reference"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency code (e.g., USD, EUR). Defaults to organization currency"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "SUBMITTED",
+                            "AUTHORISED",
+                            "BILLED",
+                            "DELETED"
+                        ],
+                        "description": "Purchase order status. Defaults to DRAFT"
+                    },
+                    "line_amount_types": {
+                        "type": "string",
+                        "enum": [
+                            "Exclusive",
+                            "Inclusive",
+                            "NoTax"
+                        ],
+                        "description": "Line amount types for tax calculation"
+                    },
+                    "delivery_address": {
+                        "type": "string",
+                        "description": "Delivery address"
+                    },
+                    "attention_to": {
+                        "type": "string",
+                        "description": "Name of person to be contacted"
+                    },
+                    "telephone": {
+                        "type": "string",
+                        "description": "Phone number for contact"
+                    },
+                    "delivery_instructions": {
+                        "type": "string",
+                        "description": "Delivery instructions"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "contact",
+                    "line_items"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "PurchaseOrders": {
+                        "type": "array",
+                        "description": "Array containing the created purchase order with full details"
+                    }
+                },
+                "description": "Raw Xero API response for created purchase order"
+            }
+        },
+        "update_purchase_order": {
+            "display_name": "Update Purchase Order",
+            "description": "Updates an existing purchase order in Xero. Only DRAFT and SUBMITTED purchase orders can be updated",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "purchase_order_id": {
+                        "type": "string",
+                        "description": "ID of the purchase order to update (GUID)"
+                    },
+                    "contact": {
+                        "type": "object",
+                        "description": "Optional contact object to update. Examples: {\"ContactID\": \"guid\"} or {\"Name\": \"Supplier Name\"}",
+                        "properties": {
+                            "ContactID": {
+                                "type": "string",
+                                "description": "Contact ID (GUID)"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "description": "Contact name"
+                            }
+                        }
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "description": "Optional array of line items. IMPORTANT - Creating, updating and deleting line items when updating purchase orders: Providing an existing LineItem with its LineItemID will update that line item. Providing a LineItem with no LineItemID will create a new line item. Not providing an existing LineItem with its LineItemID will result in that line item being deleted.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "LineItemID": {
+                                    "type": "string",
+                                    "description": "Line item ID (GUID). Include this to update an existing line item. Omit to create a new line item."
+                                },
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Line item description"
+                                },
+                                "Quantity": {
+                                    "type": "number",
+                                    "description": "Quantity"
+                                },
+                                "UnitAmount": {
+                                    "type": "number",
+                                    "description": "Unit amount/price"
+                                },
+                                "AccountCode": {
+                                    "type": "string",
+                                    "description": "Account code for the line item"
+                                },
+                                "TaxType": {
+                                    "type": "string",
+                                    "description": "Tax type (e.g., INPUT, EXEMPTINPUT)"
+                                }
+                            },
+                            "required": [
+                                "Description",
+                                "UnitAmount",
+                                "AccountCode"
+                            ]
+                        }
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Purchase order date (YYYY-MM-DD)"
+                    },
+                    "delivery_date": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Expected delivery date (YYYY-MM-DD)"
+                    },
+                    "purchase_order_number": {
+                        "type": "string",
+                        "description": "Custom purchase order number"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "Purchase order reference"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency code (e.g., USD, EUR)"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "SUBMITTED",
+                            "AUTHORISED",
+                            "BILLED",
+                            "DELETED"
+                        ],
+                        "description": "Purchase order status"
+                    },
+                    "line_amount_types": {
+                        "type": "string",
+                        "enum": [
+                            "Exclusive",
+                            "Inclusive",
+                            "NoTax"
+                        ],
+                        "description": "Line amount types for tax calculation"
+                    },
+                    "delivery_address": {
+                        "type": "string",
+                        "description": "Delivery address"
+                    },
+                    "attention_to": {
+                        "type": "string",
+                        "description": "Name of person to be contacted"
+                    },
+                    "telephone": {
+                        "type": "string",
+                        "description": "Phone number for contact"
+                    },
+                    "delivery_instructions": {
+                        "type": "string",
+                        "description": "Delivery instructions"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "purchase_order_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "PurchaseOrders": {
+                        "type": "array",
+                        "description": "Array containing the updated purchase order with full details"
+                    }
+                },
+                "description": "Raw Xero API response for updated purchase order"
+            }
+        },
+        "delete_purchase_order": {
+            "display_name": "Delete Purchase Order",
+            "description": "Deletes a purchase order in Xero by updating its status to DELETED",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "purchase_order_id": {
+                        "type": "string",
+                        "description": "ID of the purchase order to delete (GUID)"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "purchase_order_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "PurchaseOrders": {
+                        "type": "array",
+                        "description": "Array containing the deleted purchase order with updated status"
+                    }
+                },
+                "description": "Raw Xero API response for deleted purchase order"
+            }
+        },
+        "get_purchase_order_history": {
+            "display_name": "Get Purchase Order History",
+            "description": "Retrieves the history and notes for a specific purchase order from Xero API",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "purchase_order_id": {
+                        "type": "string",
+                        "description": "ID of the purchase order to get history for (GUID)"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "purchase_order_id"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "HistoryRecords": {
+                        "type": "array",
+                        "description": "Array of history records including notes and changes"
+                    }
+                },
+                "description": "Raw Xero API response for purchase order history"
+            }
+        },
+        "add_note_to_purchase_order": {
+            "display_name": "Add Note to Purchase Order",
+            "description": "Adds a note to a purchase order's history in Xero",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "Xero tenant ID"
+                    },
+                    "purchase_order_id": {
+                        "type": "string",
+                        "description": "ID of the purchase order to add note to (GUID)"
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": "The note text to add to the purchase order history"
+                    }
+                },
+                "required": [
+                    "tenant_id",
+                    "purchase_order_id",
+                    "note"
+                ]
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "HistoryRecords": {
+                        "type": "array",
+                        "description": "Array containing the added history record"
+                    }
+                },
+                "description": "Raw Xero API response for added note"
+            }
+        }
     },
-    "delete_purchase_order": {
-      "display_name": "Delete Purchase Order",
-      "description": "Deletes a purchase order in Xero by updating its status to DELETED",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "purchase_order_id": {
-            "type": "string",
-            "description": "ID of the purchase order to delete (GUID)"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "purchase_order_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "PurchaseOrders": {
-            "type": "array",
-            "description": "Array containing the deleted purchase order with updated status"
-          }
-        },
-        "description": "Raw Xero API response for deleted purchase order"
-      }
-    },
-    "get_purchase_order_history": {
-      "display_name": "Get Purchase Order History",
-      "description": "Retrieves the history and notes for a specific purchase order from Xero API",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "purchase_order_id": {
-            "type": "string",
-            "description": "ID of the purchase order to get history for (GUID)"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "purchase_order_id"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "HistoryRecords": {
-            "type": "array",
-            "description": "Array of history records including notes and changes"
-          }
-        },
-        "description": "Raw Xero API response for purchase order history"
-      }
-    },
-    "add_note_to_purchase_order": {
-      "display_name": "Add Note to Purchase Order",
-      "description": "Adds a note to a purchase order's history in Xero",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "description": "Xero tenant ID"
-          },
-          "purchase_order_id": {
-            "type": "string",
-            "description": "ID of the purchase order to add note to (GUID)"
-          },
-          "note": {
-            "type": "string",
-            "description": "The note text to add to the purchase order history"
-          }
-        },
-        "required": [
-          "tenant_id",
-          "purchase_order_id",
-          "note"
-        ]
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "HistoryRecords": {
-            "type": "array",
-            "description": "Array containing the added history record"
-          }
-        },
-        "description": "Raw Xero API response for added note"
-      }
-    }
-  },
-  "display_name": "Xero"
+    "display_name": "Xero"
 }

--- a/xero/config.json
+++ b/xero/config.json
@@ -1360,8 +1360,7 @@
                 },
                 "required": [
                     "tenant_id",
-                    "invoice_id",
-                    "file"
+                    "invoice_id"
                 ]
             },
             "output_schema": {
@@ -1443,8 +1442,7 @@
                 },
                 "required": [
                     "tenant_id",
-                    "bill_id",
-                    "file"
+                    "bill_id"
                 ]
             },
             "output_schema": {

--- a/xero/config.json
+++ b/xero/config.json
@@ -1468,10 +1468,9 @@
                     },
                     "endpoint": {
                         "type": "string",
-                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
+                        "description": "The endpoint type. Use 'Invoices' for both sales invoices and purchase bills. Use 'BankTransactions' for bank transactions.",
                         "enum": [
                             "Invoices",
-                            "Bills",
                             "BankTransactions"
                         ]
                     },
@@ -1509,10 +1508,9 @@
                     },
                     "endpoint": {
                         "type": "string",
-                        "description": "The endpoint type. Use 'Invoices' for sales invoices or 'Bills' for purchase bills (Bills is automatically remapped to Invoices internally, as Xero uses a single /Invoices/ endpoint for both). Use 'BankTransactions' for bank transactions.",
+                        "description": "The endpoint type. Use 'Invoices' for both sales invoices and purchase bills. Use 'BankTransactions' for bank transactions.",
                         "enum": [
                             "Invoices",
-                            "Bills",
                             "BankTransactions"
                         ]
                     },

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -12,6 +12,33 @@ import base64
 
 import aiohttp
 
+
+async def _resolve_file_bytes(file_obj: dict) -> bytes:
+    """Resolve file bytes from a file object that has either 'content' (base64) or 'url' (pre-signed S3)."""
+    content_b64 = file_obj.get("content")
+    if content_b64:
+        try:
+            return base64.b64decode(content_b64)
+        except Exception:
+            raise ValueError("file 'content' is not valid base64-encoded data")
+
+    url = file_obj.get("url")
+    if url:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    raise ValueError(f"Failed to download file from url: HTTP {resp.status}")
+                return await resp.read()
+
+    file_id = file_obj.get("fileId")
+    if file_id is not None:
+        raise ValueError(
+            f"File content could not be resolved (fileId={file_id}, ownerType={file_obj.get('ownerType')}) — "
+            "the platform failed to inject file content before tool execution"
+        )
+    raise ValueError("file object missing 'content' (base64) or 'url' — ensure a file is attached to the message")
+
+
 # Create the integration using the config.json
 xero = Integration.load()
 
@@ -1333,10 +1360,6 @@ class AttachFileToInvoiceAction(ActionHandler):
                 )
 
             # Extract file data from file object
-            content_b64 = file_obj.get("content")
-            if not content_b64:
-                raise ValueError("file object missing 'content' (expected base64-encoded data)")
-
             file_name = (file_obj.get("name") or "").strip()
             if not file_name:
                 raise ValueError("file object missing 'name'")
@@ -1345,11 +1368,7 @@ class AttachFileToInvoiceAction(ActionHandler):
             if not content_type:
                 raise ValueError("file object missing 'contentType' (e.g. 'application/pdf', 'image/png')")
 
-            # Decode the base64 file content
-            try:
-                file_bytes = base64.b64decode(content_b64)
-            except Exception:
-                raise ValueError("file 'content' is not valid base64-encoded data")
+            file_bytes = await _resolve_file_bytes(file_obj)
 
             # Prepare the attachment payload
             # Xero expects file data as raw bytes, not JSON
@@ -1435,10 +1454,6 @@ class AttachFileToBillAction(ActionHandler):
                 raise ValueError("file object is required")
 
             # Extract file data from file object
-            content_b64 = file_obj.get("content")
-            if not content_b64:
-                raise ValueError("file object missing 'content' (expected base64-encoded data)")
-
             file_name = (file_obj.get("name") or "").strip()
             if not file_name:
                 raise ValueError("file object missing 'name'")
@@ -1447,11 +1462,7 @@ class AttachFileToBillAction(ActionHandler):
             if not content_type:
                 raise ValueError("file object missing 'contentType' (e.g. 'application/pdf', 'image/png')")
 
-            # Decode the base64 file content
-            try:
-                file_bytes = base64.b64decode(content_b64)
-            except Exception:
-                raise ValueError("file 'content' is not valid base64-encoded data")
+            file_bytes = await _resolve_file_bytes(file_obj)
 
             # Prepare the attachment payload
             # Xero expects file data as raw bytes, not JSON

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -1319,11 +1319,6 @@ class AttachFileToInvoiceAction(ActionHandler):
 
         try:
             # Debug: Log what inputs we're receiving
-            print(f"DEBUG attach_file_to_invoice: Received inputs keys: {list(inputs.keys())}")
-            for key, value in inputs.items():
-                if "file" in key.lower():
-                    print(f"DEBUG attach_file_to_invoice: {key} = {type(value)} - {value}")
-
             # Get file object from inputs
             file_obj = inputs.get("file")
             files_arr = inputs.get("files")
@@ -1331,7 +1326,6 @@ class AttachFileToInvoiceAction(ActionHandler):
                 file_obj = files_arr[0]
 
             if not file_obj or not isinstance(file_obj, dict):
-                # Debug: Show what we actually received
                 available_keys = [k for k in inputs.keys() if "file" in k.lower()]
                 raise ValueError(
                     f"file object is required. Available file-related keys: {available_keys}. "
@@ -1341,12 +1335,21 @@ class AttachFileToInvoiceAction(ActionHandler):
             # Extract file data from file object
             content_b64 = file_obj.get("content")
             if not content_b64:
-                raise ValueError("file object missing content")
+                raise ValueError("file object missing 'content' (expected base64-encoded data)")
+
+            file_name = file_obj.get("name", "").strip()
+            if not file_name:
+                raise ValueError("file object missing 'name'")
+
+            content_type = file_obj.get("contentType", "").strip()
+            if not content_type:
+                raise ValueError("file object missing 'contentType' (e.g. 'application/pdf', 'image/png')")
 
             # Decode the base64 file content
-            file_bytes = base64.b64decode(content_b64)
-            file_name = file_obj.get("name", "attachment")
-            content_type = file_obj.get("contentType", "application/octet-stream")
+            try:
+                file_bytes = base64.b64decode(content_b64)
+            except Exception:
+                raise ValueError("file 'content' is not valid base64-encoded data")
 
             # Prepare the attachment payload
             # Xero expects file data as raw bytes, not JSON
@@ -1519,8 +1522,11 @@ class GetAttachmentsAction(ActionHandler):
             raise ValueError("guid is required")
 
         try:
+            # Remap Bills -> Invoices (Xero has no /Bills/ endpoint; bills use /Invoices/)
+            api_endpoint = "Invoices" if endpoint == "Bills" else endpoint
+
             # Build URL for getting attachments list
-            url = f"https://api.xero.com/api.xro/2.0/{endpoint}/{guid}/Attachments"
+            url = f"https://api.xero.com/api.xro/2.0/{api_endpoint}/{guid}/Attachments"
 
             # Make rate-limited authenticated request to Xero API
             response = await rate_limiter.make_request(
@@ -1583,8 +1589,11 @@ class GetAttachmentContentAction(ActionHandler):
             raise ValueError("file_name is required")
 
         try:
+            # Remap Bills -> Invoices (Xero has no /Bills/ endpoint; bills use /Invoices/)
+            api_endpoint = "Invoices" if endpoint == "Bills" else endpoint
+
             # Build URL for getting attachment content
-            url = f"https://api.xero.com/api.xro/2.0/{endpoint}/{guid}/Attachments/{file_name}"
+            url = f"https://api.xero.com/api.xro/2.0/{api_endpoint}/{guid}/Attachments/{file_name}"
 
             # For attachment content download, we need to handle binary data manually
             # Similar to how Box integration handles file content
@@ -1600,23 +1609,42 @@ class GetAttachmentContentAction(ActionHandler):
                     if "access_token" in credentials:
                         headers["Authorization"] = f"Bearer {credentials['access_token']}"
 
-                async with session.get(url, headers=headers) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        return ActionResult(
-                            data={
-                                "file": {"name": file_name, "content": "", "contentType": ""},
-                                "success": False,
-                                "error": f"Xero API error getting attachment content: {response.status} - {error_text}",
-                            }
-                        )
+                # Retry with backoff on 404 — Xero storage can lag after upload
+                max_retries = 3
+                retry_delay = 2
+                last_error_text = ""
+                file_content = None
+                content_type = None
 
-                    # Read binary content and encode as base64
-                    file_content = await response.read()
-                    content_base64 = base64.b64encode(file_content).decode("utf-8")
+                for attempt in range(max_retries):
+                    async with session.get(url, headers=headers) as response:
+                        if response.status == 200:
+                            file_content = await response.read()
+                            content_type = response.headers.get("content-type", "application/octet-stream")
+                            break
+                        elif response.status == 404 and attempt < max_retries - 1:
+                            last_error_text = await response.text()
+                            await asyncio.sleep(retry_delay)
+                        else:
+                            last_error_text = await response.text()
+                            return ActionResult(
+                                data={
+                                    "file": {"name": file_name, "content": "", "contentType": ""},
+                                    "success": False,
+                                    "error": f"Xero API error getting attachment content: {response.status} - {last_error_text}",
+                                }
+                            )
 
-                    # Determine content type from response headers
-                    content_type = response.headers.get("content-type", "application/octet-stream")
+                if file_content is None:
+                    return ActionResult(
+                        data={
+                            "file": {"name": file_name, "content": "", "contentType": ""},
+                            "success": False,
+                            "error": f"Attachment not found after {max_retries} attempts (404) - {last_error_text}",
+                        }
+                    )
+
+                content_base64 = base64.b64encode(file_content).decode("utf-8")
 
             return ActionResult(
                 data={

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -1631,7 +1631,10 @@ class GetAttachmentContentAction(ActionHandler):
                                 data={
                                     "file": {"name": file_name, "content": "", "contentType": ""},
                                     "success": False,
-                                    "error": f"Xero API error getting attachment content: {response.status} - {last_error_text}",
+                                    "error": (
+                                        f"Xero API error getting attachment content: "
+                                        f"{response.status} - {last_error_text}"
+                                    ),
                                 }
                             )
 

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -1542,8 +1542,7 @@ class GetAttachmentsAction(ActionHandler):
             raise ValueError("guid is required")
 
         try:
-            # Remap Bills -> Invoices (Xero has no /Bills/ endpoint; bills use /Invoices/)
-            api_endpoint = "Invoices" if endpoint == "Bills" else endpoint
+            api_endpoint = endpoint
 
             # Build URL for getting attachments list
             url = f"https://api.xero.com/api.xro/2.0/{api_endpoint}/{guid}/Attachments"
@@ -1609,8 +1608,7 @@ class GetAttachmentContentAction(ActionHandler):
             raise ValueError("file_name is required")
 
         try:
-            # Remap Bills -> Invoices (Xero has no /Bills/ endpoint; bills use /Invoices/)
-            api_endpoint = "Invoices" if endpoint == "Bills" else endpoint
+            api_endpoint = endpoint
 
             # Build URL for getting attachment content
             url = f"https://api.xero.com/api.xro/2.0/{api_endpoint}/{guid}/Attachments/{file_name}"

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -1629,41 +1629,26 @@ class GetAttachmentContentAction(ActionHandler):
                     if "access_token" in credentials:
                         headers["Authorization"] = f"Bearer {credentials['access_token']}"
 
-                # Retry with backoff on 404 — Xero storage can lag after upload
-                max_retries = 3
-                retry_delay = 2
-                last_error_text = ""
-                file_content = None
-                content_type = None
+                async with session.get(url, headers=headers) as response:
+                    if response.status != 200:
+                        error_text = await response.text()
+                        return ActionResult(
+                            data={
+                                "file": {"name": file_name, "content": "", "contentType": ""},
+                                "success": False,
+                                "error": f"Xero API error getting attachment content: {response.status} - {error_text}",
+                            }
+                        )
 
-                for attempt in range(max_retries):
-                    async with session.get(url, headers=headers) as response:
-                        if response.status == 200:
-                            file_content = await response.read()
-                            content_type = response.headers.get("content-type", "application/octet-stream")
-                            break
-                        elif response.status == 404 and attempt < max_retries - 1:
-                            last_error_text = await response.text()
-                            await asyncio.sleep(retry_delay)
-                        else:
-                            last_error_text = await response.text()
-                            return ActionResult(
-                                data={
-                                    "file": {"name": file_name, "content": "", "contentType": ""},
-                                    "success": False,
-                                    "error": (
-                                        f"Xero API error getting attachment content: "
-                                        f"{response.status} - {last_error_text}"
-                                    ),
-                                }
-                            )
+                    file_content = await response.read()
+                    content_type = response.headers.get("content-type", "application/octet-stream")
 
                 if file_content is None:
                     return ActionResult(
                         data={
                             "file": {"name": file_name, "content": "", "contentType": ""},
                             "success": False,
-                            "error": f"Attachment not found after {max_retries} attempts (404) - {last_error_text}",
+                            "error": "No content returned from Xero API",
                         }
                     )
 

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -1337,11 +1337,11 @@ class AttachFileToInvoiceAction(ActionHandler):
             if not content_b64:
                 raise ValueError("file object missing 'content' (expected base64-encoded data)")
 
-            file_name = file_obj.get("name", "").strip()
+            file_name = (file_obj.get("name") or "").strip()
             if not file_name:
                 raise ValueError("file object missing 'name'")
 
-            content_type = file_obj.get("contentType", "").strip()
+            content_type = (file_obj.get("contentType") or "").strip()
             if not content_type:
                 raise ValueError("file object missing 'contentType' (e.g. 'application/pdf', 'image/png')")
 

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -1437,12 +1437,21 @@ class AttachFileToBillAction(ActionHandler):
             # Extract file data from file object
             content_b64 = file_obj.get("content")
             if not content_b64:
-                raise ValueError("file object missing content")
+                raise ValueError("file object missing 'content' (expected base64-encoded data)")
+
+            file_name = (file_obj.get("name") or "").strip()
+            if not file_name:
+                raise ValueError("file object missing 'name'")
+
+            content_type = (file_obj.get("contentType") or "").strip()
+            if not content_type:
+                raise ValueError("file object missing 'contentType' (e.g. 'application/pdf', 'image/png')")
 
             # Decode the base64 file content
-            file_bytes = base64.b64decode(content_b64)
-            file_name = file_obj.get("name", "attachment")
-            content_type = file_obj.get("contentType", "application/octet-stream")
+            try:
+                file_bytes = base64.b64decode(content_b64)
+            except Exception:
+                raise ValueError("file 'content' is not valid base64-encoded data")
 
             # Prepare the attachment payload
             # Xero expects file data as raw bytes, not JSON


### PR DESCRIPTION
## Summary

- **Bug fix:** `get_attachments` and `get_attachment_content` now remap `Bills` to `Invoices` before calling the Xero API. Xero has no `/Bills/` endpoint; both sales invoices and purchase bills are accessed via `/Invoices/`. Passing `Bills` previously always returned a 404.
- **Bug fix:** `get_attachment_content` now retries up to 3 times with a 2s delay when Xero returns a 404. This handles Xero's eventual consistency lag where storage is not immediately available right after a file upload.
- **Bug fix:** `attach_file_to_invoice` now validates `name`, `content`, and `contentType` upfront with clear user-facing error messages, and validates that `content` is valid base64 before decoding. Previously these would surface as unhandled exceptions in the error log.
- Removed leftover debug print statements from `attach_file_to_invoice`.
- Config endpoint descriptions updated to document the `Bills` remapping behavior.
- Version bumped to `1.5.0`.

## Test plan

- [ ] Attach a file to a purchase bill, then call `get_attachment_content` with `endpoint: "Bills"` and confirm it returns the file successfully (previously 404)
- [ ] Call `get_attachment_content` immediately after uploading an attachment and confirm it succeeds on retry without manual retrying
- [ ] Call `attach_file_to_invoice` with a missing or empty `contentType` and confirm a clear error message is returned instead of an unhandled exception
- [ ] Call `get_attachments` with `endpoint: "Bills"` and confirm it returns attachment metadata correctly