### PR TITLE
fix(hubspot): use oneOf in get_company_properties output_schema to accept both strings and objects

### DIFF
--- a/hubspot/config.json
+++ b/hubspot/config.json
@@ -1,7 +1,7 @@
 {
   "name": "HubSpot",
   "display_name": "HubSpot CRM",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "HubSpot CRM integration for managing contacts, companies, deals, and support tickets with advanced pipeline analytics and UTC date handling",
   "entry_point": "hubspot.py",
   "auth": {
@@ -1765,35 +1765,44 @@
         "properties": {
           "properties": {
             "type": "array",
-            "description": "List of company properties with optional detailed metadata",
+            "description": "List of company properties. Returns property name strings by default, or detailed objects when include_details is true.",
             "items": {
-              "type": "object",
-              "properties": {
-                "name": {
+              "oneOf": [
+                {
                   "type": "string",
-                  "description": "Internal property name"
+                  "description": "Property name (when include_details is false)"
                 },
-                "label": {
-                  "type": "string",
-                  "description": "Display label"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Data type (string, number, enumeration, etc.)"
-                },
-                "fieldType": {
-                  "type": "string",
-                  "description": "Field type (text, select, number, etc.)"
-                },
-                "groupName": {
-                  "type": "string",
-                  "description": "Property group"
-                },
-                "hubspotDefined": {
-                  "type": "boolean",
-                  "description": "Whether it's a default HubSpot property"
+                {
+                  "type": "object",
+                  "description": "Detailed property metadata (when include_details is true)",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Internal property name"
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Data type (string, number, enumeration, etc.)"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "description": "Field type (text, select, number, etc.)"
+                    },
+                    "groupName": {
+                      "type": "string",
+                      "description": "Property group"
+                    },
+                    "hubspotDefined": {
+                      "type": "boolean",
+                      "description": "Whether it's a default HubSpot property"
+                    }
+                  }
                 }
-              }
+              ]
             }
           },
           "total_properties": {

--- a/hubspot/tests/test_hubspot_companies_unit.py
+++ b/hubspot/tests/test_hubspot_companies_unit.py
@@ -666,9 +666,10 @@ class TestGetCompanyProperties:
             mock_context,
         )
 
-        # include_details=False returns property names as strings, which conflicts
-        # with the output_schema that expects objects — SDK raises a validation error.
-        assert result.type == ResultType.VALIDATION_ERROR
+        data = result.result.data
+        assert data["total_properties"] == 2
+        assert data["custom_properties_count"] == 1
+        assert data["properties"] == ["name", "custom_score"]
 
     @pytest.mark.asyncio
     async def test_custom_properties_count(self, mock_context):


### PR DESCRIPTION
## Summary

The `get_company_properties` action's `output_schema` declared `properties` array items as strictly `type: "object"`, but when `include_details` is `false` (the default), the Python code returns an array of plain strings (property names). This caused a validation error at runtime.

## Changes

- **`hubspot/config.json`**: Updated the `get_company_properties` output_schema to use `oneOf` for the `properties` array items, accepting both `string` (default) and `object` (when `include_details` is true). Bumped version to `2.0.1`.
- **`hubspot/tests/test_hubspot_companies_unit.py`**: Updated `test_include_details_false` to verify correct data instead of asserting a validation error.

## Validation

- `validate_integration.py` passes (0 errors)
- All 264 unit tests pass

Closes #265