### PR TITLE
fix(ci): resolve fork PR number via head=user:branch lookup

### DIFF
--- a/.github/workflows/validate-integration-comment.yml
+++ b/.github/workflows/validate-integration-comment.yml
@@ -39,24 +39,33 @@ jobs:
           # workflow_run.pull_requests is populated for same-repo PRs but
           # is empty for fork PRs (the head SHA is in a different repo).
           INLINE_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          # head_repository / head_branch are populated for both same-repo
+          # and fork PRs and come from the workflow_run event payload, so
+          # they're trustworthy (not influenceable by runner code).
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          # Both INLINE_PR and HEAD_SHA come from the workflow_run event
-          # payload — they cannot be influenced by code that ran on the
-          # original runner. Never read the PR number from the artifact:
-          # the validation job executes fork-controlled code (pytest,
+          # All inputs below come from the workflow_run event payload —
+          # they cannot be influenced by code that ran on the original
+          # runner. Never read the PR number from the artifact: the
+          # validation job executes fork-controlled code (pytest,
           # imported integration modules), so any file it produces must
           # be treated as untrusted.
           PR="$INLINE_PR"
           if [ -z "$PR" ] || [ "$PR" = "null" ]; then
-            # Fork PR: pull_requests array is empty. Look up the PR via
-            # the API using the trusted head SHA.
-            PR=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
-                  --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
+            # Fork PR: pull_requests array is empty (the head SHA lives
+            # in a different repo, and /commits/{sha}/pulls doesn't
+            # index fork commits). Look up the open PR by its head
+            # (user:branch) — this pair uniquely identifies an open PR
+            # in this repo.
+            HEAD_USER="${HEAD_REPO%%/*}"
+            PR=$(gh api "repos/$REPO/pulls?state=open&head=$HEAD_USER:$HEAD_BRANCH&per_page=10" \
+                  --jq ".[] | select(.head.repo.full_name == \"$HEAD_REPO\" and .head.ref == \"$HEAD_BRANCH\") | .number" \
                   | head -1)
           fi
           if [ -z "$PR" ]; then
-            echo "::error::Could not resolve PR number for head SHA $HEAD_SHA"
+            echo "::error::Could not resolve PR for $HEAD_REPO:$HEAD_BRANCH (head SHA $HEAD_SHA)"
             exit 1
           fi
           echo "number=$PR" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #314.

## What

Fixes the `Resolve PR number` step in `.github/workflows/validate-integration-comment.yml` so it actually finds fork PRs. Switches the fallback API call from:

```
GET /repos/{owner}/{repo}/commits/{HEAD_SHA}/pulls
```

to:

```
GET /repos/{owner}/{repo}/pulls?state=open&head=<HEAD_USER>:<HEAD_BRANCH>
```

`HEAD_USER` is derived from `workflow_run.head_repository.full_name` (which is `<user>/<repo>` for both same-repo and fork PRs); `HEAD_BRANCH` is `workflow_run.head_branch`. Both come from the trusted event payload — same security property the original Codex review was after. Neither is influenceable by anything that ran on the runner during validation.

## Why

The previous fallback endpoint (`/commits/{sha}/pulls`) does not index commits that live only in a fork. Even though GitHub stores fork PR heads as `refs/pull/{n}/head` in the upstream repo, the commit-to-pulls lookup ignores those refs. So on every fork PR the companion workflow failed with:

```
::error::Could not resolve PR number for head SHA <fork-sha>
```

Concrete failure: [run 25200317388](https://github.com/Autohive-AI/autohive-integrations/actions/runs/25200317388) on PR [#293](https://github.com/Autohive-AI/autohive-integrations/pull/293), commit `ecd929b`.

The `/pulls?head=user:branch` endpoint does work for fork PRs because it filters by ref name and head-repo — neither requires the commit to be reachable from the upstream default branch.

## Verification

Verified manually that the new endpoint resolves the fork PR correctly:

```
$ gh api 'repos/Autohive-AI/autohive-integrations/pulls?state=open&head=lohitya:ls/hubspot-tasks' \
    --jq '.[] | {number, head_sha: .head.sha}'
{"number":293,"head_sha":"ecd929b968d5b329008051a1d2b73dd0e6e73ebd"}
```

End-to-end verification (after merge): push another empty commit to `lohitya/ls/hubspot-tasks` to retrigger PR #293's CI; expect `Validate Integration Comment` to succeed and the sticky comment to appear on #293.

## Uniqueness assumption

The `(head_repo.full_name, head_branch)` pair uniquely identifies an open PR in this repo: a fork branch can have at most one open PR against a given upstream (GitHub enforces this — opening a second PR with the same head/base pair is rejected). The `--jq` filter explicitly checks `head.repo.full_name` AND `head.ref` so we're not relying solely on the API's `head=user:branch` query parameter.

## One-time blind spot during this PR's review

Same as #313: this PR's own validation comment won't appear, because the workflow file change is on the PR branch and `workflow_run` reads from the default branch. The validate workflow itself will run normally (✅).