### PR TITLE
fix(github): harden connected-account and list_commits against Unhandled Lambda crash

### DIFF
--- a/github/config.json
+++ b/github/config.json
@@ -478,7 +478,10 @@
                   ]
                 },
                 "date": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             },
@@ -498,7 +501,10 @@
                   ]
                 },
                 "date": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             },

--- a/github/config.json
+++ b/github/config.json
@@ -447,6 +447,12 @@
           "until": {
             "type": "string",
             "description": "ISO 8601 timestamp to filter commits before"
+          },
+          "max_pages": {
+            "type": "integer",
+            "description": "Maximum number of pages (100 commits per page) to fetch before stopping. Prevents Lambda timeouts on large repos. Narrow with sha/path/since/until for full coverage.",
+            "default": 10,
+            "minimum": 1
           }
         },
         "required": [

--- a/github/config.json
+++ b/github/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GitHub",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "GitHub API integration for complete repository management including CRUD operations for repos, branches, issues, PRs, files, and more.",
   "display_name": "GitHub",
   "supports_connected_account": true,

--- a/github/github.py
+++ b/github/github.py
@@ -2688,11 +2688,18 @@ class GitHubConnectedAccountHandler(ConnectedAccountHandler):
 
         Returns:
             ConnectedAccountInfo with user's email, username, name, avatar, etc.
+            Falls back to an empty ConnectedAccountInfo when the GitHub API call
+            fails (e.g., revoked/expired token, 5xx outage). The SDK does not
+            catch exceptions raised from this handler, so letting one propagate
+            crashes the Lambda with "Unhandled". Auth failures surface to the
+            user the next time they run an action.
         """
-        # Fetch authenticated user info
-        user_data = await GitHubAPI.get_user(context)
+        try:
+            user_data = await GitHubAPI.get_user(context)
+        except Exception as e:
+            context.logger.warning(f"Failed to fetch GitHub account info: {e}")
+            return ConnectedAccountInfo()
 
-        # Parse name into first/last
         name = user_data.get("name", "")
         name_parts = name.split(maxsplit=1) if name else []
 

--- a/github/github.py
+++ b/github/github.py
@@ -26,6 +26,9 @@ from urllib.parse import quote
 from functools import wraps
 import asyncio
 import base64
+import logging
+
+logger = logging.getLogger(__name__)
 
 github = Integration.load()
 
@@ -62,9 +65,14 @@ def handle_github_errors(action_name: str):
                 return await func(self, inputs, context)
 
             except asyncio.CancelledError:
-                # Lambda runtime / async machinery cancelled the task (e.g., timeout).
-                # CancelledError inherits from BaseException, so a bare `except Exception`
-                # would not catch it and the Lambda would crash with "Unhandled".
+                # Defensive: convert Python-side task cancellation into an
+                # ActionError if cancellation reaches the action coroutine.
+                # This does not catch Lambda hard timeouts or caller-side
+                # invocation cancellation.
+                logger.warning(
+                    "CancelledError caught in action %s — cooperative cancellation reached the action coroutine",
+                    action_name,
+                )
                 return ActionError(
                     message=(
                         f"Action '{action_name}' was cancelled before completing. "
@@ -106,15 +114,21 @@ class GitHubAPI:
         url: str,
         params: Dict[str, Any] = None,
         data_key: str = None,
+        max_pages: int = 10,
     ) -> List[Dict[str, Any]]:
         """
         Generic paginated fetch that handles GitHub's pagination automatically.
+
+        Bounded by max_pages to prevent unbounded loops on large datasets
+        (e.g. list_commits on a repo with thousands of commits) from running
+        until the Lambda runtime cancels the task.
 
         Args:
             context: ExecutionContext
             url: API endpoint URL
             params: Query parameters
             data_key: Key to extract from response (e.g., 'workflows', 'workflow_runs')
+            max_pages: Hard cap on pages fetched. Raises TimeoutError when exceeded.
         """
         if params is None:
             params = {}
@@ -124,8 +138,23 @@ class GitHubAPI:
 
         all_items = []
         headers = GitHubAPI.get_headers(context)
+        pages_fetched = 0
         while True:
+            if pages_fetched >= max_pages:
+                logger.warning(
+                    "paginated_fetch hit max_pages cap (url=%s, max_pages=%d, items_collected=%d)",
+                    url,
+                    max_pages,
+                    len(all_items),
+                )
+                raise TimeoutError(
+                    f"GitHub pagination stopped after {max_pages} pages "
+                    f"({len(all_items)} items). Narrow the request with filters "
+                    "(e.g. sha, path, since, until) or raise max_pages."
+                )
+
             fetch_result = await context.fetch(url, params=params, headers=headers)
+            pages_fetched += 1
             response = fetch_result.data
 
             # Extract items from response
@@ -272,8 +301,9 @@ class GitHubAPI:
         path: str = None,
         since: str = None,
         until: str = None,
+        max_pages: int = 10,
     ) -> List[Dict[str, Any]]:
-        """Get commits for a repository"""
+        """Get commits for a repository (bounded by max_pages)"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/commits"
         params = {}
 
@@ -286,7 +316,7 @@ class GitHubAPI:
         if until:
             params["until"] = until
 
-        return await GitHubAPI.paginated_fetch(context, url, params)
+        return await GitHubAPI.paginated_fetch(context, url, params, max_pages=max_pages)
 
     @staticmethod
     async def get_commit(context: ExecutionContext, owner: str, repo: str, sha: str) -> Dict[str, Any]:
@@ -1197,6 +1227,7 @@ class ListCommits(ActionHandler):
             path=inputs.get("path"),
             since=inputs.get("since"),
             until=inputs.get("until"),
+            max_pages=inputs.get("max_pages", 10),
         )
 
         return ActionResult(

--- a/github/github.py
+++ b/github/github.py
@@ -21,9 +21,10 @@ from autohive_integrations_sdk import (
     ConnectedAccountHandler,
     ConnectedAccountInfo,
 )
-from typing import Dict, Any, List, Callable, TypeVar
+from typing import Dict, Any, List, Callable, Optional, TypeVar
 from urllib.parse import quote
 from functools import wraps
+import asyncio
 import base64
 
 github = Integration.load()
@@ -60,6 +61,16 @@ def handle_github_errors(action_name: str):
 
                 return await func(self, inputs, context)
 
+            except asyncio.CancelledError:
+                # Lambda runtime / async machinery cancelled the task (e.g., timeout).
+                # CancelledError inherits from BaseException, so a bare `except Exception`
+                # would not catch it and the Lambda would crash with "Unhandled".
+                return ActionError(
+                    message=(
+                        f"Action '{action_name}' was cancelled before completing. "
+                        "If listing a large dataset, try narrowing the request with filters."
+                    )
+                )
             except Exception as e:
                 return ActionError(message=str(e))
 
@@ -1154,6 +1165,24 @@ class DeleteRepository(ActionHandler):
 # ---- Commit Actions ----
 
 
+def _commit_signature(sig: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    # GitHub may return a null author/committer for commits whose email isn't
+    # linked to a GitHub user (deleted accounts, bot-authored commits, etc.).
+    sig = sig or {}
+    return {"name": sig.get("name"), "email": sig.get("email"), "date": sig.get("date")}
+
+
+def _commit_summary(commit: Dict[str, Any]) -> Dict[str, Any]:
+    inner = commit.get("commit") or {}
+    return {
+        "sha": commit.get("sha"),
+        "author": _commit_signature(inner.get("author")),
+        "committer": _commit_signature(inner.get("committer")),
+        "message": inner.get("message"),
+        "url": commit.get("html_url"),
+    }
+
+
 @github.action("list_commits")
 class ListCommits(ActionHandler):
     """List commits for a repository"""
@@ -1171,24 +1200,7 @@ class ListCommits(ActionHandler):
         )
 
         return ActionResult(
-            data=[
-                {
-                    "sha": commit["sha"],
-                    "author": {
-                        "name": commit["commit"]["author"]["name"],
-                        "email": commit["commit"]["author"]["email"],
-                        "date": commit["commit"]["author"]["date"],
-                    },
-                    "committer": {
-                        "name": commit["commit"]["committer"]["name"],
-                        "email": commit["commit"]["committer"]["email"],
-                        "date": commit["commit"]["committer"]["date"],
-                    },
-                    "message": commit["commit"]["message"],
-                    "url": commit["html_url"],
-                }
-                for commit in commits
-            ],
+            data=[_commit_summary(commit) for commit in commits],
             cost_usd=0.0,
         )
 
@@ -1203,21 +1215,9 @@ class GetCommit(ActionHandler):
 
         return ActionResult(
             data={
-                "sha": commit["sha"],
-                "author": {
-                    "name": commit["commit"]["author"]["name"],
-                    "email": commit["commit"]["author"]["email"],
-                    "date": commit["commit"]["author"]["date"],
-                },
-                "committer": {
-                    "name": commit["commit"]["committer"]["name"],
-                    "email": commit["commit"]["committer"]["email"],
-                    "date": commit["commit"]["committer"]["date"],
-                },
-                "message": commit["commit"]["message"],
+                **_commit_summary(commit),
                 "stats": commit.get("stats", {}),
                 "files": commit.get("files", []),
-                "url": commit["html_url"],
             },
             cost_usd=0.0,
         )

--- a/github/tests/test_github_branches_commits_unit.py
+++ b/github/tests/test_github_branches_commits_unit.py
@@ -88,6 +88,26 @@ class TestGetCommit:
 
         assert result.type == ResultType.ACTION_ERROR
 
+    @pytest.mark.asyncio
+    async def test_null_author_does_not_crash(self, mock_context):
+        commit_with_null_author = {
+            "sha": "deadbeef",
+            "commit": {
+                "author": None,
+                "committer": {"name": "Octocat", "email": "octocat@github.com", "date": "2021-01-01T00:00:00Z"},
+                "message": "Orphan commit",
+            },
+            "html_url": "https://github.com/octocat/Hello-World/commit/deadbeef",
+        }
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=commit_with_null_author)
+
+        result = await github.execute_action(
+            "get_commit", {"owner": "octocat", "repo": "Hello-World", "sha": "deadbeef"}, mock_context
+        )
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data["author"] == {"name": None, "email": None, "date": None}
+
 
 class TestListCommits:
     @pytest.mark.asyncio
@@ -112,6 +132,60 @@ class TestListCommits:
         params = mock_context.fetch.call_args.kwargs["params"]
         assert params["sha"] == "main"
         assert params["since"] == "2021-01-01T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_null_author_does_not_crash(self, mock_context):
+        # Repro for the Raygun "Unhandled" Lambda error: GitHub returns
+        # commit.commit.author = null for commits whose email isn't linked
+        # to a GitHub user. Previously this raised TypeError mid-action.
+        commit_with_null_author = {
+            "sha": "deadbeef",
+            "commit": {
+                "author": None,
+                "committer": {"name": "Octocat", "email": "octocat@github.com", "date": "2021-01-01T00:00:00Z"},
+                "message": "Orphan commit",
+            },
+            "html_url": "https://github.com/octocat/Hello-World/commit/deadbeef",
+        }
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[commit_with_null_author])
+
+        result = await github.execute_action("list_commits", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data[0]["author"] == {"name": None, "email": None, "date": None}
+        assert result.result.data[0]["committer"]["name"] == "Octocat"
+
+    @pytest.mark.asyncio
+    async def test_null_committer_does_not_crash(self, mock_context):
+        commit_with_null_committer = {
+            "sha": "deadbeef",
+            "commit": {
+                "author": {"name": "Octocat", "email": "octocat@github.com", "date": "2021-01-01T00:00:00Z"},
+                "committer": None,
+                "message": "Bot commit",
+            },
+            "html_url": "https://github.com/octocat/Hello-World/commit/deadbeef",
+        }
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[commit_with_null_committer])
+
+        result = await github.execute_action("list_commits", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data[0]["committer"] == {"name": None, "email": None, "date": None}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_returns_action_error(self, mock_context):
+        # Simulates the Lambda runtime cancelling the task (e.g., timeout).
+        # CancelledError is a BaseException, not Exception — without explicit
+        # handling it bypasses the decorator and the Lambda returns "Unhandled".
+        import asyncio as _asyncio
+
+        mock_context.fetch.side_effect = _asyncio.CancelledError()
+
+        result = await github.execute_action("list_commits", {"owner": "octocat", "repo": "Hello-World"}, mock_context)
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "cancelled" in result.result.message.lower()
 
 
 # ---- Branch Actions ----

--- a/github/tests/test_github_branches_commits_unit.py
+++ b/github/tests/test_github_branches_commits_unit.py
@@ -220,6 +220,29 @@ class TestListCommits:
         assert result.type == ResultType.ACTION_ERROR
         assert mock_context.fetch.call_count == 10
 
+    @pytest.mark.asyncio
+    async def test_completes_under_cap_without_firing(self, mock_context):
+        # Regression guard: 3 pages of data with cap of 10 must complete
+        # naturally and return all items. Catches off-by-one bugs where the
+        # cap fires one iteration too early and silently returns short data.
+        full_page = [SAMPLE_COMMIT] * 100
+        last_partial = [SAMPLE_COMMIT] * 30
+        mock_context.fetch.side_effect = [
+            FetchResponse(status=200, headers={}, data=full_page),
+            FetchResponse(status=200, headers={}, data=full_page),
+            FetchResponse(status=200, headers={}, data=last_partial),
+        ]
+
+        result = await github.execute_action(
+            "list_commits",
+            {"owner": "octocat", "repo": "Hello-World"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION
+        assert len(result.result.data) == 230
+        assert mock_context.fetch.call_count == 3
+
 
 # ---- Branch Actions ----
 

--- a/github/tests/test_github_branches_commits_unit.py
+++ b/github/tests/test_github_branches_commits_unit.py
@@ -187,6 +187,39 @@ class TestListCommits:
         assert result.type == ResultType.ACTION_ERROR
         assert "cancelled" in result.result.message.lower()
 
+    @pytest.mark.asyncio
+    async def test_max_pages_cap_stops_unbounded_pagination(self, mock_context):
+        # Each page returns a full 100 items so paginated_fetch would keep going
+        # forever; the max_pages cap must stop it and surface a TimeoutError
+        # which the decorator turns into an ActionError.
+        full_page = [SAMPLE_COMMIT] * 100
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=full_page)
+
+        result = await github.execute_action(
+            "list_commits",
+            {"owner": "octocat", "repo": "Hello-World", "max_pages": 2},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "2 pages" in result.result.message
+        assert mock_context.fetch.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_default_max_pages_is_ten(self, mock_context):
+        # When the caller omits max_pages, the default cap of 10 must apply.
+        full_page = [SAMPLE_COMMIT] * 100
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=full_page)
+
+        result = await github.execute_action(
+            "list_commits",
+            {"owner": "octocat", "repo": "Hello-World"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert mock_context.fetch.call_count == 10
+
 
 # ---- Branch Actions ----
 

--- a/github/tests/test_github_misc_unit.py
+++ b/github/tests/test_github_misc_unit.py
@@ -11,7 +11,7 @@ sys.path.insert(0, _deps)
 import pytest  # noqa: E402
 from unittest.mock import AsyncMock, MagicMock  # noqa: E402
 from autohive_integrations_sdk import FetchResponse  # noqa: E402
-from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+from autohive_integrations_sdk.integration import HTTPError, ResultType  # noqa: E402
 
 _spec = importlib.util.spec_from_file_location("github_mod", os.path.join(_parent, "github.py"))
 _mod = importlib.util.module_from_spec(_spec)
@@ -519,3 +519,56 @@ class TestGetReleaseByTag:
 
         url = mock_context.fetch.call_args.args[0]
         assert "release%2F2024-01" in url
+
+
+# ---- Connected Account ----
+
+
+class TestConnectedAccount:
+    @pytest.mark.asyncio
+    async def test_returns_populated_account_info(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data={
+                "login": "octocat",
+                "id": 1,
+                "name": "The Octocat",
+                "company": "@github",
+                "email": "octocat@github.com",
+                "avatar_url": "https://github.com/images/error/octocat.gif",
+            },
+        )
+
+        result = await github.get_connected_account(mock_context)
+
+        assert result.type == ResultType.CONNECTED_ACCOUNT
+        assert result.result.username == "octocat"
+        assert result.result.email == "octocat@github.com"
+        assert result.result.first_name == "The"
+        assert result.result.last_name == "Octocat"
+        assert result.result.user_id == "1"
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_empty_info_instead_of_crashing(self, mock_context):
+        # Reproduces the Raygun "Unhandled" Lambda crash: an HTTPError raised by
+        # context.fetch (e.g., revoked/expired token) used to propagate out of the
+        # handler and crash the Lambda. Handler must absorb it and return a valid
+        # (empty) ConnectedAccountInfo so the Lambda returns normally.
+        mock_context.fetch.side_effect = HTTPError(401, "Bad credentials")
+
+        result = await github.get_connected_account(mock_context)
+
+        assert result.type == ResultType.CONNECTED_ACCOUNT
+        assert result.result.username is None
+        assert result.result.email is None
+        assert result.result.user_id is None
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_empty_info(self, mock_context):
+        mock_context.fetch.side_effect = Exception("network unreachable")
+
+        result = await github.get_connected_account(mock_context)
+
+        assert result.type == ResultType.CONNECTED_ACCOUNT
+        assert result.result.username is None


### PR DESCRIPTION
## Summary

This PR closes known fragility holes that can produce the `Unhandled` Lambda error seen in Raygun (`integration-github:14`). The reviewer noted the original Raygun instance was triggered inside `list_commits`, not the connected-account path — so this PR covers both, plus a defensive widening of the action decorator. **Updated after review feedback from @TheRealAgentK to add deterministic page-limit controls and observability.**

### 1. Connected-account handler (original scope)
`GitHubConnectedAccountHandler.get_account_info` had no error handling. The SDK's `Integration.get_connected_account()` also doesn't catch handler exceptions, so any `HTTPError` (revoked/expired token, 5xx outage) propagated out of the Lambda.

**Fix:** wrap `GitHubAPI.get_user(context)` in `try/except`, log a warning, and return an empty `ConnectedAccountInfo` so the Lambda returns normally.

### 2. `list_commits` / `get_commit` null-author crash
The result-shaping code accessed `commit["commit"]["author"]["name"]` directly. GitHub returns `commit.author = null` for commits whose email isn't tied to a GitHub user (deleted accounts, bot commits), which raised `TypeError` mid-action.

**Fix:** new `_commit_summary` helper uses `.get()` chains and treats null author/committer as `{name: null, email: null, date: null}`. Output schema updated to allow `date = null` to match.

### 3. `handle_github_errors` decorator — defensive `CancelledError` catch
The decorator's `except Exception` does not catch `asyncio.CancelledError` (a `BaseException`). If cooperative cancellation ever reaches the action coroutine it would surface as `Unhandled`.

**Fix:** explicit `except asyncio.CancelledError` returns a clean `ActionError`. **Comment rewritten per @TheRealAgentK's suggestion** — this catch does *not* claim to catch Lambda hard timeouts (those kill the process at the OS level, no Python exception fires). It only handles cooperative cancellation reaching the coroutine. Kept as defensive instrumentation; the new `logger.warning` (section 5) will let us verify in production whether this path ever fires.

### 4. Deterministic page-limit on `paginated_fetch` (added per review)

@TheRealAgentK identified the likely upstream cause: `paginated_fetch` had a `while True` loop that ran until GitHub returned a short page. On a large repo, `list_commits` could keep paging until the Lambda runtime cancelled the task — making the `CancelledError` catch reactive rather than preventative.

**Fix:**
- `paginated_fetch` now takes `max_pages: int = 10` and raises `TimeoutError` with guidance to narrow the request (e.g. `sha`, `path`, `since`, `until`) when exceeded.
- `get_commits` forwards `max_pages` to `paginated_fetch`.
- `ListCommits` action reads `max_pages` from inputs (default 10).
- `config.json` exposes `max_pages` as an optional input so callers can raise the cap when they actually need more than 1000 commits.

### 5. Logging (added per review)

@TheRealAgentK asked for *"more details to see what's really going on."* Added two `logger.warning` calls:
- When `paginated_fetch` hits `max_pages` — logs URL, cap value, and items collected.
- When the `CancelledError` catch fires — logs the action name (so we can verify Kai's hypothesis that this path rarely fires in production).

## Caveat on root cause attribution

The actual Python traceback for the original production `Unhandled` events is **not available** — the .NET wrapper that talks to the Lambda only forwards the AWS `FunctionError: Unhandled` header to Raygun, not the `LogResult` payload that contains the Python traceback. The most likely mechanism (unbounded pagination → Lambda runtime cancellation) is now addressed preventatively by section 4. The other fixes each close a real, independently demonstrable fragility identified during code review. A follow-up to forward `LogResult` to Raygun would let us tie future incidents to a specific cause faster.

**Known scope gap:** `get_pull_requests` has its own pagination loop (not using `paginated_fetch`) and is still unbounded if the caller doesn't pass `limit`. Same bug class as Kai flagged. Deferred to a follow-up — the new logging will help us detect if it fires in production before then.

## Test plan (verified locally)

- [x] **92 unit tests pass** (82 prior + 10 new across all scopes of this PR)
- [x] New tests added in this PR:
  - **Connected-account fix:** `TestConnectedAccount::test_returns_populated_account_info`, `test_http_error_returns_empty_info_instead_of_crashing`, `test_generic_exception_returns_empty_info`
  - **Null author/committer fix:** `TestListCommits::test_null_author_does_not_crash`, `test_null_committer_does_not_crash`, `TestGetCommit::test_null_author_does_not_crash`
  - **`CancelledError` catch:** `TestListCommits::test_cancelled_error_returns_action_error`
  - **`max_pages` cap (post-review):**
    - `TestListCommits::test_max_pages_cap_stops_unbounded_pagination` — confirms `max_pages: 2` input stops after exactly 2 fetches with the cap message
    - `TestListCommits::test_default_max_pages_is_ten` — confirms default cap fires at 10 fetches when no override is passed
    - `TestListCommits::test_completes_under_cap_without_firing` — regression guard: 3 pages of data with the default cap of 10 must complete naturally and return all 230 items (catches off-by-one bugs where the cap fires one iteration too early and silently truncates results)
- [x] `validate_integration.py github` — passed
- [x] `check_code.py github` — passed (lint, format, bandit, pip-audit, config sync, fetch patterns)

## Production verification (for reviewer / QA)

**For the connected-account path:**
1. Connect a GitHub account normally.
2. Revoke Autohive's access in GitHub → Settings → Applications → Authorized OAuth Apps.
3. Trigger the connected-account refresh (reload Integrations page).
4. **Expected:** integration card stays usable; no new `Unhandled` event in Raygun.

**For the `list_commits` null-author path:**
1. Pick an old open-source repo with commits authored by deleted GitHub accounts.
2. Run `list_commits` on it.
3. **Expected:** returns commits with `author: null` fields rather than crashing.

**For the `max_pages` cap:**
1. Run `list_commits` against a large repo (e.g. `torvalds/linux`) with no filters and `max_pages: 2`.
2. **Expected:** returns an `ActionError` after exactly 2 page fetches with message `"GitHub pagination stopped after 2 pages..."`. CloudWatch shows the corresponding `logger.warning`.
3. Re-run with `since="2026-05-01T00:00:00Z"` (recent date — small enough commit window to fit under the default cap) and no `max_pages` override.
4. **Expected:** completes normally, returns commits since that date.
