### PR TITLE
fix(slider): bump version to 21.0.0 — SDK v2 is a major breaking change (#308)

### DIFF
--- a/slider/config.json
+++ b/slider/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Slide Maker",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "PowerPoint automation integration using python-pptx. Unified markdown-based content addition (add_elements), template filling (find_and_replace), and comprehensive slide manipulation. Optimized for AI agents with intelligent auto-positioning, overlap detection, and graceful error handling.",
   "entry_point": "slide_maker.py",
   "actions": {


### PR DESCRIPTION
Closes #308

## Summary

Slider's `requirements.txt` was upgraded to `autohive-integrations-sdk~=2.0.0` in #283, but the integration version only bumped from `20.0.0` to `20.1.0`. The SDK v2 upgrade is a breaking dependency change and should be a major version bump.

**Change:** `20.1.0` → `21.0.0`

## Files Changed

- `slider/config.json` — version `20.1.0` → `21.0.0`