### PR TITLE
feat(app-business-reviews): upgrade SDK to 2.0.0, add pytest unit tests

### DIFF
--- a/app-business-reviews/app_business_reviews.py
+++ b/app-business-reviews/app_business_reviews.py
@@ -1,4 +1,4 @@
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult, ActionError
 from typing import Dict, Any
 
 # Create the integration using the config.json
@@ -29,7 +29,7 @@ class SearchAppsIOS(ActionHandler):
         response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
         # Extract apps from organic results
-        organic_results = response.get("organic_results", [])
+        organic_results = response.data.get("organic_results", [])
         limit = inputs.get("num", 10)
         apps = []
 
@@ -48,7 +48,7 @@ class SearchAppsIOS(ActionHandler):
             }
             apps.append(app)
 
-        return {"apps": apps, "total_results": len(apps)}
+        return ActionResult(data={"apps": apps, "total_results": len(apps)}, cost_usd=0.0)
 
 
 @app_business_reviews.action("get_reviews_app_store")
@@ -61,7 +61,7 @@ class GetReviewsAppStore(ActionHandler):
         app_name = inputs.get("app_name")
 
         if not product_id and not app_name:
-            raise ValueError("Either product_id or app_name must be provided")
+            return ActionError(message="Either product_id or app_name must be provided")
 
         # If app_name is provided but no product_id, search for the app first
         if app_name and not product_id:
@@ -73,16 +73,16 @@ class GetReviewsAppStore(ActionHandler):
 
             search_response = await context.fetch("https://serpapi.com/search", method="GET", params=search_params)
 
-            organic_results = search_response.get("organic_results", [])
+            organic_results = search_response.data.get("organic_results", [])
             if not organic_results:
-                raise ValueError(f"No apps found for search term: {app_name}")
+                return ActionError(message=f"No apps found for search term: {app_name}")
 
             # Get the first result's product ID
             first_result = organic_results[0]
             product_id = str(first_result.get("id"))
 
             if not product_id:
-                raise ValueError(f"Could not extract product ID for app: {app_name}")
+                return ActionError(message=f"Could not extract product ID for app: {app_name}")
 
         # Build SerpApi request parameters for reviews
         params = {"api_key": api_key, "engine": "apple_reviews", "product_id": product_id}
@@ -110,7 +110,7 @@ class GetReviewsAppStore(ActionHandler):
             response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
             # Extract reviews data from current page
-            page_reviews = response.get("reviews", [])
+            page_reviews = response.data.get("reviews", [])
             if not page_reviews:
                 break
 
@@ -139,16 +139,19 @@ class GetReviewsAppStore(ActionHandler):
             current_page += 1
 
             # Check if there are more pages using pagination info
-            pagination_info = response.get("serpapi_pagination", {})
+            pagination_info = response.data.get("serpapi_pagination", {})
             if not pagination_info.get("next"):
                 break
 
-        return {
-            "reviews": all_reviews,
-            "total_reviews": len(all_reviews),
-            "app_name": app_title,
-            "product_id": product_id,
-        }
+        return ActionResult(
+            data={
+                "reviews": all_reviews,
+                "total_reviews": len(all_reviews),
+                "app_name": app_title,
+                "product_id": product_id,
+            },
+            cost_usd=0.0,
+        )
 
 
 # ---- Google Play Store Actions ----
@@ -166,7 +169,7 @@ class SearchAppsAndroid(ActionHandler):
         response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
         # Extract apps from organic results
-        organic_results = response.get("organic_results", [])
+        organic_results = response.data.get("organic_results", [])
         limit = inputs.get("limit", 10)
         apps = []
 
@@ -189,7 +192,7 @@ class SearchAppsAndroid(ActionHandler):
             if len(apps) >= limit:
                 break
 
-        return {"apps": apps, "total_results": len(apps)}
+        return ActionResult(data={"apps": apps, "total_results": len(apps)}, cost_usd=0.0)
 
 
 @app_business_reviews.action("get_reviews_google_play")
@@ -202,7 +205,7 @@ class GetReviewsGooglePlay(ActionHandler):
         app_name = inputs.get("app_name")
 
         if not product_id and not app_name:
-            raise ValueError("Either product_id or app_name must be provided")
+            return ActionError(message="Either product_id or app_name must be provided")
 
         # If app_name is provided but no product_id, search for the app first
         if app_name and not product_id:
@@ -210,9 +213,9 @@ class GetReviewsGooglePlay(ActionHandler):
 
             search_response = await context.fetch("https://serpapi.com/search", method="GET", params=search_params)
 
-            organic_results = search_response.get("organic_results", [])
+            organic_results = search_response.data.get("organic_results", [])
             if not organic_results:
-                raise ValueError(f"No apps found for search term: {app_name}")
+                return ActionError(message=f"No apps found for search term: {app_name}")
 
             # Get the first result's product ID from nested items structure
             product_id = None
@@ -224,7 +227,7 @@ class GetReviewsGooglePlay(ActionHandler):
                     break
 
             if not product_id:
-                raise ValueError(f"Could not extract product ID for app: {app_name}")
+                return ActionError(message=f"Could not extract product ID for app: {app_name}")
 
         # Build SerpApi request parameters
         params = {
@@ -251,6 +254,7 @@ class GetReviewsGooglePlay(ActionHandler):
         all_reviews = []
         next_page_token = None
         pages_fetched = 0
+        response = None
 
         # Fetch reviews with pagination
         while pages_fetched < max_pages:
@@ -265,7 +269,7 @@ class GetReviewsGooglePlay(ActionHandler):
             response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
             # Extract reviews data from current page
-            page_reviews = response.get("reviews", [])
+            page_reviews = response.data.get("reviews", [])
             if not page_reviews:
                 break
 
@@ -285,21 +289,24 @@ class GetReviewsGooglePlay(ActionHandler):
             pages_fetched += 1
 
             # Check if there's a next page
-            pagination_info = response.get("serpapi_pagination", {})
+            pagination_info = response.data.get("serpapi_pagination", {})
             next_page_token = pagination_info.get("next_page_token")
             if not next_page_token:
                 break
 
         # Extract app information from the response
-        app_info = response.get("product_info", {})
+        app_info = response.data.get("product_info", {}) if response is not None else {}
 
-        return {
-            "reviews": all_reviews,
-            "total_reviews": len(all_reviews),
-            "app_name": app_info.get("title", ""),
-            "app_rating": app_info.get("rating") or 0.0,
-            "product_id": product_id,
-        }
+        return ActionResult(
+            data={
+                "reviews": all_reviews,
+                "total_reviews": len(all_reviews),
+                "app_name": app_info.get("title", ""),
+                "app_rating": app_info.get("rating") or 0.0,
+                "product_id": product_id,
+            },
+            cost_usd=0.0,
+        )
 
 
 # ---- Google Maps Actions ----
@@ -323,7 +330,7 @@ class SearchPlacesGoogleMaps(ActionHandler):
         response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
         # Extract places from local results
-        local_results = response.get("local_results", [])
+        local_results = response.data.get("local_results", [])
         limit = inputs.get("num_results", 5)
         places = []
 
@@ -340,7 +347,7 @@ class SearchPlacesGoogleMaps(ActionHandler):
             }
             places.append(place)
 
-        return {"places": places, "total_results": len(places)}
+        return ActionResult(data={"places": places, "total_results": len(places)}, cost_usd=0.0)
 
 
 @app_business_reviews.action("get_reviews_google_maps")
@@ -355,7 +362,7 @@ class GetReviewsGoogleMaps(ActionHandler):
         local_results = []  # Initialize to store search results
 
         if not place_id and not data_id and not query:
-            raise ValueError("Either place_id, data_id, or query (business name) must be provided")
+            return ActionError(message="Either place_id, data_id, or query (business name) must be provided")
 
         # If query is provided but no place_id/data_id, search for the place first
         if query and not place_id and not data_id:
@@ -369,7 +376,7 @@ class GetReviewsGoogleMaps(ActionHandler):
             # Search for the place to get place_id and data_id
             search_response = await context.fetch("https://serpapi.com/search", method="GET", params=search_params)
 
-            local_results = search_response.get("local_results", [])
+            local_results = search_response.data.get("local_results", [])
             if not local_results:
                 # Provide helpful error message
                 suggestion = (
@@ -377,7 +384,7 @@ class GetReviewsGoogleMaps(ActionHandler):
                     "Visit: https://developers.google.com/maps/documentation/places/web-service/"
                     "place-id to find Place ID manually."
                 )
-                raise ValueError(suggestion)
+                return ActionError(message=suggestion)
 
             # Get the first result's place_id and data_id
             first_result = local_results[0]
@@ -385,9 +392,11 @@ class GetReviewsGoogleMaps(ActionHandler):
             data_id = first_result.get("data_id")
 
             if not place_id and not data_id:
-                raise ValueError(
-                    f"Could not extract place_id or data_id for business: {search_query}. "
-                    "The search returned results but they don't contain required identifiers."
+                return ActionError(
+                    message=(
+                        f"Could not extract place_id or data_id for business: {search_query}. "
+                        "The search returned results but they don't contain required identifiers."
+                    )
                 )
 
         # Build SerpApi request parameters for reviews
@@ -399,7 +408,7 @@ class GetReviewsGoogleMaps(ActionHandler):
         elif data_id:
             params["data_id"] = data_id
         else:
-            raise ValueError("Could not resolve place_id or data_id from the provided query")
+            return ActionError(message="Could not resolve place_id or data_id from the provided query")
 
         # Add sort parameter if provided
         if inputs.get("sort_by"):
@@ -411,6 +420,7 @@ class GetReviewsGoogleMaps(ActionHandler):
         all_reviews = []
         next_page_token = None
         pages_fetched = 0
+        response = None
 
         # Fetch reviews with pagination
         while pages_fetched < max_pages:
@@ -426,7 +436,7 @@ class GetReviewsGoogleMaps(ActionHandler):
             response = await context.fetch("https://serpapi.com/search", method="GET", params=params)
 
             # Extract reviews data from current page
-            page_reviews = response.get("reviews", [])
+            page_reviews = response.data.get("reviews", [])
             if not page_reviews:
                 break
 
@@ -444,12 +454,12 @@ class GetReviewsGoogleMaps(ActionHandler):
             pages_fetched += 1
 
             # Check if there's a next page
-            next_page_token = response.get("serpapi_pagination", {}).get("next_page_token")
+            next_page_token = response.data.get("serpapi_pagination", {}).get("next_page_token")
             if not next_page_token:
                 break
 
         # Extract business information from the last response
-        place_info = response.get("place_info", {})
+        place_info = response.data.get("place_info", {}) if response is not None else {}
 
         # Use business name from search result if we searched, otherwise from place_info
         business_name = place_info.get("title", "")
@@ -458,10 +468,13 @@ class GetReviewsGoogleMaps(ActionHandler):
             if local_results:
                 business_name = local_results[0].get("title", business_name)
 
-        return {
-            "reviews": all_reviews,
-            "total_reviews": len(all_reviews),
-            "average_rating": place_info.get("rating") or 0.0,
-            "business_name": business_name,
-            "place_id": place_id or place_info.get("place_id", inputs.get("place_id", "")),
-        }
+        return ActionResult(
+            data={
+                "reviews": all_reviews,
+                "total_reviews": len(all_reviews),
+                "average_rating": place_info.get("rating") or 0.0,
+                "business_name": business_name,
+                "place_id": place_id or place_info.get("place_id", inputs.get("place_id", "")),
+            },
+            cost_usd=0.0,
+        )

--- a/app-business-reviews/config.json
+++ b/app-business-reviews/config.json
@@ -1,7 +1,7 @@
 {
     "name": "App and Business Reviews",
     "display_name": "App and Business Reviews",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "Access reviews from App Store, Google Play Store, and Google Maps using SerpAPI",
     "entry_point": "app_business_reviews.py",
     "auth": {

--- a/app-business-reviews/requirements.txt
+++ b/app-business-reviews/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/app-business-reviews/tests/conftest.py
+++ b/app-business-reviews/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Allow 'from context import ...' to work when pytest runs from repo root
+sys.path.insert(0, os.path.dirname(__file__))

--- a/app-business-reviews/tests/test_app_business_reviews_unit.py
+++ b/app-business-reviews/tests/test_app_business_reviews_unit.py
@@ -1,0 +1,722 @@
+import os
+import sys
+import importlib
+import importlib.util
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "app_business_reviews_mod", os.path.join(_parent, "app_business_reviews.py")
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+app_business_reviews = _mod.app_business_reviews
+
+pytestmark = pytest.mark.unit
+
+# ---- Shared sample data ----
+
+SAMPLE_IOS_APP = {
+    "id": 310633997,
+    "title": "WhatsApp Messenger",
+    "bundle_id": "net.whatsapp.WhatsApp",
+    "developer": {"name": "WhatsApp Inc.", "id": 310633998},
+    "rating": [{"rating": 4.7}],
+    "price": {"value": 0},
+    "link": "https://apps.apple.com/us/app/whatsapp/id310633997",
+}
+
+SAMPLE_IOS_REVIEW = {
+    "id": "rev_001",
+    "title": "Great app",
+    "text": "Works perfectly",
+    "rating": 5,
+    "author": {"name": "JohnDoe", "author_id": "a1"},
+    "review_date": "2024-01-15",
+    "reviewed_version": "24.1",
+    "helpfulness_vote_information": "",
+}
+
+SAMPLE_ANDROID_APP_SECTION = {
+    "items": [
+        {
+            "product_id": "com.whatsapp",
+            "title": "WhatsApp Messenger",
+            "author": "WhatsApp LLC",
+            "rating": 4.3,
+            "price": "Free",
+            "thumbnail": "https://example.com/thumb.png",
+            "link": "https://play.google.com/store/apps/details?id=com.whatsapp",
+        }
+    ]
+}
+
+SAMPLE_ANDROID_REVIEW = {
+    "id": "gp_rev_001",
+    "rating": 5,
+    "snippet": "Excellent app",
+    "user": {"name": "Jane", "avatar": "https://example.com/avatar.png"},
+    "date": "2024-02-01",
+    "likes": 12,
+}
+
+SAMPLE_MAPS_PLACE = {
+    "place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4",
+    "data_id": "0xdata123",
+    "title": "Starbucks Reserve Roastery",
+    "address": "1124 Pike St, Seattle, WA",
+    "rating": 4.5,
+    "reviews": 1234,
+    "type": "Coffee shop",
+    "phone": "+1-206-123-4567",
+}
+
+SAMPLE_MAPS_REVIEW = {
+    "rating": 5,
+    "snippet": "Best coffee ever",
+    "user": {"name": "Alice"},
+    "date": "January 2024",
+    "likes": 3,
+}
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    # custom auth — flat object matching config.json auth.fields
+    ctx.auth = {
+        "api_key": "test_serpapi_key",  # nosec B105
+    }
+    return ctx
+
+
+# ---- iOS App Store: Search Apps ----
+
+
+class TestSearchAppsIOS:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_apps(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"organic_results": [SAMPLE_IOS_APP]},
+        )
+
+        result = await app_business_reviews.execute_action("search_apps_ios", {"term": "WhatsApp"}, mock_context)
+
+        assert result.result.data["total_results"] == 1
+        assert result.result.data["apps"][0]["title"] == "WhatsApp Messenger"
+
+    @pytest.mark.asyncio
+    async def test_request_url_and_method(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        await app_business_reviews.execute_action("search_apps_ios", {"term": "WhatsApp"}, mock_context)
+
+        call_args = mock_context.fetch.call_args
+        assert call_args.args[0] == "https://serpapi.com/search"
+        assert call_args.kwargs["method"] == "GET"
+
+    @pytest.mark.asyncio
+    async def test_request_params_include_term(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        await app_business_reviews.execute_action(
+            "search_apps_ios", {"term": "Instagram", "country": "uk"}, mock_context
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["term"] == "Instagram"
+        assert params["engine"] == "apple_app_store"
+        assert params["country"] == "uk"
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        result = await app_business_reviews.execute_action("search_apps_ios", {"term": "NonExistent"}, mock_context)
+
+        assert result.result.data["apps"] == []
+        assert result.result.data["total_results"] == 0
+
+    @pytest.mark.asyncio
+    async def test_num_limit_applied(self, mock_context):
+        apps = [dict(SAMPLE_IOS_APP, id=i, title=f"App {i}") for i in range(5)]
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": apps})
+
+        result = await app_business_reviews.execute_action("search_apps_ios", {"term": "App", "num": 3}, mock_context)
+
+        assert result.result.data["total_results"] == 3
+
+    @pytest.mark.asyncio
+    async def test_developer_property_search(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        await app_business_reviews.execute_action(
+            "search_apps_ios", {"term": "WhatsApp", "property": "developer"}, mock_context
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["property"] == "developer"
+
+
+# ---- iOS App Store: Get Reviews ----
+
+
+class TestGetReviewsAppStore:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_product_id(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [SAMPLE_IOS_REVIEW], "serpapi_pagination": {}},
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_app_store", {"product_id": "310633997"}, mock_context
+        )
+
+        assert result.result.data["total_reviews"] == 1
+        assert result.result.data["reviews"][0]["title"] == "Great app"
+        assert result.result.data["product_id"] == "310633997"
+
+    @pytest.mark.asyncio
+    async def test_request_url_and_method(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200, headers={}, data={"reviews": [], "serpapi_pagination": {}}
+        )
+
+        await app_business_reviews.execute_action("get_reviews_app_store", {"product_id": "310633997"}, mock_context)
+
+        call_args = mock_context.fetch.call_args
+        assert call_args.args[0] == "https://serpapi.com/search"
+        assert call_args.kwargs["method"] == "GET"
+
+    @pytest.mark.asyncio
+    async def test_request_params_apple_reviews_engine(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200, headers={}, data={"reviews": [], "serpapi_pagination": {}}
+        )
+
+        await app_business_reviews.execute_action(
+            "get_reviews_app_store", {"product_id": "310633997", "sort": "mostrecent"}, mock_context
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["engine"] == "apple_reviews"
+        assert params["product_id"] == "310633997"
+        assert params["sort"] == "mostrecent"
+
+    @pytest.mark.asyncio
+    async def test_auto_resolve_app_name(self, mock_context):
+        mock_context.fetch.side_effect = [
+            # Search response
+            FetchResponse(
+                status=200,
+                headers={},
+                data={"organic_results": [SAMPLE_IOS_APP]},
+            ),
+            # Reviews response
+            FetchResponse(
+                status=200,
+                headers={},
+                data={"reviews": [SAMPLE_IOS_REVIEW], "serpapi_pagination": {}},
+            ),
+        ]
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_app_store", {"app_name": "WhatsApp"}, mock_context
+        )
+
+        assert result.result.data["app_name"] == "WhatsApp"
+        assert result.result.data["total_reviews"] == 1
+
+    @pytest.mark.asyncio
+    async def test_error_no_product_id_or_app_name(self, mock_context):
+        result = await app_business_reviews.execute_action("get_reviews_app_store", {}, mock_context)
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "product_id" in result.result.message or "app_name" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_error_app_name_not_found(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_app_store", {"app_name": "NonExistentApp"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "NonExistentApp" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_pagination_stops_when_no_next(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [SAMPLE_IOS_REVIEW], "serpapi_pagination": {}},  # no "next" key
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_app_store", {"product_id": "310633997", "max_pages": 5}, mock_context
+        )
+
+        # Should only make 1 call since there's no next page
+        assert mock_context.fetch.call_count == 1
+        assert result.result.data["total_reviews"] == 1
+
+    @pytest.mark.asyncio
+    async def test_response_shape(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200, headers={}, data={"reviews": [SAMPLE_IOS_REVIEW], "serpapi_pagination": {}}
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_app_store", {"product_id": "310633997"}, mock_context
+        )
+
+        data = result.result.data
+        assert "reviews" in data
+        assert "total_reviews" in data
+        assert "app_name" in data
+        assert "product_id" in data
+
+
+# ---- Android: Search Apps ----
+
+
+class TestSearchAppsAndroid:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_apps(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"organic_results": [SAMPLE_ANDROID_APP_SECTION]},
+        )
+
+        result = await app_business_reviews.execute_action("search_apps_android", {"query": "WhatsApp"}, mock_context)
+
+        assert result.result.data["total_results"] == 1
+        assert result.result.data["apps"][0]["product_id"] == "com.whatsapp"
+
+    @pytest.mark.asyncio
+    async def test_request_url_and_params(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        await app_business_reviews.execute_action("search_apps_android", {"query": "Spotify"}, mock_context)
+
+        call_args = mock_context.fetch.call_args
+        assert call_args.args[0] == "https://serpapi.com/search"
+        params = call_args.kwargs["params"]
+        assert params["engine"] == "google_play"
+        assert params["q"] == "Spotify"
+        assert params["store"] == "apps"
+
+    @pytest.mark.asyncio
+    async def test_limit_applied(self, mock_context):
+        items = [dict(product_id=f"com.app{i}", title=f"App {i}") for i in range(10)]
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"organic_results": [{"items": items}]},
+        )
+
+        result = await app_business_reviews.execute_action(
+            "search_apps_android", {"query": "App", "limit": 3}, mock_context
+        )
+
+        assert result.result.data["total_results"] == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        result = await app_business_reviews.execute_action(
+            "search_apps_android", {"query": "NonExistent"}, mock_context
+        )
+
+        assert result.result.data["apps"] == []
+        assert result.result.data["total_results"] == 0
+
+
+# ---- Android: Get Reviews Google Play ----
+
+
+class TestGetReviewsGooglePlay:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_product_id(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "reviews": [SAMPLE_ANDROID_REVIEW],
+                "product_info": {"title": "WhatsApp", "rating": 4.3},
+                "serpapi_pagination": {},
+            },
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_play", {"product_id": "com.whatsapp"}, mock_context
+        )
+
+        assert result.result.data["total_reviews"] == 1
+        assert result.result.data["product_id"] == "com.whatsapp"
+        assert result.result.data["app_name"] == "WhatsApp"
+
+    @pytest.mark.asyncio
+    async def test_request_uses_google_play_product_engine(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [], "product_info": {}, "serpapi_pagination": {}},
+        )
+
+        await app_business_reviews.execute_action(
+            "get_reviews_google_play", {"product_id": "com.whatsapp"}, mock_context
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["engine"] == "google_play_product"
+        assert params["product_id"] == "com.whatsapp"
+        assert params["all_reviews"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_auto_resolve_app_name(self, mock_context):
+        mock_context.fetch.side_effect = [
+            FetchResponse(
+                status=200,
+                headers={},
+                data={"organic_results": [SAMPLE_ANDROID_APP_SECTION]},
+            ),
+            FetchResponse(
+                status=200,
+                headers={},
+                data={
+                    "reviews": [SAMPLE_ANDROID_REVIEW],
+                    "product_info": {"title": "WhatsApp", "rating": 4.3},
+                    "serpapi_pagination": {},
+                },
+            ),
+        ]
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_play", {"app_name": "WhatsApp"}, mock_context
+        )
+
+        assert result.result.data["product_id"] == "com.whatsapp"
+
+    @pytest.mark.asyncio
+    async def test_error_no_product_id_or_app_name(self, mock_context):
+        result = await app_business_reviews.execute_action("get_reviews_google_play", {}, mock_context)
+
+        assert result.type == ResultType.ACTION_ERROR
+
+    @pytest.mark.asyncio
+    async def test_error_app_name_not_found(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"organic_results": []})
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_play", {"app_name": "NonExistentApp"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "NonExistentApp" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_optional_filters_included_in_params(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [], "product_info": {}, "serpapi_pagination": {}},
+        )
+
+        await app_business_reviews.execute_action(
+            "get_reviews_google_play",
+            {"product_id": "com.instagram.android", "rating": 5, "platform": "phone", "sort_by": 2},
+            mock_context,
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["rating"] == 5
+        assert params["platform"] == "phone"
+        assert params["sort_by"] == 2
+
+    @pytest.mark.asyncio
+    async def test_response_shape(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "reviews": [SAMPLE_ANDROID_REVIEW],
+                "product_info": {"title": "App", "rating": 4.0},
+                "serpapi_pagination": {},
+            },
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_play", {"product_id": "com.whatsapp"}, mock_context
+        )
+
+        data = result.result.data
+        assert "reviews" in data
+        assert "total_reviews" in data
+        assert "app_name" in data
+        assert "app_rating" in data
+        assert "product_id" in data
+
+
+# ---- Google Maps: Search Places ----
+
+
+class TestSearchPlacesGoogleMaps:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_places(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"local_results": [SAMPLE_MAPS_PLACE]},
+        )
+
+        result = await app_business_reviews.execute_action(
+            "search_places_google_maps", {"query": "Starbucks"}, mock_context
+        )
+
+        assert result.result.data["total_results"] == 1
+        assert result.result.data["places"][0]["title"] == "Starbucks Reserve Roastery"
+
+    @pytest.mark.asyncio
+    async def test_request_url_and_engine(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"local_results": []})
+
+        await app_business_reviews.execute_action("search_places_google_maps", {"query": "Pizza"}, mock_context)
+
+        call_args = mock_context.fetch.call_args
+        assert call_args.args[0] == "https://serpapi.com/search"
+        params = call_args.kwargs["params"]
+        assert params["engine"] == "google_maps"
+        assert params["type"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_location_appended_to_query(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"local_results": []})
+
+        await app_business_reviews.execute_action(
+            "search_places_google_maps", {"query": "Pizza", "location": "New York, NY"}, mock_context
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["q"] == "Pizza in New York, NY"
+
+    @pytest.mark.asyncio
+    async def test_num_results_limit(self, mock_context):
+        places = [dict(SAMPLE_MAPS_PLACE, place_id=f"place_{i}", title=f"Place {i}") for i in range(10)]
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"local_results": places})
+
+        result = await app_business_reviews.execute_action(
+            "search_places_google_maps", {"query": "Coffee", "num_results": 3}, mock_context
+        )
+
+        assert result.result.data["total_results"] == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"local_results": []})
+
+        result = await app_business_reviews.execute_action(
+            "search_places_google_maps", {"query": "NonExistent"}, mock_context
+        )
+
+        assert result.result.data["places"] == []
+
+    @pytest.mark.asyncio
+    async def test_response_shape(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200, headers={}, data={"local_results": [SAMPLE_MAPS_PLACE]}
+        )
+
+        result = await app_business_reviews.execute_action(
+            "search_places_google_maps", {"query": "Starbucks"}, mock_context
+        )
+
+        place = result.result.data["places"][0]
+        assert "place_id" in place
+        assert "data_id" in place
+        assert "title" in place
+        assert "address" in place
+        assert "rating" in place
+
+
+# ---- Google Maps: Get Reviews ----
+
+
+class TestGetReviewsGoogleMaps:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_place_id(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "reviews": [SAMPLE_MAPS_REVIEW],
+                "place_info": {"title": "Starbucks", "rating": 4.5, "place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4"},
+                "serpapi_pagination": {},
+            },
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_maps",
+            {"place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4"},
+            mock_context,
+        )
+
+        assert result.result.data["total_reviews"] == 1
+        assert result.result.data["average_rating"] == 4.5
+
+    @pytest.mark.asyncio
+    async def test_request_uses_google_maps_reviews_engine(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [], "place_info": {}, "serpapi_pagination": {}},
+        )
+
+        await app_business_reviews.execute_action(
+            "get_reviews_google_maps",
+            {"place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4"},
+            mock_context,
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["engine"] == "google_maps_reviews"
+        assert params["place_id"] == "ChIJN1t_tDeuEmsRUsoyG83frY4"
+
+    @pytest.mark.asyncio
+    async def test_uses_data_id_when_no_place_id(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [], "place_info": {}, "serpapi_pagination": {}},
+        )
+
+        await app_business_reviews.execute_action("get_reviews_google_maps", {"data_id": "0xdata123"}, mock_context)
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["data_id"] == "0xdata123"
+        assert "place_id" not in params
+
+    @pytest.mark.asyncio
+    async def test_auto_resolve_by_query(self, mock_context):
+        mock_context.fetch.side_effect = [
+            FetchResponse(
+                status=200,
+                headers={},
+                data={"local_results": [SAMPLE_MAPS_PLACE]},
+            ),
+            FetchResponse(
+                status=200,
+                headers={},
+                data={
+                    "reviews": [SAMPLE_MAPS_REVIEW],
+                    "place_info": {"title": "Starbucks Reserve Roastery", "rating": 4.5},
+                    "serpapi_pagination": {},
+                },
+            ),
+        ]
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_maps", {"query": "Starbucks Reserve Roastery", "location": "Seattle, WA"}, mock_context
+        )
+
+        assert result.result.data["total_reviews"] == 1
+        assert result.result.data["business_name"] == "Starbucks Reserve Roastery"
+
+    @pytest.mark.asyncio
+    async def test_error_no_identifiers(self, mock_context):
+        result = await app_business_reviews.execute_action("get_reviews_google_maps", {}, mock_context)
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "place_id" in result.result.message or "query" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_error_query_no_results(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data={"local_results": []})
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_maps", {"query": "NonExistentBusiness"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "NonExistentBusiness" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_sort_by_included_in_params(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"reviews": [], "place_info": {}, "serpapi_pagination": {}},
+        )
+
+        await app_business_reviews.execute_action(
+            "get_reviews_google_maps",
+            {"place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4", "sort_by": "newestFirst"},
+            mock_context,
+        )
+
+        params = mock_context.fetch.call_args.kwargs["params"]
+        assert params["sort_by"] == "newestFirst"
+
+    @pytest.mark.asyncio
+    async def test_pagination_stops_when_no_next_token(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "reviews": [SAMPLE_MAPS_REVIEW],
+                "place_info": {"title": "Starbucks", "rating": 4.5},
+                "serpapi_pagination": {},  # no next_page_token
+            },
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_maps",
+            {"place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4", "max_pages": 5},
+            mock_context,
+        )
+
+        assert mock_context.fetch.call_count == 1
+        assert result.result.data["total_reviews"] == 1
+
+    @pytest.mark.asyncio
+    async def test_response_shape(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "reviews": [SAMPLE_MAPS_REVIEW],
+                "place_info": {"title": "Cafe", "rating": 4.2},
+                "serpapi_pagination": {},
+            },
+        )
+
+        result = await app_business_reviews.execute_action(
+            "get_reviews_google_maps", {"place_id": "ChIJN1t_tDeuEmsRUsoyG83frY4"}, mock_context
+        )
+
+        data = result.result.data
+        assert "reviews" in data
+        assert "total_reviews" in data
+        assert "average_rating" in data
+        assert "business_name" in data
+        assert "place_id" in data

--- a/toggl/config.json
+++ b/toggl/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Toggl Track",
-    "version": "0.1.0",
+    "version": "2.0.0",
     "description": "Create time entries in Toggl Track via API.",
     "entry_point": "toggl.py",
     "auth": {

--- a/toggl/requirements.txt
+++ b/toggl/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/toggl/tests/conftest.py
+++ b/toggl/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Allow 'from context import ...' to work when pytest runs from repo root
+sys.path.insert(0, os.path.dirname(__file__))

--- a/toggl/tests/test_toggl_unit.py
+++ b/toggl/tests/test_toggl_unit.py
@@ -1,0 +1,211 @@
+import os
+import sys
+import importlib
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("toggl_mod", os.path.join(_parent, "toggl.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+toggl = _mod.toggl  # the Integration instance
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_TIME_ENTRY = {
+    "id": 1234567890,
+    "workspace_id": 9876543,
+    "description": "Working on feature X",
+    "start": "2024-01-15T09:00:00Z",
+    "stop": "2024-01-15T10:00:00Z",
+    "duration": 3600,
+    "project_id": 111222333,
+    "billable": False,
+    "created_with": "autohive-integrations",
+}
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "api_token": "test_api_token_123",  # nosec B105
+        "credentials": {
+            "api_token": "test_api_token_123",  # nosec B105
+        },
+    }
+    return ctx
+
+
+# ---- Create Time Entry ----
+
+
+class TestCreateTimeEntry:
+    @pytest.mark.asyncio
+    async def test_create_time_entry_success(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data=SAMPLE_TIME_ENTRY,
+        )
+
+        result = await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data["id"] == 1234567890
+        assert result.result.data["workspace_id"] == 9876543
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_request_url_and_method(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_TIME_ENTRY)
+
+        await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        call_args = mock_context.fetch.call_args
+        assert "9876543" in call_args.args[0]
+        assert "time_entries" in call_args.args[0]
+        assert call_args.kwargs["method"] == "POST"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_request_payload(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_TIME_ENTRY)
+
+        await toggl.execute_action(
+            "create_time_entry",
+            {
+                "workspace_id": 9876543,
+                "start": "2024-01-15T09:00:00Z",
+                "description": "Test task",
+                "billable": True,
+            },
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["workspace_id"] == 9876543
+        assert payload["description"] == "Test task"
+        assert payload["billable"] is True
+        assert payload["created_with"] == "autohive-integrations"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_auth_header(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_TIME_ENTRY)
+
+        await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        headers = mock_context.fetch.call_args.kwargs["headers"]
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Basic ")
+        assert headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_exception_returns_action_error(self, mock_context):
+        mock_context.fetch.side_effect = Exception("Connection refused")
+
+        result = await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "Connection refused" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_missing_api_token_returns_action_error(self, mock_context):
+        mock_context.auth = {"credentials": {"api_token": ""}}
+
+        result = await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "api_token" in result.result.message
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_optional_fields_excluded_when_none(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_TIME_ENTRY)
+
+        await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        # Optional fields with None values should be stripped from payload
+        assert "stop" not in payload
+        assert "project_id" not in payload
+        assert "task_id" not in payload
+        assert "tags" not in payload
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_all_optional_fields(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_TIME_ENTRY)
+
+        await toggl.execute_action(
+            "create_time_entry",
+            {
+                "workspace_id": 9876543,
+                "start": "2024-01-15T09:00:00Z",
+                "stop": "2024-01-15T10:00:00Z",
+                "duration": 3600,
+                "description": "Full entry",
+                "project_id": 111,
+                "task_id": 222,
+                "billable": True,
+                "tags": ["work", "dev"],
+                "tag_ids": [1, 2],
+                "user_id": 333,
+            },
+            mock_context,
+        )
+
+        payload = mock_context.fetch.call_args.kwargs["json"]
+        assert payload["stop"] == "2024-01-15T10:00:00Z"
+        assert payload["duration"] == 3600
+        assert payload["project_id"] == 111
+        assert payload["task_id"] == 222
+        assert payload["tags"] == ["work", "dev"]
+        assert payload["tag_ids"] == [1, 2]
+        assert payload["user_id"] == 333
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_response_shape(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={"id": 999, "workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+        )
+
+        result = await toggl.execute_action(
+            "create_time_entry",
+            {"workspace_id": 9876543, "start": "2024-01-15T09:00:00Z"},
+            mock_context,
+        )
+
+        assert "id" in result.result.data
+        assert "workspace_id" in result.result.data

--- a/toggl/toggl.py
+++ b/toggl/toggl.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 import base64
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult, ActionError
 
 # Create the integration using the config.json
 toggl = Integration.load()
@@ -16,37 +16,38 @@ def _basic_auth_header_for_api_token(api_token: str) -> Dict[str, str]:
 @toggl.action("create_time_entry")
 class CreateTimeEntry(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
-        api_token = context.auth.get("credentials").get("api_token")
-        if not api_token:
-            raise Exception("Toggl API token is required in auth (field 'api_token').")
+        try:
+            api_token = context.auth.get("credentials").get("api_token")
+            if not api_token:
+                return ActionError(message="Toggl API token is required in auth (field 'api_token').")
 
-        workspace_id = inputs["workspace_id"]
+            workspace_id = inputs["workspace_id"]
 
-        body: Dict[str, Any] = {
-            # Required by Toggl when creating a TE
-            "created_with": "autohive-integrations",
-            # Mirror incoming fields if present
-            "description": inputs.get("description"),
-            "start": inputs.get("start"),
-            "stop": inputs.get("stop"),
-            "duration": inputs.get("duration"),
-            "project_id": inputs.get("project_id"),
-            "task_id": inputs.get("task_id"),
-            "billable": inputs.get("billable", False),
-            "tags": inputs.get("tags"),
-            "tag_ids": inputs.get("tag_ids"),
-            "user_id": inputs.get("user_id"),
-            "workspace_id": workspace_id,
-        }
+            body: Dict[str, Any] = {
+                # Required by Toggl when creating a TE
+                "created_with": "autohive-integrations",
+                # Mirror incoming fields if present
+                "description": inputs.get("description"),
+                "start": inputs.get("start"),
+                "stop": inputs.get("stop"),
+                "duration": inputs.get("duration"),
+                "project_id": inputs.get("project_id"),
+                "task_id": inputs.get("task_id"),
+                "billable": inputs.get("billable", False),
+                "tags": inputs.get("tags"),
+                "tag_ids": inputs.get("tag_ids"),
+                "user_id": inputs.get("user_id"),
+                "workspace_id": workspace_id,
+            }
 
-        # Remove keys with None values to avoid API complaints
-        body = {k: v for k, v in body.items() if v is not None}
+            # Remove keys with None values to avoid API complaints
+            body = {k: v for k, v in body.items() if v is not None}
 
-        headers = _basic_auth_header_for_api_token(api_token)
-        url = f"https://api.track.toggl.com/api/v9/workspaces/{workspace_id}/time_entries"
+            headers = _basic_auth_header_for_api_token(api_token)
+            url = f"https://api.track.toggl.com/api/v9/workspaces/{workspace_id}/time_entries"
 
-        # Perform POST request via the SDK's HTTP client
-        resp = await context.fetch(url, method="POST", headers=headers, json=body)
-
-        # The SDK returns parsed JSON for JSON responses; if it's bytes/string parse may be needed.
-        return resp
+            # Perform POST request via the SDK's HTTP client
+            fetch_result = await context.fetch(url, method="POST", headers=headers, json=body)
+            return ActionResult(data=fetch_result.data, cost_usd=0.0)
+        except Exception as e:
+            return ActionError(message=str(e))


### PR DESCRIPTION
## Summary

- Upgrades `autohive-integrations-sdk` from `~=1.0.2` to `~=2.0.0` in `requirements.txt`
- Adds `.data` to all `context.fetch()` return value accesses (SDK 2.0.0 `FetchResponse` breaking change)
- Converts all `raise ValueError(...)` error paths to `return ActionError(message=...)` 
- Wraps all success returns in `ActionResult(data=..., cost_usd=0.0)`
- Bumps `config.json` version to `2.0.0`
- Adds `tests/conftest.py` and 40-test unit suite covering all 6 actions across App Store, Google Play, and Google Maps

## Test plan

- [ ] `validate_integration.py app-business-reviews` passes (0 errors, 0 warnings)
- [ ] `check_code.py app-business-reviews` passes (lint, format, bandit, pip-audit, config-code sync, fetch patterns)
- [ ] `pytest app-business-reviews/ -v` — 40 tests pass
- [ ] All 6 actions have happy path, request verification, error path, and edge case tests