### PR TITLE
fix(github): return ActionError instead of malformed ActionResult on errors

### DIFF
--- a/github/config.json
+++ b/github/config.json
@@ -90,7 +90,10 @@
             "type": "string"
           },
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "private": {
             "type": "boolean"
@@ -105,7 +108,10 @@
             "type": "string"
           },
           "pushed_at": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "clone_url": {
             "type": "string"
@@ -357,7 +363,10 @@
             "type": "string"
           },
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "private": {
             "type": "boolean"
@@ -980,7 +989,10 @@
             "type": "integer"
           },
           "body": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "created_at": {
             "type": "string"
@@ -1031,7 +1043,10 @@
               "type": "integer"
             },
             "body": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "created_at": {
               "type": "string"
@@ -2579,7 +2594,10 @@
             "type": "string"
           },
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "public": {
             "type": "boolean"
@@ -3133,24 +3151,45 @@
             "default": 1
           }
         },
-        "required": ["owner", "repo"]
+        "required": [
+          "owner",
+          "repo"
+        ]
       },
       "output_schema": {
         "type": "array",
         "items": {
           "type": "object",
           "properties": {
-            "name": { "type": "string" },
+            "name": {
+              "type": "string"
+            },
             "commit": {
               "type": "object",
               "properties": {
-                "sha": { "type": "string" },
-                "url": { "type": "string" }
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
               }
             },
-            "zipball_url": { "type": ["string", "null"] },
-            "tarball_url": { "type": ["string", "null"] },
-            "node_id": { "type": "string" }
+            "zipball_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tarball_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "node_id": {
+              "type": "string"
+            }
           }
         }
       }
@@ -3180,26 +3219,73 @@
             "default": 1
           }
         },
-        "required": ["owner", "repo"]
+        "required": [
+          "owner",
+          "repo"
+        ]
       },
       "output_schema": {
         "type": "array",
         "items": {
           "type": "object",
           "properties": {
-            "id": { "type": "integer" },
-            "tag_name": { "type": "string" },
-            "name": { "type": ["string", "null"] },
-            "body": { "type": ["string", "null"] },
-            "draft": { "type": "boolean" },
-            "prerelease": { "type": "boolean" },
-            "created_at": { "type": "string" },
-            "published_at": { "type": ["string", "null"] },
-            "html_url": { "type": "string" },
-            "tarball_url": { "type": ["string", "null"] },
-            "zipball_url": { "type": ["string", "null"] },
-            "author": { "type": ["object", "null"] },
-            "assets": { "type": "array" }
+            "id": {
+              "type": "integer"
+            },
+            "tag_name": {
+              "type": "string"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "body": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "draft": {
+              "type": "boolean"
+            },
+            "prerelease": {
+              "type": "boolean"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "published_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "tarball_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "zipball_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "author": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "assets": {
+              "type": "array"
+            }
           }
         }
       }
@@ -3223,25 +3309,78 @@
             "description": "The unique identifier of the release"
           }
         },
-        "required": ["owner", "repo", "release_id"]
+        "required": [
+          "owner",
+          "repo",
+          "release_id"
+        ]
       },
       "output_schema": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
-          "tag_name": { "type": "string" },
-          "target_commitish": { "type": "string" },
-          "name": { "type": ["string", "null"] },
-          "body": { "type": ["string", "null"] },
-          "draft": { "type": "boolean" },
-          "prerelease": { "type": "boolean" },
-          "created_at": { "type": "string" },
-          "published_at": { "type": ["string", "null"] },
-          "html_url": { "type": "string" },
-          "tarball_url": { "type": ["string", "null"] },
-          "zipball_url": { "type": ["string", "null"] },
-          "author": { "type": ["object", "null"] },
-          "assets": { "type": "array" }
+          "id": {
+            "type": "integer"
+          },
+          "tag_name": {
+            "type": "string"
+          },
+          "target_commitish": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "prerelease": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "tarball_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "zipball_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "author": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "assets": {
+            "type": "array"
+          }
         }
       }
     },
@@ -3260,25 +3399,77 @@
             "description": "Repository name"
           }
         },
-        "required": ["owner", "repo"]
+        "required": [
+          "owner",
+          "repo"
+        ]
       },
       "output_schema": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
-          "tag_name": { "type": "string" },
-          "target_commitish": { "type": "string" },
-          "name": { "type": ["string", "null"] },
-          "body": { "type": ["string", "null"] },
-          "draft": { "type": "boolean" },
-          "prerelease": { "type": "boolean" },
-          "created_at": { "type": "string" },
-          "published_at": { "type": ["string", "null"] },
-          "html_url": { "type": "string" },
-          "tarball_url": { "type": ["string", "null"] },
-          "zipball_url": { "type": ["string", "null"] },
-          "author": { "type": ["object", "null"] },
-          "assets": { "type": "array" }
+          "id": {
+            "type": "integer"
+          },
+          "tag_name": {
+            "type": "string"
+          },
+          "target_commitish": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "prerelease": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "tarball_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "zipball_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "author": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "assets": {
+            "type": "array"
+          }
         }
       }
     },
@@ -3301,25 +3492,78 @@
             "description": "Tag name (e.g., 'v1.0.0')"
           }
         },
-        "required": ["owner", "repo", "tag"]
+        "required": [
+          "owner",
+          "repo",
+          "tag"
+        ]
       },
       "output_schema": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
-          "tag_name": { "type": "string" },
-          "target_commitish": { "type": "string" },
-          "name": { "type": ["string", "null"] },
-          "body": { "type": ["string", "null"] },
-          "draft": { "type": "boolean" },
-          "prerelease": { "type": "boolean" },
-          "created_at": { "type": "string" },
-          "published_at": { "type": ["string", "null"] },
-          "html_url": { "type": "string" },
-          "tarball_url": { "type": ["string", "null"] },
-          "zipball_url": { "type": ["string", "null"] },
-          "author": { "type": ["object", "null"] },
-          "assets": { "type": "array" }
+          "id": {
+            "type": "integer"
+          },
+          "tag_name": {
+            "type": "string"
+          },
+          "target_commitish": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "prerelease": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "tarball_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "zipball_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "author": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "assets": {
+            "type": "array"
+          }
         }
       }
     }

--- a/github/config.json
+++ b/github/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GitHub",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "GitHub API integration for complete repository management including CRUD operations for repos, branches, issues, PRs, files, and more.",
   "display_name": "GitHub",
   "supports_connected_account": true,

--- a/github/github.py
+++ b/github/github.py
@@ -17,6 +17,7 @@ from autohive_integrations_sdk import (
     ExecutionContext,
     ActionHandler,
     ActionResult,
+    ActionError,
     ConnectedAccountHandler,
     ConnectedAccountInfo,
 )
@@ -51,21 +52,17 @@ def handle_github_errors(action_name: str):
                 credentials = context.auth.get("credentials", {})
                 token = credentials.get("access_token")
                 if not token:
-                    return ActionResult(
-                        data={
-                            "error": (
-                                "GitHub authentication failed: No access token found. "
-                                "Please reconnect your GitHub account."
-                            ),
-                            "result": False,
-                        },
-                        cost_usd=0.0,
+                    return ActionError(
+                        message=(
+                            "GitHub authentication failed: No access token found. "
+                            "Please reconnect your GitHub account."
+                        )
                     )
 
                 return await func(self, inputs, context)
 
             except Exception as e:
-                return ActionResult(data={"error": str(e), "result": False}, cost_usd=0.0)
+                return ActionError(message=str(e))
 
         return wrapper
 

--- a/github/github.py
+++ b/github/github.py
@@ -54,8 +54,7 @@ def handle_github_errors(action_name: str):
                 if not token:
                     return ActionError(
                         message=(
-                            "GitHub authentication failed: No access token found. "
-                            "Please reconnect your GitHub account."
+                            "GitHub authentication failed: No access token found. Please reconnect your GitHub account."
                         )
                     )
 

--- a/github/github.py
+++ b/github/github.py
@@ -114,7 +114,8 @@ class GitHubAPI:
         all_items = []
         headers = GitHubAPI.get_headers(context)
         while True:
-            response = await context.fetch(url, params=params, headers=headers)
+            fetch_result = await context.fetch(url, params=params, headers=headers)
+            response = fetch_result.data
 
             # Extract items from response
             if data_key and isinstance(response, dict):
@@ -178,13 +179,13 @@ class GitHubAPI:
         if license_template:
             data["license_template"] = license_template
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def get_repository(context: ExecutionContext, owner: str, repo: str) -> Dict[str, Any]:
         """Get repository details"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def list_repositories(
@@ -241,7 +242,7 @@ class GitHubAPI:
         """Update repository settings"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}"
         data = {k: v for k, v in kwargs.items() if v is not None}
-        return await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def delete_repository(context: ExecutionContext, owner: str, repo: str) -> None:
@@ -280,7 +281,7 @@ class GitHubAPI:
     async def get_commit(context: ExecutionContext, owner: str, repo: str, sha: str) -> Dict[str, Any]:
         """Get a specific commit"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/commits/{sha}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def compare_branches(
@@ -288,7 +289,7 @@ class GitHubAPI:
     ) -> Dict[str, Any]:
         """Compare two branches"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/compare/{base}...{head}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Issue Operations ----
 
@@ -318,7 +319,7 @@ class GitHubAPI:
     async def get_issue(context: ExecutionContext, owner: str, repo: str, issue_number: int) -> Dict[str, Any]:
         """Get a specific issue"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/issues/{issue_number}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def create_issue(
@@ -344,7 +345,7 @@ class GitHubAPI:
         if milestone:
             data["milestone"] = milestone
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def update_issue(
@@ -376,7 +377,7 @@ class GitHubAPI:
         if milestone is not None:
             data["milestone"] = milestone
 
-        return await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def get_issue_comments(
@@ -393,7 +394,7 @@ class GitHubAPI:
         """Create a comment on an issue"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/issues/{issue_number}/comments"
         data = {"body": body}
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Pull Request Operations ----
 
@@ -443,8 +444,8 @@ class GitHubAPI:
         all_prs: List[Dict[str, Any]] = []
 
         while True:
-            response = await context.fetch(url, params=params, headers=headers)
-            items = response.get("items", [])
+            fetch_result = await context.fetch(url, params=params, headers=headers)
+            items = fetch_result.data.get("items", [])
             if not items:
                 break
 
@@ -464,7 +465,7 @@ class GitHubAPI:
     async def get_pull_request(context: ExecutionContext, owner: str, repo: str, pull_number: int) -> Dict[str, Any]:
         """Get detailed information about a pull request"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def create_pull_request(
@@ -491,7 +492,7 @@ class GitHubAPI:
         if body:
             data["body"] = body
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def update_pull_request(
@@ -500,7 +501,7 @@ class GitHubAPI:
         """Update a pull request"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}"
         data = {k: v for k, v in kwargs.items() if v is not None}
-        return await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PATCH", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def merge_pull_request(
@@ -521,7 +522,7 @@ class GitHubAPI:
         if commit_message:
             data["commit_message"] = commit_message
 
-        return await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def add_pull_request_reviewers(
@@ -541,7 +542,7 @@ class GitHubAPI:
         if team_reviewers:
             data["team_reviewers"] = team_reviewers
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def remove_pull_request_reviewers(
@@ -561,7 +562,7 @@ class GitHubAPI:
         if team_reviewers:
             data["team_reviewers"] = team_reviewers
 
-        return await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def list_pull_request_reviewers(
@@ -569,7 +570,7 @@ class GitHubAPI:
     ) -> Dict[str, Any]:
         """List reviewers for a pull request"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def create_pull_request_review(
@@ -592,7 +593,7 @@ class GitHubAPI:
         if comments:
             data["comments"] = comments
 
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Branch Operations ----
 
@@ -606,7 +607,7 @@ class GitHubAPI:
     async def get_branch(context: ExecutionContext, owner: str, repo: str, branch: str) -> Dict[str, Any]:
         """Get branch details"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/branches/{branch}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def create_branch(
@@ -615,7 +616,7 @@ class GitHubAPI:
         """Create a new branch"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/git/refs"
         data = {"ref": f"refs/heads/{branch_name}", "sha": sha}
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def delete_branch(context: ExecutionContext, owner: str, repo: str, branch: str) -> None:
@@ -627,7 +628,7 @@ class GitHubAPI:
     async def get_branch_protection(context: ExecutionContext, owner: str, repo: str, branch: str) -> Dict[str, Any]:
         """Get branch protection rules"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/branches/{branch}/protection"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Webhook Operations ----
 
@@ -652,12 +653,14 @@ class GitHubAPI:
 
         data = {"name": "web", "active": active, "events": events, "config": config}
 
-        return await context.fetch(
-            webhook_url,
-            method="POST",
-            json=data,
-            headers=GitHubAPI.get_headers(context),
-        )
+        return (
+            await context.fetch(
+                webhook_url,
+                method="POST",
+                json=data,
+                headers=GitHubAPI.get_headers(context),
+            )
+        ).data
 
     @staticmethod
     async def list_webhooks(context: ExecutionContext, owner: str, repo: str) -> List[Dict[str, Any]]:
@@ -669,7 +672,7 @@ class GitHubAPI:
     async def get_webhook(context: ExecutionContext, owner: str, repo: str, hook_id: int) -> Dict[str, Any]:
         """Get webhook details"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/hooks/{hook_id}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def delete_webhook(context: ExecutionContext, owner: str, repo: str, hook_id: int) -> None:
@@ -690,11 +693,12 @@ class GitHubAPI:
         if ref:
             params["ref"] = ref
 
-        response = await context.fetch(
+        fetch_result = await context.fetch(
             url,
             params=params if params else None,
             headers=GitHubAPI.get_headers(context),
         )
+        response = fetch_result.data
 
         # Decode base64 content
         content = base64.b64decode(response.get("content", "").replace("\n", "")).decode("utf-8")
@@ -729,7 +733,7 @@ class GitHubAPI:
         if branch:
             data["branch"] = branch
 
-        return await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def update_file(
@@ -754,7 +758,7 @@ class GitHubAPI:
         if branch:
             data["branch"] = branch
 
-        return await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="PUT", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def delete_file(
@@ -774,7 +778,7 @@ class GitHubAPI:
         if branch:
             data["branch"] = branch
 
-        return await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="DELETE", json=data, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Gist Operations ----
 
@@ -788,13 +792,13 @@ class GitHubAPI:
         """Create a gist"""
         url = f"{GitHubAPI.BASE_URL}/gists"
         data = {"description": description, "public": public, "files": files}
-        return await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, method="POST", json=data, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def get_gist(context: ExecutionContext, gist_id: str) -> Dict[str, Any]:
         """Get gist details"""
         url = f"{GitHubAPI.BASE_URL}/gists/{gist_id}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def list_gists(context: ExecutionContext, username: str = None) -> List[Dict[str, Any]]:
@@ -822,7 +826,7 @@ class GitHubAPI:
         else:
             url = f"{GitHubAPI.BASE_URL}/user"
 
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Organization Operations ----
 
@@ -888,7 +892,7 @@ class GitHubAPI:
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/tags"
         params = {"per_page": per_page, "page": page}
-        return await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context))).data
 
     # -------------------------------------------------------------------------
     # Release Operations
@@ -917,7 +921,7 @@ class GitHubAPI:
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases"
         params = {"per_page": per_page, "page": page}
-        return await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, params=params, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def get_release(context: ExecutionContext, owner: str, repo: str, release_id: int) -> Dict[str, Any]:
@@ -933,7 +937,7 @@ class GitHubAPI:
             Release object with full details including assets
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases/{release_id}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def get_latest_release(context: ExecutionContext, owner: str, repo: str) -> Dict[str, Any]:
@@ -950,7 +954,7 @@ class GitHubAPI:
             Latest release object
         """
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases/latest"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     @staticmethod
     async def get_release_by_tag(context: ExecutionContext, owner: str, repo: str, tag: str) -> Dict[str, Any]:
@@ -969,7 +973,7 @@ class GitHubAPI:
         """
         encoded_tag = quote(tag, safe="")
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/releases/tags/{encoded_tag}"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
     # ---- Rate Limiting ----
 
@@ -977,7 +981,7 @@ class GitHubAPI:
     async def get_rate_limit(context: ExecutionContext) -> Dict[str, Any]:
         """Get current rate limit status"""
         url = f"{GitHubAPI.BASE_URL}/rate_limit"
-        return await context.fetch(url, headers=GitHubAPI.get_headers(context))
+        return (await context.fetch(url, headers=GitHubAPI.get_headers(context))).data
 
 
 # ============================================================================
@@ -1905,8 +1909,7 @@ class GetBranchProtection(ActionHandler):
                 cost_usd=0.0,
             )
         except Exception as e:
-            # Branch protection not enabled
-            return ActionResult(data={"enabled": False, "error": str(e)}, cost_usd=0.0)
+            return ActionError(message=f"Branch protection not available: {e}")
 
 
 @github.action("diff_branch_to_branch")

--- a/github/requirements.txt
+++ b/github/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk==1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/github/tests/conftest.py
+++ b/github/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))

--- a/github/tests/test_github_branches_commits_unit.py
+++ b/github/tests/test_github_branches_commits_unit.py
@@ -1,0 +1,296 @@
+import os
+import sys
+import importlib
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("github_mod", os.path.join(_parent, "github.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+github = _mod.github
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_COMMIT = {
+    "sha": "abc123def456",
+    "commit": {
+        "author": {"name": "Octocat", "email": "octocat@github.com", "date": "2021-01-01T00:00:00Z"},
+        "committer": {"name": "Octocat", "email": "octocat@github.com", "date": "2021-01-01T00:00:00Z"},
+        "message": "Initial commit",
+    },
+    "html_url": "https://github.com/octocat/Hello-World/commit/abc123",
+    "stats": {"additions": 10, "deletions": 2, "total": 12},
+    "files": [],
+}
+
+SAMPLE_BRANCH = {
+    "name": "main",
+    "protected": True,
+    "commit": {"sha": "abc123", "url": "https://api.github.com/repos/octocat/Hello-World/commits/abc123"},
+    "protection": {},
+}
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+# ---- Commit Actions ----
+
+
+class TestGetCommit:
+    @pytest.mark.asyncio
+    async def test_returns_commit_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_COMMIT)
+
+        result = await github.execute_action(
+            "get_commit", {"owner": "octocat", "repo": "Hello-World", "sha": "abc123def456"}, mock_context
+        )
+
+        assert result.result.data["sha"] == "abc123def456"
+        assert result.result.data["message"] == "Initial commit"
+        assert result.result.data["author"]["name"] == "Octocat"
+
+    @pytest.mark.asyncio
+    async def test_url_includes_sha(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_COMMIT)
+
+        await github.execute_action(
+            "get_commit", {"owner": "octocat", "repo": "Hello-World", "sha": "abc123def456"}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "commits/abc123def456" in url
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("Commit not found")
+
+        result = await github.execute_action(
+            "get_commit", {"owner": "octocat", "repo": "Hello-World", "sha": "bad_sha"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+
+
+class TestListCommits:
+    @pytest.mark.asyncio
+    async def test_returns_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_COMMIT])
+
+        result = await github.execute_action("list_commits", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["sha"] == "abc123def456"
+
+    @pytest.mark.asyncio
+    async def test_filters_applied_to_params(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
+
+        await github.execute_action(
+            "list_commits",
+            {"owner": "octocat", "repo": "Hello-World", "sha": "main", "since": "2021-01-01T00:00:00Z"},
+            mock_context,
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["sha"] == "main"
+        assert params["since"] == "2021-01-01T00:00:00Z"
+
+
+# ---- Branch Actions ----
+
+
+class TestGetBranch:
+    @pytest.mark.asyncio
+    async def test_returns_branch_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_BRANCH)
+
+        result = await github.execute_action(
+            "get_branch", {"owner": "octocat", "repo": "Hello-World", "branch": "main"}, mock_context
+        )
+
+        assert result.result.data["name"] == "main"
+        assert result.result.data["protected"] is True
+
+    @pytest.mark.asyncio
+    async def test_url_includes_branch_name(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_BRANCH)
+
+        await github.execute_action(
+            "get_branch", {"owner": "octocat", "repo": "Hello-World", "branch": "main"}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "branches/main" in url
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("Branch not found")
+
+        result = await github.execute_action(
+            "get_branch", {"owner": "octocat", "repo": "Hello-World", "branch": "nonexistent"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+
+
+class TestListBranches:
+    @pytest.mark.asyncio
+    async def test_returns_branches(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_BRANCH])
+
+        result = await github.execute_action("list_branches", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["name"] == "main"
+
+
+class TestCreateBranch:
+    @pytest.mark.asyncio
+    async def test_creates_branch(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={
+                "ref": "refs/heads/new-branch",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/refs/heads/new-branch",
+                "object": {"sha": "abc123", "type": "commit", "url": "https://..."},
+            },
+        )
+
+        result = await github.execute_action(
+            "create_branch",
+            {"owner": "octocat", "repo": "Hello-World", "branch_name": "new-branch", "sha": "abc123"},
+            mock_context,
+        )
+
+        assert result.result.data["ref"] == "refs/heads/new-branch"
+        assert result.result.data["object"]["sha"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_payload_contains_ref_and_sha(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={"ref": "refs/heads/nb", "url": "", "object": {"sha": "abc", "type": "commit", "url": ""}},
+        )
+
+        await github.execute_action(
+            "create_branch",
+            {"owner": "octocat", "repo": "Hello-World", "branch_name": "nb", "sha": "abc"},
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["ref"] == "refs/heads/nb"
+        assert payload["sha"] == "abc"
+
+
+class TestDeleteBranch:
+    @pytest.mark.asyncio
+    async def test_delete_returns_deleted_true(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=204, headers={}, data=None)
+
+        result = await github.execute_action(
+            "delete_branch", {"owner": "octocat", "repo": "Hello-World", "branch": "old-branch"}, mock_context
+        )
+
+        assert result.result.data["deleted"] is True
+        assert result.result.data["branch"] == "old-branch"
+
+
+class TestGetBranchProtection:
+    @pytest.mark.asyncio
+    async def test_returns_protection_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "required_status_checks": {"contexts": ["ci/test"]},
+                "enforce_admins": {"enabled": True},
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 1,
+                    "dismiss_stale_reviews": False,
+                    "require_code_owner_reviews": False,
+                },
+                "restrictions": None,
+            },
+        )
+
+        result = await github.execute_action(
+            "get_branch_protection", {"owner": "octocat", "repo": "Hello-World", "branch": "main"}, mock_context
+        )
+
+        assert result.result.data["enabled"] is True
+        assert result.result.data["enforce_admins"] is True
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("Branch has no protection rules")
+
+        result = await github.execute_action(
+            "get_branch_protection", {"owner": "octocat", "repo": "Hello-World", "branch": "main"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "Branch protection not available" in result.result.message
+
+
+class TestDiffBranchToBranch:
+    @pytest.mark.asyncio
+    async def test_returns_diff_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "status": "ahead",
+                "ahead_by": 3,
+                "behind_by": 0,
+                "total_commits": 3,
+                "commits": [],
+                "files": [],
+            },
+        )
+
+        result = await github.execute_action(
+            "diff_branch_to_branch",
+            {"owner": "octocat", "repo": "Hello-World", "base_branch": "main", "head_branch": "feature"},
+            mock_context,
+        )
+
+        assert result.result.data["status"] == "ahead"
+        assert result.result.data["ahead_by"] == 3
+
+    @pytest.mark.asyncio
+    async def test_url_contains_compare(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"status": "identical", "ahead_by": 0, "behind_by": 0, "total_commits": 0, "commits": [], "files": []},
+        )
+
+        await github.execute_action(
+            "diff_branch_to_branch",
+            {"owner": "octocat", "repo": "Hello-World", "base_branch": "main", "head_branch": "feature"},
+            mock_context,
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "compare/main...feature" in url

--- a/github/tests/test_github_issues_unit.py
+++ b/github/tests/test_github_issues_unit.py
@@ -1,0 +1,227 @@
+import os
+import sys
+import importlib
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("github_mod", os.path.join(_parent, "github.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+github = _mod.github
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_USER = {"login": "octocat", "avatar_url": "https://github.com/images/octocat.png"}
+
+SAMPLE_ISSUE = {
+    "number": 42,
+    "title": "Found a bug",
+    "body": "Something isn't working",
+    "state": "open",
+    "created_at": "2021-01-01T00:00:00Z",
+    "updated_at": "2021-01-02T00:00:00Z",
+    "closed_at": None,
+    "user": SAMPLE_USER,
+    "assignees": [],
+    "labels": [],
+    "comments": 0,
+    "html_url": "https://github.com/octocat/Hello-World/issues/42",
+}
+
+SAMPLE_COMMENT = {
+    "id": 1,
+    "body": "A comment",
+    "created_at": "2021-01-01T00:00:00Z",
+    "updated_at": "2021-01-01T00:00:00Z",
+    "user": SAMPLE_USER,
+    "html_url": "https://github.com/octocat/Hello-World/issues/42#issuecomment-1",
+}
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+# ---- Issue Actions ----
+
+
+class TestGetIssue:
+    @pytest.mark.asyncio
+    async def test_returns_issue_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_ISSUE)
+
+        result = await github.execute_action(
+            "get_issue", {"owner": "octocat", "repo": "Hello-World", "issue_number": 42}, mock_context
+        )
+
+        assert result.result.data["number"] == 42
+        assert result.result.data["title"] == "Found a bug"
+        assert result.result.data["author"]["login"] == "octocat"
+
+    @pytest.mark.asyncio
+    async def test_request_url_includes_issue_number(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_ISSUE)
+
+        await github.execute_action(
+            "get_issue", {"owner": "octocat", "repo": "Hello-World", "issue_number": 42}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "issues/42" in url
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("Not found")
+
+        result = await github.execute_action(
+            "get_issue", {"owner": "octocat", "repo": "Hello-World", "issue_number": 42}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+
+
+class TestListIssues:
+    @pytest.mark.asyncio
+    async def test_returns_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_ISSUE])
+
+        result = await github.execute_action("list_issues", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["number"] == 42
+
+    @pytest.mark.asyncio
+    async def test_empty_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
+
+        result = await github.execute_action("list_issues", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert result.result.data == []
+
+
+class TestCreateIssue:
+    @pytest.mark.asyncio
+    async def test_creates_issue(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_ISSUE)
+
+        result = await github.execute_action(
+            "create_issue", {"owner": "octocat", "repo": "Hello-World", "title": "Found a bug"}, mock_context
+        )
+
+        assert result.result.data["number"] == 42
+        assert result.result.data["title"] == "Found a bug"
+
+    @pytest.mark.asyncio
+    async def test_request_uses_post(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_ISSUE)
+
+        await github.execute_action(
+            "create_issue", {"owner": "octocat", "repo": "Hello-World", "title": "Found a bug"}, mock_context
+        )
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "POST"
+        assert "issues" in mock_context.fetch.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_title_in_payload(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_ISSUE)
+
+        await github.execute_action(
+            "create_issue", {"owner": "octocat", "repo": "Hello-World", "title": "Found a bug"}, mock_context
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["title"] == "Found a bug"
+
+
+class TestUpdateIssue:
+    @pytest.mark.asyncio
+    async def test_updates_issue(self, mock_context):
+        updated = {**SAMPLE_ISSUE, "state": "closed", "closed_at": "2021-01-03T00:00:00Z"}
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=updated)
+
+        result = await github.execute_action(
+            "update_issue",
+            {"owner": "octocat", "repo": "Hello-World", "issue_number": 42, "state": "closed"},
+            mock_context,
+        )
+
+        assert result.result.data["state"] == "closed"
+
+    @pytest.mark.asyncio
+    async def test_request_uses_patch(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_ISSUE)
+
+        await github.execute_action(
+            "update_issue", {"owner": "octocat", "repo": "Hello-World", "issue_number": 42}, mock_context
+        )
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "PATCH"
+
+
+class TestCreateIssueComment:
+    @pytest.mark.asyncio
+    async def test_creates_comment(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_COMMENT)
+
+        result = await github.execute_action(
+            "create_issue_comment",
+            {"owner": "octocat", "repo": "Hello-World", "issue_number": 42, "body": "A comment"},
+            mock_context,
+        )
+
+        assert result.result.data["id"] == 1
+        assert result.result.data["body"] == "A comment"
+
+    @pytest.mark.asyncio
+    async def test_body_in_payload(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_COMMENT)
+
+        await github.execute_action(
+            "create_issue_comment",
+            {"owner": "octocat", "repo": "Hello-World", "issue_number": 42, "body": "A comment"},
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["body"] == "A comment"
+
+
+class TestGetIssueComments:
+    @pytest.mark.asyncio
+    async def test_returns_comments_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_COMMENT])
+
+        result = await github.execute_action(
+            "get_issue_comments", {"owner": "octocat", "repo": "Hello-World", "issue_number": 42}, mock_context
+        )
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["body"] == "A comment"
+
+    @pytest.mark.asyncio
+    async def test_url_includes_issue_comments_path(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
+
+        await github.execute_action(
+            "get_issue_comments", {"owner": "octocat", "repo": "Hello-World", "issue_number": 42}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "issues/42/comments" in url

--- a/github/tests/test_github_misc_unit.py
+++ b/github/tests/test_github_misc_unit.py
@@ -1,0 +1,521 @@
+import os
+import sys
+import importlib
+import base64
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("github_mod", os.path.join(_parent, "github.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+github = _mod.github
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+# ---- Webhook Actions ----
+
+
+class TestCreateWebhook:
+    @pytest.mark.asyncio
+    async def test_creates_webhook(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={
+                "id": 1,
+                "name": "web",
+                "active": True,
+                "events": ["push"],
+                "config": {"url": "https://example.com/webhook", "content_type": "json"},
+                "created_at": "2021-01-01T00:00:00Z",
+                "updated_at": "2021-01-01T00:00:00Z",
+                "url": "https://api.github.com/repos/octocat/Hello-World/hooks/1",
+            },
+        )
+
+        result = await github.execute_action(
+            "create_webhook",
+            {"owner": "octocat", "repo": "Hello-World", "url": "https://example.com/webhook", "events": ["push"]},
+            mock_context,
+        )
+
+        assert result.result.data["id"] == 1
+        assert result.result.data["active"] is True
+        assert result.result.data["events"] == ["push"]
+
+    @pytest.mark.asyncio
+    async def test_request_uses_post(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={
+                "id": 1,
+                "name": "web",
+                "active": True,
+                "events": ["push"],
+                "config": {"url": "https://...", "content_type": "json"},
+                "created_at": "",
+                "updated_at": "",
+                "url": "",
+            },
+        )
+
+        await github.execute_action(
+            "create_webhook",
+            {"owner": "octocat", "repo": "Hello-World", "url": "https://example.com/webhook", "events": ["push"]},
+            mock_context,
+        )
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "POST"
+
+
+class TestDeleteWebhook:
+    @pytest.mark.asyncio
+    async def test_delete_returns_deleted_true(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=204, headers={}, data=None)
+
+        result = await github.execute_action(
+            "delete_webhook", {"owner": "octocat", "repo": "Hello-World", "hook_id": 42}, mock_context
+        )
+
+        assert result.result.data["deleted"] is True
+        assert result.result.data["hook_id"] == 42
+
+
+class TestListWebhooks:
+    @pytest.mark.asyncio
+    async def test_returns_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data=[
+                {
+                    "id": 1,
+                    "name": "web",
+                    "active": True,
+                    "events": ["push"],
+                    "config": {"url": "https://example.com/webhook", "content_type": "json"},
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z",
+                    "url": "https://api.github.com/...",
+                }
+            ],
+        )
+
+        result = await github.execute_action("list_webhooks", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["id"] == 1
+
+
+# ---- File Operations ----
+
+
+class TestGetFileContent:
+    @pytest.mark.asyncio
+    async def test_returns_decoded_content(self, mock_context):
+        raw_content = base64.b64encode(b"Hello, World!").decode("utf-8")
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "content": raw_content + "\n",
+                "sha": "file_sha_123",
+                "size": 13,
+                "name": "README.md",
+                "path": "README.md",
+            },
+        )
+
+        result = await github.execute_action(
+            "get_file_content", {"owner": "octocat", "repo": "Hello-World", "path": "README.md"}, mock_context
+        )
+
+        assert result.result.data["content"] == "Hello, World!"
+        assert result.result.data["sha"] == "file_sha_123"
+        assert result.result.data["name"] == "README.md"
+
+    @pytest.mark.asyncio
+    async def test_url_includes_contents_path(self, mock_context):
+        raw_content = base64.b64encode(b"test").decode("utf-8")
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"content": raw_content, "sha": "x", "size": 4, "name": "test.txt", "path": "test.txt"},
+        )
+
+        await github.execute_action(
+            "get_file_content", {"owner": "octocat", "repo": "Hello-World", "path": "test.txt"}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "contents/test.txt" in url
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("File not found")
+
+        result = await github.execute_action(
+            "get_file_content", {"owner": "octocat", "repo": "Hello-World", "path": "missing.txt"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+
+
+class TestCreateFile:
+    @pytest.mark.asyncio
+    async def test_creates_file(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={
+                "content": {"name": "hello.txt", "path": "hello.txt", "sha": "new_sha", "size": 5},
+                "commit": {"sha": "commit_sha", "message": "Add hello.txt"},
+            },
+        )
+
+        result = await github.execute_action(
+            "create_file",
+            {
+                "owner": "octocat",
+                "repo": "Hello-World",
+                "path": "hello.txt",
+                "message": "Add hello.txt",
+                "content": "Hello",
+            },
+            mock_context,
+        )
+
+        assert result.result.data["content"]["name"] == "hello.txt"
+        assert result.result.data["commit"]["sha"] == "commit_sha"
+
+    @pytest.mark.asyncio
+    async def test_content_is_base64_encoded(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={
+                "content": {"name": "f.txt", "path": "f.txt", "sha": "s", "size": 4},
+                "commit": {"sha": "c", "message": "m"},
+            },
+        )
+
+        await github.execute_action(
+            "create_file",
+            {"owner": "octocat", "repo": "Hello-World", "path": "f.txt", "message": "m", "content": "test"},
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["content"] == base64.b64encode(b"test").decode("utf-8")
+
+
+class TestDeleteFile:
+    @pytest.mark.asyncio
+    async def test_delete_returns_deleted_true(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"commit": {"sha": "del_commit", "message": "Remove file"}},
+        )
+
+        result = await github.execute_action(
+            "delete_file",
+            {"owner": "octocat", "repo": "Hello-World", "path": "old.txt", "message": "Remove file", "sha": "file_sha"},
+            mock_context,
+        )
+
+        assert result.result.data["deleted"] is True
+        assert result.result.data["path"] == "old.txt"
+        assert result.result.data["commit"]["sha"] == "del_commit"
+
+
+# ---- User and Org Actions ----
+
+
+class TestGetUser:
+    @pytest.mark.asyncio
+    async def test_returns_user_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "login": "octocat",
+                "id": 1,
+                "name": "The Octocat",
+                "company": "@github",
+                "blog": "https://github.blog",
+                "location": "San Francisco, CA",
+                "email": None,
+                "bio": "A GitHub mascot",
+                "public_repos": 8,
+                "public_gists": 8,
+                "followers": 4000,
+                "following": 9,
+                "created_at": "2011-01-25T18:44:36Z",
+                "updated_at": "2021-01-01T00:00:00Z",
+                "avatar_url": "https://github.com/images/error/octocat.gif",
+                "html_url": "https://github.com/octocat",
+            },
+        )
+
+        result = await github.execute_action("get_user", {"username": "octocat"}, mock_context)
+
+        assert result.result.data["login"] == "octocat"
+        assert result.result.data["public_repos"] == 8
+
+    @pytest.mark.asyncio
+    async def test_with_username_uses_users_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "login": "octocat",
+                "id": 1,
+                "name": None,
+                "company": None,
+                "blog": None,
+                "location": None,
+                "email": None,
+                "bio": None,
+                "public_repos": 0,
+                "public_gists": 0,
+                "followers": 0,
+                "following": 0,
+                "created_at": "",
+                "updated_at": "",
+                "avatar_url": "",
+                "html_url": "",
+            },
+        )
+
+        await github.execute_action("get_user", {"username": "octocat"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "users/octocat" in url
+
+
+# ---- Workflow Actions ----
+
+
+class TestListWorkflows:
+    @pytest.mark.asyncio
+    async def test_returns_workflows(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "total_count": 1,
+                "workflows": [
+                    {
+                        "id": 161335,
+                        "name": "CI",
+                        "path": ".github/workflows/ci.yml",
+                        "state": "active",
+                        "created_at": "2021-01-01T00:00:00Z",
+                        "updated_at": "2021-01-01T00:00:00Z",
+                        "html_url": "https://github.com/octocat/Hello-World/actions/workflows/ci.yml",
+                    }
+                ],
+            },
+        )
+
+        result = await github.execute_action(
+            "list_workflows", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["name"] == "CI"
+        assert result.result.data[0]["state"] == "active"
+
+
+class TestGetRateLimit:
+    @pytest.mark.asyncio
+    async def test_returns_rate_limit_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "resources": {
+                    "core": {"limit": 5000, "remaining": 4999, "reset": 1372700873, "used": 1},
+                    "search": {"limit": 30, "remaining": 18, "reset": 1372697452, "used": 12},
+                    "graphql": {"limit": 5000, "remaining": 4993, "reset": 1372700389, "used": 7},
+                }
+            },
+        )
+
+        result = await github.execute_action("get_rate_limit", {}, mock_context)
+
+        assert result.result.data["core"]["limit"] == 5000
+        assert result.result.data["core"]["remaining"] == 4999
+        assert result.result.data["search"]["limit"] == 30
+
+    @pytest.mark.asyncio
+    async def test_url_is_rate_limit(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "resources": {
+                    "core": {"limit": 5000, "remaining": 5000, "reset": 0, "used": 0},
+                    "search": {"limit": 30, "remaining": 30, "reset": 0, "used": 0},
+                    "graphql": {"limit": 5000, "remaining": 5000, "reset": 0, "used": 0},
+                }
+            },
+        )
+
+        await github.execute_action("get_rate_limit", {}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "rate_limit" in url
+
+
+# ---- Tags and Releases ----
+
+
+class TestListTags:
+    @pytest.mark.asyncio
+    async def test_returns_tags(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data=[
+                {
+                    "name": "v1.0.0",
+                    "commit": {"sha": "abc123", "url": "https://..."},
+                    "zipball_url": "https://...",
+                    "tarball_url": "https://...",
+                    "node_id": "MDM6UmVm",
+                }
+            ],
+        )
+
+        result = await github.execute_action("list_tags", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["name"] == "v1.0.0"
+
+
+class TestGetLatestRelease:
+    @pytest.mark.asyncio
+    async def test_returns_latest_release(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "id": 1,
+                "tag_name": "v1.0.0",
+                "name": "First release",
+                "body": "Release notes",
+                "draft": False,
+                "prerelease": False,
+                "created_at": "2021-01-01T00:00:00Z",
+                "published_at": "2021-01-01T00:00:00Z",
+                "html_url": "https://github.com/octocat/Hello-World/releases/tag/v1.0.0",
+                "assets": [],
+            },
+        )
+
+        result = await github.execute_action(
+            "get_latest_release", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert result.result.data["tag_name"] == "v1.0.0"
+
+    @pytest.mark.asyncio
+    async def test_url_contains_releases_latest(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "id": 1,
+                "tag_name": "v1.0.0",
+                "name": None,
+                "body": None,
+                "draft": False,
+                "prerelease": False,
+                "created_at": "",
+                "published_at": "",
+                "html_url": "",
+                "assets": [],
+            },
+        )
+
+        await github.execute_action("get_latest_release", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "releases/latest" in url
+
+
+class TestGetReleaseByTag:
+    @pytest.mark.asyncio
+    async def test_returns_release_for_tag(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "id": 1,
+                "tag_name": "v1.0.0",
+                "name": "First release",
+                "body": None,
+                "draft": False,
+                "prerelease": False,
+                "created_at": "",
+                "published_at": "",
+                "html_url": "",
+                "assets": [],
+            },
+        )
+
+        result = await github.execute_action(
+            "get_release_by_tag", {"owner": "octocat", "repo": "Hello-World", "tag": "v1.0.0"}, mock_context
+        )
+
+        assert result.result.data["tag_name"] == "v1.0.0"
+
+    @pytest.mark.asyncio
+    async def test_tag_url_encoded_in_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "id": 1,
+                "tag_name": "release/2024-01",
+                "name": None,
+                "body": None,
+                "draft": False,
+                "prerelease": False,
+                "created_at": "",
+                "published_at": "",
+                "html_url": "",
+                "assets": [],
+            },
+        )
+
+        await github.execute_action(
+            "get_release_by_tag", {"owner": "octocat", "repo": "Hello-World", "tag": "release/2024-01"}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "release%2F2024-01" in url

--- a/github/tests/test_github_prs_unit.py
+++ b/github/tests/test_github_prs_unit.py
@@ -1,0 +1,288 @@
+import os
+import sys
+import importlib
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("github_mod", os.path.join(_parent, "github.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+github = _mod.github
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_USER = {"login": "octocat", "id": 1, "avatar_url": "https://github.com/octocat.png"}
+
+SAMPLE_REPO_REF = {"name": "Hello-World", "full_name": "octocat/Hello-World", "id": 1}
+
+SAMPLE_PR = {
+    "id": 100,
+    "node_id": "PR_001",
+    "number": 7,
+    "title": "Fix the bug",
+    "body": "This PR fixes the bug",
+    "state": "open",
+    "created_at": "2021-01-01T00:00:00Z",
+    "updated_at": "2021-01-02T00:00:00Z",
+    "closed_at": None,
+    "merged_at": None,
+    "draft": False,
+    "merged": False,
+    "mergeable": True,
+    "mergeable_state": "clean",
+    "merge_commit_sha": None,
+    "html_url": "https://github.com/octocat/Hello-World/pull/7",
+    "url": "https://api.github.com/repos/octocat/Hello-World/pulls/7",
+    "diff_url": "https://github.com/octocat/Hello-World/pull/7.diff",
+    "patch_url": "https://github.com/octocat/Hello-World/pull/7.patch",
+    "user": SAMPLE_USER,
+    "assignee": None,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [],
+    "milestone": None,
+    "author_association": "OWNER",
+    "comments": 0,
+    "review_comments": 0,
+    "commits": 1,
+    "additions": 10,
+    "deletions": 2,
+    "changed_files": 1,
+    "head": {"ref": "feature-branch", "sha": "abc123", "repo": SAMPLE_REPO_REF},
+    "base": {"ref": "main", "sha": "def456", "repo": SAMPLE_REPO_REF},
+}
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+class TestGetPullRequest:
+    @pytest.mark.asyncio
+    async def test_returns_pr_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_PR)
+
+        result = await github.execute_action(
+            "get_pull_request", {"owner": "octocat", "repo": "Hello-World", "pull_number": 7}, mock_context
+        )
+
+        assert result.result.data["number"] == 7
+        assert result.result.data["title"] == "Fix the bug"
+        assert result.result.data["head"]["ref"] == "feature-branch"
+
+    @pytest.mark.asyncio
+    async def test_url_includes_pull_number(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_PR)
+
+        await github.execute_action(
+            "get_pull_request", {"owner": "octocat", "repo": "Hello-World", "pull_number": 7}, mock_context
+        )
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "pulls/7" in url
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("PR not found")
+
+        result = await github.execute_action(
+            "get_pull_request", {"owner": "octocat", "repo": "Hello-World", "pull_number": 7}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "PR not found" in result.result.message
+
+
+class TestListPullRequests:
+    @pytest.mark.asyncio
+    async def test_returns_prs_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200, headers={}, data={"items": [SAMPLE_PR], "total_count": 1}
+        )
+
+        result = await github.execute_action(
+            "list_pull_requests", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["number"] == 7
+
+    @pytest.mark.asyncio
+    async def test_uses_search_api(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"items": [], "total_count": 0})
+
+        await github.execute_action("list_pull_requests", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "search/issues" in url
+
+    @pytest.mark.asyncio
+    async def test_search_query_includes_is_pr(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"items": [], "total_count": 0})
+
+        await github.execute_action("list_pull_requests", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert "is:pr" in params["q"]
+        assert "octocat/Hello-World" in params["q"]
+
+
+class TestCreatePullRequest:
+    @pytest.mark.asyncio
+    async def test_creates_pr(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_PR)
+
+        result = await github.execute_action(
+            "create_pull_request",
+            {
+                "owner": "octocat",
+                "repo": "Hello-World",
+                "title": "Fix the bug",
+                "head": "feature-branch",
+                "base": "main",
+            },
+            mock_context,
+        )
+
+        assert result.result.data["number"] == 7
+        assert result.result.data["title"] == "Fix the bug"
+
+    @pytest.mark.asyncio
+    async def test_request_uses_post(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_PR)
+
+        await github.execute_action(
+            "create_pull_request",
+            {"owner": "octocat", "repo": "Hello-World", "title": "Fix", "head": "feature", "base": "main"},
+            mock_context,
+        )
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "POST"
+
+    @pytest.mark.asyncio
+    async def test_payload_contains_required_fields(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_PR)
+
+        await github.execute_action(
+            "create_pull_request",
+            {"owner": "octocat", "repo": "Hello-World", "title": "Fix", "head": "feature", "base": "main"},
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["title"] == "Fix"
+        assert payload["head"] == "feature"
+        assert payload["base"] == "main"
+
+
+class TestMergePullRequest:
+    @pytest.mark.asyncio
+    async def test_merge_returns_merged_true(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"sha": "abc123", "merged": True, "message": "Pull Request successfully merged"},
+        )
+
+        result = await github.execute_action(
+            "merge_pull_request",
+            {"owner": "octocat", "repo": "Hello-World", "pull_number": 7},
+            mock_context,
+        )
+
+        assert result.result.data["merged"] is True
+        assert result.result.data["sha"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_request_uses_put(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"sha": "abc"})
+
+        await github.execute_action(
+            "merge_pull_request",
+            {"owner": "octocat", "repo": "Hello-World", "pull_number": 7},
+            mock_context,
+        )
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "PUT"
+        assert "pulls/7/merge" in mock_context.fetch.call_args.args[0]
+
+
+class TestAddPullRequestReviewers:
+    @pytest.mark.asyncio
+    async def test_adds_reviewers(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=201,
+            headers={},
+            data={"requested_reviewers": [{"login": "reviewer1", "id": 2}], "requested_teams": []},
+        )
+
+        result = await github.execute_action(
+            "add_pull_request_reviewers",
+            {"owner": "octocat", "repo": "Hello-World", "pull_number": 7, "reviewers": ["reviewer1"]},
+            mock_context,
+        )
+
+        assert len(result.result.data["requested_reviewers"]) == 1
+        assert result.result.data["requested_reviewers"][0]["login"] == "reviewer1"
+
+
+class TestListPullRequestReviewers:
+    @pytest.mark.asyncio
+    async def test_returns_reviewers(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"users": [{"login": "reviewer1", "id": 2, "avatar_url": "https://..."}], "teams": []},
+        )
+
+        result = await github.execute_action(
+            "list_pull_request_reviewers",
+            {"owner": "octocat", "repo": "Hello-World", "pull_number": 7},
+            mock_context,
+        )
+
+        assert len(result.result.data["users"]) == 1
+        assert result.result.data["users"][0]["login"] == "reviewer1"
+
+
+class TestCreatePullRequestReview:
+    @pytest.mark.asyncio
+    async def test_creates_review(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "id": 99,
+                "body": "LGTM",
+                "state": "APPROVED",
+                "submitted_at": "2021-01-01T00:00:00Z",
+                "user": {"login": "reviewer1", "avatar_url": "https://..."},
+                "html_url": "https://github.com/octocat/Hello-World/pull/7#pullrequestreview-99",
+            },
+        )
+
+        result = await github.execute_action(
+            "create_pull_request_review",
+            {"owner": "octocat", "repo": "Hello-World", "pull_number": 7, "body": "LGTM", "event": "APPROVE"},
+            mock_context,
+        )
+
+        assert result.result.data["id"] == 99
+        assert result.result.data["state"] == "APPROVED"

--- a/github/tests/test_github_repos_unit.py
+++ b/github/tests/test_github_repos_unit.py
@@ -1,0 +1,242 @@
+import os
+import sys
+import importlib
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("github_mod", os.path.join(_parent, "github.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+github = _mod.github
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_REPO = {
+    "id": 1,
+    "name": "Hello-World",
+    "full_name": "octocat/Hello-World",
+    "description": "A test repo",
+    "private": False,
+    "fork": False,
+    "default_branch": "main",
+    "created_at": "2020-01-01T00:00:00Z",
+    "updated_at": "2021-01-01T00:00:00Z",
+    "pushed_at": "2021-01-01T00:00:00Z",
+    "clone_url": "https://github.com/octocat/Hello-World.git",
+    "ssh_url": "git@github.com:octocat/Hello-World.git",
+    "html_url": "https://github.com/octocat/Hello-World",
+    "language": "Python",
+    "visibility": "public",
+    "forks_count": 5,
+    "stargazers_count": 10,
+    "watchers_count": 10,
+    "open_issues_count": 2,
+    "has_issues": True,
+    "has_wiki": True,
+}
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+# ---- Repository Actions ----
+
+
+class TestGetRepository:
+    @pytest.mark.asyncio
+    async def test_returns_repo_data(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_REPO)
+
+        result = await github.execute_action(
+            "get_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert result.result.data["name"] == "Hello-World"
+        assert result.result.data["full_name"] == "octocat/Hello-World"
+
+    @pytest.mark.asyncio
+    async def test_request_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_REPO)
+
+        await github.execute_action("get_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "repos/octocat/Hello-World" in url
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("API error")
+
+        result = await github.execute_action(
+            "get_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "API error" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_token_returns_action_error(self, mock_context):
+        mock_context.auth = {"credentials": {}}
+
+        result = await github.execute_action(
+            "get_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "token" in result.result.message.lower()
+
+
+class TestListRepositories:
+    @pytest.mark.asyncio
+    async def test_returns_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_REPO])
+
+        result = await github.execute_action("list_repositories", {}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["name"] == "Hello-World"
+
+    @pytest.mark.asyncio
+    async def test_empty_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
+
+        result = await github.execute_action("list_repositories", {}, mock_context)
+
+        assert result.result.data == []
+
+
+class TestCreateRepository:
+    @pytest.mark.asyncio
+    async def test_creates_repo(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_REPO)
+
+        result = await github.execute_action("create_repository", {"name": "Hello-World"}, mock_context)
+
+        assert result.result.data["name"] == "Hello-World"
+        assert result.result.data["clone_url"] == SAMPLE_REPO["clone_url"]
+
+    @pytest.mark.asyncio
+    async def test_request_uses_post(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_REPO)
+
+        await github.execute_action("create_repository", {"name": "Hello-World"}, mock_context)
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "POST"
+
+    @pytest.mark.asyncio
+    async def test_org_repo_uses_org_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_REPO)
+
+        await github.execute_action("create_repository", {"name": "Hello-World", "org": "myorg"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "orgs/myorg/repos" in url
+
+    @pytest.mark.asyncio
+    async def test_user_repo_uses_user_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=201, headers={}, data=SAMPLE_REPO)
+
+        await github.execute_action("create_repository", {"name": "Hello-World"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "user/repos" in url
+
+
+class TestDeleteRepository:
+    @pytest.mark.asyncio
+    async def test_delete_returns_deleted_true(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=204, headers={}, data=None)
+
+        result = await github.execute_action(
+            "delete_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context
+        )
+
+        assert result.result.data["deleted"] is True
+        assert "octocat/Hello-World" in result.result.data["repository"]
+
+    @pytest.mark.asyncio
+    async def test_request_uses_delete(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=204, headers={}, data=None)
+
+        await github.execute_action("delete_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "DELETE"
+
+
+class TestUpdateRepository:
+    @pytest.mark.asyncio
+    async def test_updates_repo(self, mock_context):
+        updated = {**SAMPLE_REPO, "description": "Updated description"}
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=updated)
+
+        result = await github.execute_action(
+            "update_repository",
+            {"owner": "octocat", "repo": "Hello-World", "description": "Updated description"},
+            mock_context,
+        )
+
+        assert result.result.data["name"] == "Hello-World"
+
+    @pytest.mark.asyncio
+    async def test_request_uses_patch(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_REPO)
+
+        await github.execute_action("update_repository", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert mock_context.fetch.call_args.kwargs["method"] == "PATCH"
+
+
+class TestListUserRepositories:
+    @pytest.mark.asyncio
+    async def test_returns_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_REPO])
+
+        result = await github.execute_action("list_user_repositories", {}, mock_context)
+
+        assert isinstance(result.result.data, list)
+        assert result.result.data[0]["name"] == "Hello-World"
+
+    @pytest.mark.asyncio
+    async def test_with_username_uses_users_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
+
+        await github.execute_action("list_user_repositories", {"username": "octocat"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "users/octocat/repos" in url
+
+
+class TestListOrganizationRepositories:
+    @pytest.mark.asyncio
+    async def test_returns_list(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_REPO])
+
+        result = await github.execute_action("list_organization_repositories", {"org": "myorg"}, mock_context)
+
+        assert isinstance(result.result.data, list)
+
+    @pytest.mark.asyncio
+    async def test_uses_org_url(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
+
+        await github.execute_action("list_organization_repositories", {"org": "myorg"}, mock_context)
+
+        url = mock_context.fetch.call_args.args[0]
+        assert "orgs/myorg/repos" in url


### PR DESCRIPTION
## Summary

All GitHub actions use a shared `@handle_github_errors` decorator for error handling. On any exception (including 404s), the decorator was returning `ActionResult(data={"error": ..., "result": False})`. This dict doesn't satisfy the output schema of actions like `list_organization_repositories` (which expects `repositories: array`), causing the SDK to throw a `ValidationError` instead of returning a clean error to the caller.

This has been firing in production since December 2025 (232 instances).

## Root Cause

`ActionError` was not imported and the decorator used `ActionResult` for both success and error paths. The SDK validates `ActionResult.data` against the output schema — an error dict will never match an action's success schema.

## Changes

- `github/github.py` — import `ActionError`; replace both `ActionResult` error returns in the decorator with `ActionError(message=...)` — fixes all actions at once since they all share the decorator

## Before / After

| Scenario | Before | After |
|---|---|---|
| 404 / any exception | `ValidationError` crash | Clean `ActionError` returned to caller |
| No access token | `ValidationError` crash | Clean `ActionError` returned to caller |