### PR TITLE
ci: post Validate Integration comments on fork PRs via workflow_run

### DIFF
--- a/.github/workflows/validate-integration-comment.yml
+++ b/.github/workflows/validate-integration-comment.yml
@@ -1,0 +1,78 @@
+name: Validate Integration Comment
+
+# Posts the validation-results comment to the PR.
+#
+# Why a separate workflow?
+# ------------------------
+# When a pull request is opened from a fork, GitHub deliberately downgrades
+# the GITHUB_TOKEN provided to `pull_request`-triggered workflows to
+# read-only — even if the workflow declares `permissions: pull-requests:
+# write`. That means the validation workflow can't post a sticky comment
+# directly on fork PRs.
+#
+# This companion workflow runs on `workflow_run` (which executes in the
+# base repository's context with normal token permissions) and posts the
+# comment using the artifact uploaded by validate-integration.yml.
+#
+# See: https://docs.github.com/actions/security-guides/automatic-token-authentication
+
+on:
+  workflow_run:
+    workflows: ['Validate Integration (Tooling)']
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: validation-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: validation-artifact
+
+      - name: Determine action
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f validation-artifact/pr-number.txt ]; then
+            echo "::error::Artifact missing pr-number.txt"
+            exit 1
+          fi
+          PR=$(tr -d '[:space:]' < validation-artifact/pr-number.txt)
+          if [ -z "$PR" ]; then
+            echo "::error::Empty PR number in artifact"
+            exit 1
+          fi
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          if [ -f validation-artifact/delete.marker ]; then
+            echo "action=delete" >> "$GITHUB_OUTPUT"
+          elif [ -f validation-artifact/comment.md ]; then
+            echo "action=post" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Artifact missing both comment.md and delete.marker"
+            exit 1
+          fi
+
+      - name: Delete stale comment
+        if: steps.meta.outputs.action == 'delete'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.meta.outputs.pr }}
+          header: validation-results
+          delete: true
+
+      - name: Post sticky comment
+        if: steps.meta.outputs.action == 'post'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.meta.outputs.pr }}
+          header: validation-results
+          path: validation-artifact/comment.md

--- a/.github/workflows/validate-integration-comment.yml
+++ b/.github/workflows/validate-integration-comment.yml
@@ -29,6 +29,38 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - name: Resolve PR number
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run.pull_requests is populated for same-repo PRs but
+          # is empty for fork PRs (the head SHA is in a different repo).
+          INLINE_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          # Both INLINE_PR and HEAD_SHA come from the workflow_run event
+          # payload — they cannot be influenced by code that ran on the
+          # original runner. Never read the PR number from the artifact:
+          # the validation job executes fork-controlled code (pytest,
+          # imported integration modules), so any file it produces must
+          # be treated as untrusted.
+          PR="$INLINE_PR"
+          if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+            # Fork PR: pull_requests array is empty. Look up the PR via
+            # the API using the trusted head SHA.
+            PR=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+                  --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
+                  | head -1)
+          fi
+          if [ -z "$PR" ]; then
+            echo "::error::Could not resolve PR number for head SHA $HEAD_SHA"
+            exit 1
+          fi
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
       - name: Download comment artifact
         uses: actions/download-artifact@v4
         with:
@@ -42,16 +74,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ ! -f validation-artifact/pr-number.txt ]; then
-            echo "::error::Artifact missing pr-number.txt"
-            exit 1
-          fi
-          PR=$(tr -d '[:space:]' < validation-artifact/pr-number.txt)
-          if [ -z "$PR" ]; then
-            echo "::error::Empty PR number in artifact"
-            exit 1
-          fi
-          echo "pr=$PR" >> "$GITHUB_OUTPUT"
           if [ -f validation-artifact/delete.marker ]; then
             echo "action=delete" >> "$GITHUB_OUTPUT"
           elif [ -f validation-artifact/comment.md ]; then
@@ -65,7 +87,7 @@ jobs:
         if: steps.meta.outputs.action == 'delete'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ steps.meta.outputs.pr }}
+          number: ${{ steps.pr.outputs.number }}
           header: validation-results
           delete: true
 
@@ -73,6 +95,6 @@ jobs:
         if: steps.meta.outputs.action == 'post'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ steps.meta.outputs.pr }}
+          number: ${{ steps.pr.outputs.number }}
           header: validation-results
           path: validation-artifact/comment.md

--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -32,12 +32,17 @@ jobs:
         if: always()
         shell: bash
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           COMMENT_PATH: ${{ steps.validate.outputs.comment_path }}
         run: |
           set -euo pipefail
           mkdir -p validation-artifact
-          printf '%s\n' "$PR_NUMBER" > validation-artifact/pr-number.txt
+          # Note: the PR number is intentionally NOT written to the artifact.
+          # This step runs after the validation pipeline has executed fork
+          # tests / fork-imported code on the runner, so anything written
+          # here must be considered untrusted by the companion workflow.
+          # The companion derives the target PR from the trusted
+          # workflow_run event payload (and a GitHub API lookup as the
+          # fork-PR fallback) instead of trusting an artifact value.
           if [ -n "$COMMENT_PATH" ] && [ -f "$COMMENT_PATH" ]; then
             cp "$COMMENT_PATH" validation-artifact/comment.md
           else

--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -10,7 +10,6 @@ jobs:
     name: Validate Integration
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,6 +17,41 @@ jobs:
           fetch-depth: 0
 
       - name: Validate
+        id: validate
         uses: autohive-ai/autohive-integrations-tooling@v2
         with:
           base_ref: origin/${{ github.base_ref }}
+          # Don't post directly: pull_request workflows triggered from forks
+          # run with a read-only GITHUB_TOKEN, so the comment would 403 and
+          # the job would go red even when validation passed. Instead we
+          # upload the rendered comment as an artifact and let
+          # validate-integration-comment.yml post it from base-repo context.
+          post_comment: 'false'
+
+      - name: Stage comment artifact
+        if: always()
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_PATH: ${{ steps.validate.outputs.comment_path }}
+        run: |
+          set -euo pipefail
+          mkdir -p validation-artifact
+          printf '%s\n' "$PR_NUMBER" > validation-artifact/pr-number.txt
+          if [ -n "$COMMENT_PATH" ] && [ -f "$COMMENT_PATH" ]; then
+            cp "$COMMENT_PATH" validation-artifact/comment.md
+          else
+            # No integration directories changed (or the action bailed out
+            # before rendering). Tell the companion workflow to clear any
+            # stale comment instead of posting a new one.
+            : > validation-artifact/delete.marker
+          fi
+
+      - name: Upload comment artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-comment
+          path: validation-artifact/
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
Closes #312.

## What

Switches the `Validate Integration (Tooling)` workflow to the two-workflow pattern for fork PR comments:

- **`.github/workflows/validate-integration.yml`** (modified)
  - Sets `post_comment: 'false'` on the tooling action so the inline post step is skipped.
  - Captures the rendered comment via the new `comment_path` output ([tooling 2.1.0](https://github.com/autohive-ai/autohive-integrations-tooling/releases/tag/2.1.0)).
  - Uploads `{ pr-number.txt, comment.md }` (or `delete.marker` when no integration directories changed) as a `validation-comment` artifact, 1-day retention.
  - Drops `pull-requests: write` from `permissions:` — no longer needed in this job.
- **`.github/workflows/validate-integration-comment.yml`** (new)
  - Triggers on `workflow_run` completion of `Validate Integration (Tooling)`.
  - Runs in base-repo context with `pull-requests: write` (which actually works there because the token isn't downgraded — `workflow_run` is the documented escape hatch).
  - Downloads the artifact, reads the PR number, then either deletes a stale sticky comment (`delete.marker`) or posts the rendered comment via `marocchino/sticky-pull-request-comment@v2`.

## Why

`pull_request` workflows triggered from forks always run with a **read-only** `GITHUB_TOKEN` regardless of the workflow's `permissions:` block ([docs](https://docs.github.com/actions/security-guides/automatic-token-authentication)). The existing inline comment step always 403s on fork PRs and the job goes red purely because of the failed comment-posting step, even when validation passed. Concrete example: [#293](https://github.com/Autohive-AI/autohive-integrations/pull/293) (HubSpot tasks, opened from `lohitya/autohive-integrations`).

`workflow_run`-triggered jobs run in the **base-repository context** with normal token permissions, regardless of whether the original event was a fork PR. Untrusted fork code never executes with elevated tokens — the validation job stays read-only, and the companion job only ever processes a small artifact (PR number + Markdown text), never executes fork code. Same trade-off (and same reason) that ruled out `pull_request_target` for this workflow.

## Properties

- ✅ Same-repo PRs: comment posting still happens, via the new flow. Slight delay (~few seconds for the second workflow to start) but otherwise identical.
- ✅ Fork PRs: comment now appears (didn't before). CI ✅/❌ reflects validation, not comment-posting.
- ✅ Untrusted fork code never runs with elevated tokens.
- ✅ `marocchino`'s sticky behaviour still works — matches by `header: validation-results` and updates in place across runs.

## One-time blind spot during this PR's review

`workflow_run` triggers fire based on the workflow file **on the repository's default branch**, not on the PR branch. So while this PR is open, the new `validate-integration-comment.yml` is on the PR branch but not yet on master — meaning this PR's own CI runs won't have a companion workflow to post their comment. CI ✅/❌ will still be correct (reflects validation only). After merge, every subsequent PR — fork or same-repo — gets the full pipeline working.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files — both parse cleanly.
- Renderer (in tooling) and the file-handoff design were smoke-tested locally during the [tooling-repo PR](https://github.com/autohive-ai/autohive-integrations-tooling/pull/38).

## Prerequisites (already done)

- [x] [`autohive-ai/autohive-integrations-tooling#37`](https://github.com/autohive-ai/autohive-integrations-tooling/issues/37) / [#38](https://github.com/autohive-ai/autohive-integrations-tooling/pull/38) merged
- [x] [Tooling release `2.1.0`](https://github.com/autohive-ai/autohive-integrations-tooling/releases/tag/2.1.0) published; `v2` tag moved to the new commit (`6ae64fe`)