### PR TITLE
fix(google-calendar, google-looker): address post-merge review comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,13 @@
 # OAuth2 access token with scope: https://www.googleapis.com/auth/calendar
 # GOOGLE_CALENDAR_ACCESS_TOKEN=
 
+# -- Google Looker --
+# LOOKER_BASE_URL=
+# LOOKER_CLIENT_ID=
+# LOOKER_CLIENT_SECRET=
+# LOOKER_TEST_DASHBOARD_ID=
+# LOOKER_TEST_MODEL_NAME=
+
 # -- Google Forms --
 # OAuth2 access token with scopes: forms.body, forms.responses.readonly
 # GOOGLE_FORMS_ACCESS_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,10 @@
 # GOOGLE_SHEETS_ACCESS_TOKEN=
 # GOOGLE_SHEETS_TEST_SPREADSHEET_ID=
 
+# -- Google Calendar --
+# OAuth2 access token with scope: https://www.googleapis.com/auth/calendar
+# GOOGLE_CALENDAR_ACCESS_TOKEN=
+
 # -- Google Forms --
 # OAuth2 access token with scopes: forms.body, forms.responses.readonly
 # GOOGLE_FORMS_ACCESS_TOKEN=

--- a/google-calendar/README.md
+++ b/google-calendar/README.md
@@ -40,8 +40,8 @@ No additional configuration fields are required as authentication is handled thr
 - **Description:** List events from a specified Google Calendar with optional filtering and pagination
 - **Inputs:**
   - `calendar_id`: Calendar ID to list events from (use 'primary' for user's main calendar)
-  - `time_min`: Filter events after this time (RFC3339 timestamp, optional)
-  - `time_max`: Filter events before this time (RFC3339 timestamp, optional)
+  - `time_min`: Exclusive lower bound on event **end time** (RFC3339, optional). Events whose end time is after this value are included — long events that started before the bound but end after it will still appear.
+  - `time_max`: Exclusive upper bound on event **start time** (RFC3339, optional). Only events that start before this value are returned.
   - `max_results`: Maximum number of events to return (1-2500, optional)
   - `page_token`: Pagination token for retrieving next page (optional)
 - **Outputs:**

--- a/google-calendar/README.md
+++ b/google-calendar/README.md
@@ -71,7 +71,7 @@ No additional configuration fields are required as authentication is handled thr
   - `start_datetime`: Start time for timed events (RFC3339 format, optional)
   - `end_datetime`: End time for timed events (RFC3339 format, optional)
   - `start_date`: Start date for all-day events (YYYY-MM-DD format, optional)
-  - `end_date`: End date for all-day events (YYYY-MM-DD format, optional)
+  - `end_date`: End date for all-day events (YYYY-MM-DD, **exclusive**). For a single-day event on 2026-06-15, pass `end_date="2026-06-16"` (optional)
   - `location`: Event location (optional)
   - `attendees`: Array of attendee email addresses (optional)
 - **Outputs:**
@@ -90,7 +90,7 @@ No additional configuration fields are required as authentication is handled thr
   - `start_datetime`: Updated start time for timed events (optional)
   - `end_datetime`: Updated end time for timed events (optional)
   - `start_date`: Updated start date for all-day events (optional)
-  - `end_date`: Updated end date for all-day events (optional)
+  - `end_date`: Updated end date for all-day events (YYYY-MM-DD, **exclusive** — same convention as create_event, optional)
   - `location`: Updated event location (optional)
   - `attendees`: Updated attendee list (optional)
 - **Outputs:**

--- a/google-calendar/config.json
+++ b/google-calendar/config.json
@@ -67,7 +67,7 @@
                     },
                     "time_min": {
                         "type": "string",
-                        "description": "Lower bound (inclusive) for an event's start time in RFC3339 format (e.g. '2026-06-01T00:00:00Z')"
+                        "description": "Lower bound (exclusive) for an event's end time in RFC3339 format (e.g. '2026-06-01T00:00:00Z'). Events whose end time is after this value are returned, including long events that started before it."
                     },
                     "time_max": {
                         "type": "string",

--- a/google-calendar/config.json
+++ b/google-calendar/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Google Calendar",
     "display_name": "Google Calendar",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Google Calendar integration for managing calendars, events, and recurring event instances.",
     "entry_point": "google_calendar.py",
     "auth": {

--- a/google-calendar/config.json
+++ b/google-calendar/config.json
@@ -267,7 +267,7 @@
                     },
                     "end_date": {
                         "type": "string",
-                        "description": "Event end date in YYYY-MM-DD format. Use with start_date for all-day events."
+                        "description": "Event end date in YYYY-MM-DD format (exclusive). For a single-day event on 2026-06-15, pass '2026-06-16'. Use with start_date for all-day events."
                     },
                     "location": {
                         "type": "string",
@@ -341,7 +341,7 @@
                     },
                     "end_date": {
                         "type": "string",
-                        "description": "New event end date in YYYY-MM-DD format for all-day events. Use with start_date."
+                        "description": "New event end date in YYYY-MM-DD format (exclusive). For a single-day event on 2026-06-15, pass '2026-06-16'. Use with start_date for all-day events."
                     },
                     "location": {
                         "type": "string",

--- a/google-calendar/config.json
+++ b/google-calendar/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Google Calendar",
     "display_name": "Google Calendar",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Google Calendar integration for managing calendars, events, and recurring event instances.",
     "entry_point": "google_calendar.py",
     "auth": {

--- a/google-calendar/google_calendar.py
+++ b/google-calendar/google_calendar.py
@@ -90,15 +90,15 @@ class ListEvents(ActionHandler):
                 "singleEvents": "true",
                 "orderBy": "startTime",
             }
-            if "time_min" in inputs:
+            if inputs.get("time_min") is not None:
                 params["timeMin"] = inputs["time_min"]
-            if "time_max" in inputs:
+            if inputs.get("time_max") is not None:
                 params["timeMax"] = inputs["time_max"]
-            if "max_results" in inputs:
+            if inputs.get("max_results") is not None:
                 params["maxResults"] = inputs["max_results"]
-            if "page_token" in inputs:
+            if inputs.get("page_token") is not None:
                 params["pageToken"] = inputs["page_token"]
-            if "query" in inputs:
+            if inputs.get("query") is not None:
                 params["q"] = inputs["query"]
 
             response = await context.fetch(
@@ -143,16 +143,16 @@ class CreateEvent(ActionHandler):
 
             event_data: Dict[str, Any] = {"summary": inputs["summary"]}
 
-            if "description" in inputs:
+            if inputs.get("description") is not None:
                 event_data["description"] = inputs["description"]
-            if "location" in inputs:
+            if inputs.get("location") is not None:
                 event_data["location"] = inputs["location"]
 
-            if "start_datetime" in inputs and "end_datetime" in inputs:
+            if inputs.get("start_datetime") is not None and inputs.get("end_datetime") is not None:
                 timezone = inputs.get("timezone", "UTC")
                 event_data["start"] = {"dateTime": inputs["start_datetime"], "timeZone": timezone}
                 event_data["end"] = {"dateTime": inputs["end_datetime"], "timeZone": timezone}
-            elif "start_date" in inputs and "end_date" in inputs:
+            elif inputs.get("start_date") is not None and inputs.get("end_date") is not None:
                 event_data["start"] = {"date": inputs["start_date"]}
                 event_data["end"] = {"date": inputs["end_date"]}
 
@@ -183,23 +183,23 @@ class UpdateEvent(ActionHandler):
             )
             event_data = dict(_unwrap(existing_response))
 
-            if "summary" in inputs:
+            if inputs.get("summary") is not None:
                 event_data["summary"] = inputs["summary"]
-            if "description" in inputs:
+            if inputs.get("description") is not None:
                 event_data["description"] = inputs["description"]
-            if "location" in inputs:
+            if inputs.get("location") is not None:
                 event_data["location"] = inputs["location"]
 
-            if "start_datetime" in inputs and "end_datetime" in inputs:
+            if inputs.get("start_datetime") is not None and inputs.get("end_datetime") is not None:
                 timezone = inputs.get("timezone", event_data.get("start", {}).get("timeZone", "UTC"))
                 event_data["start"] = {"dateTime": inputs["start_datetime"], "timeZone": timezone}
                 event_data["end"] = {"dateTime": inputs["end_datetime"], "timeZone": timezone}
-            elif "start_date" in inputs and "end_date" in inputs:
+            elif inputs.get("start_date") is not None and inputs.get("end_date") is not None:
                 event_data["start"] = {"date": inputs["start_date"]}
                 event_data["end"] = {"date": inputs["end_date"]}
 
             if "attendees" in inputs:
-                if inputs["attendees"]:
+                if inputs.get("attendees"):
                     event_data["attendees"] = [{"email": email} for email in inputs["attendees"]]
                 else:
                     event_data.pop("attendees", None)

--- a/google-calendar/google_calendar.py
+++ b/google-calendar/google_calendar.py
@@ -149,7 +149,7 @@ class CreateEvent(ActionHandler):
                 event_data["location"] = inputs["location"]
 
             if inputs.get("start_datetime") is not None and inputs.get("end_datetime") is not None:
-                timezone = inputs.get("timezone", "UTC")
+                timezone = inputs.get("timezone") or "UTC"
                 event_data["start"] = {"dateTime": inputs["start_datetime"], "timeZone": timezone}
                 event_data["end"] = {"dateTime": inputs["end_datetime"], "timeZone": timezone}
             elif inputs.get("start_date") is not None and inputs.get("end_date") is not None:
@@ -191,15 +191,15 @@ class UpdateEvent(ActionHandler):
                 event_data["location"] = inputs["location"]
 
             if inputs.get("start_datetime") is not None and inputs.get("end_datetime") is not None:
-                timezone = inputs.get("timezone", event_data.get("start", {}).get("timeZone", "UTC"))
+                timezone = inputs.get("timezone") or event_data.get("start", {}).get("timeZone", "UTC")
                 event_data["start"] = {"dateTime": inputs["start_datetime"], "timeZone": timezone}
                 event_data["end"] = {"dateTime": inputs["end_datetime"], "timeZone": timezone}
             elif inputs.get("start_date") is not None and inputs.get("end_date") is not None:
                 event_data["start"] = {"date": inputs["start_date"]}
                 event_data["end"] = {"date": inputs["end_date"]}
 
-            if "attendees" in inputs:
-                if inputs.get("attendees"):
+            if inputs.get("attendees") is not None:
+                if inputs["attendees"]:
                     event_data["attendees"] = [{"email": email} for email in inputs["attendees"]]
                 else:
                     event_data.pop("attendees", None)

--- a/google-calendar/tests/test_google_calendar_integration.py
+++ b/google-calendar/tests/test_google_calendar_integration.py
@@ -157,7 +157,7 @@ async def test_create_all_day_event(gcal_auth):
                 "calendar_id": CALENDAR_ID,
                 "summary": "[Autohive Test] All Day",
                 "start_date": "2026-07-20",
-                "end_date": "2026-07-20",
+                "end_date": "2026-07-21",
             },
             ctx,
         )

--- a/google-calendar/tests/test_google_calendar_unit.py
+++ b/google-calendar/tests/test_google_calendar_unit.py
@@ -209,6 +209,8 @@ class TestCreateEvent:
 
     @pytest.mark.asyncio
     async def test_all_day_event(self, mock_context):
+        # Google Calendar end.date is exclusive: a single-day event on 2026-06-15
+        # requires end.date = 2026-06-16.
         mock_context.fetch.return_value = make_fetch_response({"id": "e1", "summary": "All Day"})
         await google_calendar.execute_action(
             "create_event",
@@ -216,13 +218,13 @@ class TestCreateEvent:
                 "calendar_id": "primary",
                 "summary": "All Day",
                 "start_date": "2026-06-15",
-                "end_date": "2026-06-15",
+                "end_date": "2026-06-16",
             },
             mock_context,
         )
         body = mock_context.fetch.call_args[1]["json"]
         assert body["start"] == {"date": "2026-06-15"}
-        assert body["end"] == {"date": "2026-06-15"}
+        assert body["end"] == {"date": "2026-06-16"}
 
     @pytest.mark.asyncio
     async def test_adds_attendees(self, mock_context):


### PR DESCRIPTION
## Summary

Addresses post-merge review comments from #339, plus a missing `.env.example` entry flagged for Google Looker (#332).

### Google Calendar
- **`time_min` semantics**: Corrected description — `timeMin` is an exclusive lower bound on event **end time**, not start time
- **`end_date` convention**: Documented and tested that `end.date` is exclusive for all-day events (single-day event on 2026-06-15 requires `end_date="2026-06-16"`)
- **`.env.example`**: Added missing `GOOGLE_CALENDAR_ACCESS_TOKEN` entry
- **Validator warnings**: Replaced `inputs["key"]` with `inputs.get()` for optional params
- **Version bump**: `1.0.0` → `1.1.0` (minor — new `query` and `timezone` inputs)

### Google Looker
- **`.env.example`**: Added missing `LOOKER_BASE_URL`, `LOOKER_CLIENT_ID`, `LOOKER_CLIENT_SECRET`, `LOOKER_TEST_DASHBOARD_ID`, `LOOKER_TEST_MODEL_NAME`

## Commits

- `841104d` — fix: correct `time_min` description
- `cb9e1a4` — chore: add `GOOGLE_CALENDAR_ACCESS_TOKEN` to `.env.example`
- `1b8c6fb` — chore: bump version `1.0.0` → `1.0.1`
- `3e9bcb8` — fix: document and test `end.date` exclusive convention for all-day events
- `ad520f0` — fix: replace `inputs["key"]` with `inputs.get()` to silence validator warnings
- `3246bec` — chore: bump version `1.0.1` → `1.1.0`
- `ade61b5` — chore: add Google Looker env vars to `.env.example`