### PR TITLE
fix(salesforce): fall back to userinfo endpoint when instance_url missing from credentials

### DIFF
--- a/salesforce/config.json
+++ b/salesforce/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Salesforce",
   "display_name": "Salesforce",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Salesforce CRM integration for searching and updating records, and summarising task and event activity.",
   "entry_point": "salesforce.py",
   "auth": {

--- a/salesforce/salesforce.py
+++ b/salesforce/salesforce.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse
 from autohive_integrations_sdk import (
     Integration,
     ExecutionContext,
@@ -32,7 +33,24 @@ def _headers(token: str) -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
-def _get_token_and_instance(context: ExecutionContext):
+async def _resolve_instance_url(context: ExecutionContext, token: str) -> str:
+    """Derive instance URL from the Salesforce userinfo endpoint as a fallback."""
+    resp = await context.fetch(
+        "https://login.salesforce.com/services/oauth2/userinfo",
+        method="GET",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    rest_url = (resp.data or {}).get("urls", {}).get("rest", "")
+    if rest_url:
+        parsed = urlparse(rest_url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+    raise ValueError(
+        "Salesforce instance_url not found in credentials or metadata and could not be resolved "
+        "from the userinfo endpoint. Please reconnect."
+    )
+
+
+async def _get_token_and_instance(context: ExecutionContext):
     credentials = context.auth.get("credentials", {})
     token = credentials.get("access_token", "")
     instance_url = (
@@ -41,7 +59,7 @@ def _get_token_and_instance(context: ExecutionContext):
         or os.environ.get("SALESFORCE_INSTANCE_URL", "")
     )
     if not instance_url:
-        raise ValueError("Salesforce instance_url not found in credentials or metadata. Please reconnect.")
+        instance_url = await _resolve_instance_url(context, token)
     return token, instance_url
 
 
@@ -49,7 +67,7 @@ def _get_token_and_instance(context: ExecutionContext):
 class SearchRecordsAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             response = await context.fetch(
                 f"{_base_url(instance_url)}/query",
                 method="GET",
@@ -73,7 +91,7 @@ class SearchRecordsAction(ActionHandler):
 class GetRecordAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             object_type = inputs["object_type"]
             record_id = _validate_sf_id(inputs["record_id"], "record_id")
             url = f"{_base_url(instance_url)}/sobjects/{object_type}/{record_id}"
@@ -92,7 +110,7 @@ class GetRecordAction(ActionHandler):
 class UpdateRecordAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             object_type = inputs["object_type"]
             record_id = _validate_sf_id(inputs["record_id"], "record_id")
             url = f"{_base_url(instance_url)}/sobjects/{object_type}/{record_id}"
@@ -164,7 +182,7 @@ def _build_event_query(  # nosec B608
 class ListTasksAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             soql = _build_task_query(
                 status=inputs.get("status"),
                 assigned_to_id=inputs.get("assigned_to_id"),
@@ -194,7 +212,7 @@ class ListTasksAction(ActionHandler):
 class ListEventsAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             soql = _build_event_query(
                 start_date_from=inputs.get("start_date_from"),
                 start_date_to=inputs.get("start_date_to"),
@@ -242,7 +260,7 @@ def _summarise_event(event: Dict[str, Any]) -> str:
 class GetTaskSummaryAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             task_id = _validate_sf_id(inputs["task_id"], "task_id")
             fields = (
                 "Id, Subject, Status, Priority, ActivityDate, Description, "
@@ -271,7 +289,7 @@ class GetTaskSummaryAction(ActionHandler):
 class GetEventSummaryAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            token, instance_url = _get_token_and_instance(context)
+            token, instance_url = await _get_token_and_instance(context)
             event_id = _validate_sf_id(inputs["event_id"], "event_id")
             fields = (
                 "Id, Subject, StartDateTime, EndDateTime, Location, Description, "


### PR DESCRIPTION
## Summary

The Salesforce integration was intermittently failing with `instance_url not found in credentials or metadata` across all actions. The platform's OAuth layer does not always forward `instance_url` in the credentials dict — most notably after a token refresh, where only standard OAuth fields are returned. This fix makes the integration self-sufficient: when `instance_url` isn't available through the normal channels, it derives it from Salesforce's `/services/oauth2/userinfo` endpoint using the access token that's always present.

## Root Cause

`_get_token_and_instance` was synchronous and raised immediately if `instance_url` wasn't found in `credentials`, `context.metadata`, or `SALESFORCE_INSTANCE_URL`. After a token refresh the platform reconstructs credentials from the refresh response, which may omit non-standard fields like `instance_url`, causing every action to fail until the user reconnected.

## Changes

- `salesforce/salesforce.py` — made `_get_token_and_instance` async; added `_resolve_instance_url` fallback that calls `https://login.salesforce.com/services/oauth2/userinfo` and parses `urls.rest` to extract the instance hostname; updated all 7 call sites to `await`

## Behaviour

| Scenario | Before | After |
|---|---|---|
| `instance_url` in credentials | Works | Works (unchanged path) |
| `instance_url` in metadata/env | Works | Works (unchanged path) |
| `instance_url` missing (e.g. post-refresh) | Fails with reconnect error | Fetches from userinfo endpoint transparently |

## Notes

- The happy path (instance_url present) has zero extra API calls — the fallback only fires when needed
- Unit tests are unaffected — they set `ctx.metadata["instance_url"]` which still resolves on the second check
- No app-side or platform changes required