### PR TITLE
fix(github): add commit_id support for inline PR review comments

### DIFF
--- a/github/config.json
+++ b/github/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GitHub",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "GitHub API integration for complete repository management including CRUD operations for repos, branches, issues, PRs, files, and more.",
   "display_name": "GitHub",
   "supports_connected_account": true,

--- a/github/config.json
+++ b/github/config.json
@@ -1290,7 +1290,20 @@
             }
           },
           "head": {
-            "type": "object"
+            "type": "object",
+            "description": "The head branch info. head.sha is the latest commit SHA — pass this as commit_id when calling create_pull_request_review.",
+            "properties": {
+              "sha": {
+                "type": "string",
+                "description": "The latest commit SHA on the PR head branch. Use as commit_id in create_pull_request_review."
+              },
+              "ref": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            }
           },
           "base": {
             "type": "object"
@@ -1734,7 +1747,7 @@
     },
     "create_pull_request_review": {
       "display_name": "Create Pull Request Review",
-      "description": "Create a review for a pull request",
+      "description": "Create a review for a pull request, optionally with inline comments on specific lines of changed files. Use get_pull_request first to obtain the head commit SHA (head.sha) required for commit_id.",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -1750,9 +1763,13 @@
             "type": "integer",
             "description": "Pull request number"
           },
+          "commit_id": {
+            "type": "string",
+            "description": "The SHA of the latest commit on the PR head branch. Required when posting inline comments. Obtain this from get_pull_request → head.sha."
+          },
           "body": {
             "type": "string",
-            "description": "Review body"
+            "description": "Overall review body text. Required when event is REQUEST_CHANGES or COMMENT."
           },
           "event": {
             "type": "string",
@@ -1761,25 +1778,21 @@
               "REQUEST_CHANGES",
               "COMMENT"
             ],
-            "description": "Review action"
+            "description": "Review action: APPROVE, REQUEST_CHANGES, or COMMENT."
           },
           "comments": {
             "type": "array",
-            "description": "Line comments",
+            "description": "Inline comments to post on specific lines of the diff. Each comment must target a line that actually appears in the PR diff — use diff_branch_to_branch or the patch field from get_pull_request to find valid line numbers.",
             "items": {
               "type": "object",
               "properties": {
                 "path": {
                   "type": "string",
-                  "description": "File path"
-                },
-                "position": {
-                  "type": "integer",
-                  "description": "Diff position (deprecated)"
+                  "description": "File path relative to the repo root (e.g. 'src/main.py')"
                 },
                 "line": {
                   "type": "integer",
-                  "description": "Line number"
+                  "description": "Line number in the file to comment on. Must be a line present in the PR diff — GitHub rejects comments on lines not in the diff."
                 },
                 "side": {
                   "type": "string",
@@ -1787,13 +1800,26 @@
                     "LEFT",
                     "RIGHT"
                   ],
-                  "description": "Side of diff"
+                  "description": "Which side of the diff to comment on. RIGHT for the new version (added/unchanged lines), LEFT for the old version (removed lines). Use RIGHT for almost all cases."
                 },
                 "body": {
                   "type": "string",
-                  "description": "Comment text"
+                  "description": "The inline comment text."
+                },
+                "start_line": {
+                  "type": "integer",
+                  "description": "First line of a multi-line comment range. Only set this when the comment spans multiple lines; omit for single-line comments."
+                },
+                "start_side": {
+                  "type": "string",
+                  "enum": [
+                    "LEFT",
+                    "RIGHT"
+                  ],
+                  "description": "Side for the start_line when making a multi-line comment. Usually matches side."
                 }
-              }
+              },
+              "required": ["path", "line", "body"]
             }
           }
         },

--- a/github/github.py
+++ b/github/github.py
@@ -1754,6 +1754,7 @@ class CreatePullRequestReview(ActionHandler):
             inputs["owner"],
             inputs["repo"],
             inputs["pull_number"],
+            commit_id=inputs.get("commit_id"),
             body=inputs.get("body"),
             event=inputs.get("event"),
             comments=inputs.get("comments"),

--- a/github/github.py
+++ b/github/github.py
@@ -578,6 +578,7 @@ class GitHubAPI:
         owner: str,
         repo: str,
         pull_number: int,
+        commit_id: str = None,
         body: str = None,
         event: str = None,
         comments: List[Dict[str, Any]] = None,
@@ -586,6 +587,8 @@ class GitHubAPI:
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
         data = {}
 
+        if commit_id:
+            data["commit_id"] = commit_id
         if body:
             data["body"] = body
         if event:


### PR DESCRIPTION
## Summary

The `create_pull_request_review` action was missing the `commit_id` field required by GitHub's API for inline review comments. Without it, GitHub either rejects the request or silently drops all inline comments. Additionally, the `get_pull_request` output schema returned `head` as an opaque object, giving AI agents no way to discover that `head.sha` is the commit SHA they need to pass as `commit_id`.

## Changes

### `config.json`

- Added `commit_id` input field to `create_pull_request_review` with a clear description explaining it must come from `get_pull_request → head.sha`
- Expanded `comments` array item schema: added `required` fields (`path`, `line`, `body`), added `start_line` and `start_side` for multi-line comments, and improved all field descriptions to explain the diff-line constraint
- Improved action `description` to document the required two-step flow (get PR → create review)
- Expanded `get_pull_request` output schema's `head` object to explicitly expose `head.sha` with a description pointing agents to use it as `commit_id`

### `github.py`

- Added `commit_id: str = None` parameter to `create_pull_request_review`
- Passes `commit_id` to the GitHub API request body when provided

## Root Cause

GitHub's `POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews` API requires `commit_id` to anchor inline comments to the correct commit. Without it the request returns 422 or inline comments are ignored. The schema also gave agents no signal about where to find the commit SHA, causing them to omit it entirely.

## Agent Flow (after this fix)

1. Call `get_pull_request` → extract `head.sha`
2. Call `diff_branch_to_branch` to identify changed files and valid line numbers in the diff
3. Call `create_pull_request_review` with `commit_id = head.sha` and inline `comments` targeting only lines present in the diff