### PR TITLE
docs(heartbeat): mark integration as unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ Supports basic HTTP authentication and Bearer token authentication via the SDK.
 
 ### Heartbeat
 
-[heartbeat](heartbeat): Connects to Heartbeat.chat community platform for comprehensive access to channels, threads, comments, users, and events. Supports retrieving channel information, managing thread discussions, creating and viewing comments, accessing user profiles, and viewing community events. Includes full CRUD operations for community engagement and content management. Supports API key authentication.
+> ⚠️ **Unsupported** — this integration is no longer maintained by the Autohive team and is not guaranteed to work. Use at your own risk.
+
+[heartbeat](heartbeat): **[UNSUPPORTED]** Connects to Heartbeat.chat community platform for comprehensive access to channels, threads, comments, users, and events. Supports retrieving channel information, managing thread discussions, creating and viewing comments, accessing user profiles, and viewing community events. Includes full CRUD operations for community engagement and content management. Supports API key authentication.
 
 ### Humanitix
 

--- a/heartbeat/README.md
+++ b/heartbeat/README.md
@@ -1,5 +1,9 @@
 # Heartbeat Integration for Autohive
 
+> ⚠️ **Status: Unsupported**
+>
+> This integration is **no longer supported or maintained** by the Autohive team. It is kept in the repository for reference only and is not covered by validation, CI checks, or bug-fix updates. Use at your own risk — functionality may break without notice.
+
 Connects Autohive to the Heartbeat.chat API to allow users to retrieve channel information, manage threads and comments, access user data, and view community events.
 
 ## Description


### PR DESCRIPTION
## Summary

Marks the Heartbeat (heartbeat.chat) integration as **unsupported** so users can see at a glance that it is no longer maintained.

## Changes

- **`README.md`** — adds an `⚠️ Unsupported` callout under the Heartbeat heading and prefixes the entry with `[UNSUPPORTED]`.
- **`heartbeat/README.md`** — adds a prominent `⚠️ Status: Unsupported` blockquote at the top explaining the integration is no longer maintained, not covered by CI/validation, and used at the user's own risk.

No code changes — documentation only.

Closes #319
