### PR TITLE
feat(gmail): signature support + datetime filtering and support for finer grained querying

### DIFF
--- a/gmail/README.md
+++ b/gmail/README.md
@@ -11,11 +11,14 @@ HTML email bodies are sanitised with [`bleach`](https://github.com/mozilla/bleac
 Key features:
 
 - Send plain-text or rich-HTML email with attachments, CC, and BCC
+- Optional `signature` input on send/reply/draft actions appends a signature to the body with format-appropriate separators
 - Reply to threads with automatic recipient and subject handling
 - Draft lifecycle: create, update, list, get, send, delete
 - Read inbox / all mail with read/unread filtering and pagination
 - Read full threads and individual messages (with body, headers, and attachments)
+- Time-window filtering via optional `after` / `before` (ISO 8601) inputs on `read_inbox`, `read_all_mail`, and `list_emails_by_label`, plus an optional raw `q` passthrough for power-user Gmail search operators
 - Label management: list, create, apply, remove, list-by-label
+- List per-send-as default signatures via `list_send_as_signatures`
 - Archive and mark as read/unread in batch
 - Pagination via `nextPageToken` on all list endpoints
 
@@ -33,7 +36,7 @@ No additional configuration fields are required as authentication is handled thr
 
 ## Actions
 
-The integration exposes 21 actions across messages, threads, drafts, and labels.
+The integration exposes 22 actions across messages, threads, drafts, labels, and settings.
 
 ### Messages
 
@@ -76,6 +79,12 @@ The integration exposes 21 actions across messages, threads, drafts, and labels.
 | `remove_labels_from_emails` | Remove one or more labels from one or more messages |
 | `list_emails_by_label` | List messages with a given label, paginated |
 
+### Settings
+
+| Action | Description |
+|---|---|
+| `list_send_as_signatures` | List the user's send-as addresses (primary + aliases) with the signature bound to each as the new-mail default. The Gmail API does not expose the user's full saved-signatures library — only the per-send-as default. |
+
 See [`config.json`](config.json) for the full input/output schema of every action.
 
 ## HTML Email Notes
@@ -90,7 +99,7 @@ When `body_format` is `"html"` on `send_email` / `reply_to_thread` / `create_dra
 
 Pinned in [`requirements.txt`](requirements.txt):
 
-- `autohive-integrations-sdk~=1.0.2`
+- `autohive-integrations-sdk~=2.0.0`
 - `google-api-python-client`
 - `google-auth-httplib2`
 - `google-auth-oauthlib`

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Gmail",
     "display_name": "Gmail",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Send, read, and manage emails with labels and threads.",
     "entry_point": "gmail.py",
     "auth": {

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -59,6 +59,10 @@
                         ],
                         "default": "text"
                     },
+                    "signature": {
+                        "type": "string",
+                        "description": "Optional signature to append to the reply body. The signature should use the same format as body_format (plain text for 'text', HTML fragment for 'html')."
+                    },
                     "files": {
                         "type": "array",
                         "description": "List of files to attach to the reply",
@@ -361,6 +365,10 @@
                         ],
                         "default": "text"
                     },
+                    "signature": {
+                        "type": "string",
+                        "description": "Optional signature to append to the email body. The signature should use the same format as body_format (plain text for 'text', HTML fragment for 'html')."
+                    },
                     "files": {
                         "type": "array",
                         "description": "List of files to attach to the email",
@@ -429,6 +437,18 @@
                     "pageToken": {
                         "type": "string",
                         "description": "An optional parameter: The page token to get the next page of results. Use the nextPageToken from a previous response."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Optional: ISO 8601 datetime (e.g. '2024-01-01' or '2024-01-01T15:30:00Z'). Filters to emails received strictly after this instant. UTC is assumed when no timezone offset is supplied."
+                    },
+                    "before": {
+                        "type": "string",
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same format and timezone behavior as 'after'."
+                    },
+                    "q": {
+                        "type": "string",
+                        "description": "Optional: raw Gmail search-syntax string (e.g. 'has:attachment from:alice@example.com'). ANDed with all other filters. Use for operators not exposed as structured inputs."
                     }
                 },
                 "required": [
@@ -529,6 +549,18 @@
                     "include_spam_trash": {
                         "type": "boolean",
                         "description": "An optional parameter: Whether to include emails from spam and trash. When false, emails in trash and spam are excluded. When true, returns all emails including those in trash and spam."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Optional: ISO 8601 datetime (e.g. '2024-01-01' or '2024-01-01T15:30:00Z'). Filters to emails received strictly after this instant. UTC is assumed when no timezone offset is supplied."
+                    },
+                    "before": {
+                        "type": "string",
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same format and timezone behavior as 'after'."
+                    },
+                    "q": {
+                        "type": "string",
+                        "description": "Optional: raw Gmail search-syntax string (e.g. 'has:attachment from:alice@example.com'). ANDed with all other filters. Use for operators not exposed as structured inputs."
                     }
                 },
                 "required": [
@@ -707,6 +739,18 @@
                         "type": "boolean",
                         "description": "An optional parameter: Whether to include archived emails. When false (default), only returns emails in the inbox. When true, returns all emails with the specified labels including archived ones.",
                         "default": false
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Optional: ISO 8601 datetime (e.g. '2024-01-01' or '2024-01-01T15:30:00Z'). Filters to emails received strictly after this instant. UTC is assumed when no timezone offset is supplied."
+                    },
+                    "before": {
+                        "type": "string",
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same format and timezone behavior as 'after'."
+                    },
+                    "q": {
+                        "type": "string",
+                        "description": "Optional: raw Gmail search-syntax string (e.g. 'has:attachment from:alice@example.com'). ANDed with all other filters. Use for operators not exposed as structured inputs."
                     }
                 },
                 "required": [
@@ -1123,6 +1167,10 @@
                         ],
                         "default": "text"
                     },
+                    "signature": {
+                        "type": "string",
+                        "description": "Optional signature to append to the draft body. The signature should use the same format as body_format (plain text for 'text', HTML fragment for 'html')."
+                    },
                     "files": {
                         "type": "array",
                         "description": "List of files to attach to the draft",
@@ -1240,6 +1288,10 @@
                             "html"
                         ],
                         "default": "text"
+                    },
+                    "signature": {
+                        "type": "string",
+                        "description": "Optional signature to append to the draft body. The signature should use the same format as body_format (plain text for 'text', HTML fragment for 'html')."
                     },
                     "files": {
                         "type": "array",
@@ -1572,6 +1624,67 @@
             "output_schema": {
                 "type": "object",
                 "properties": {}
+            }
+        },
+        "list_send_as_signatures": {
+            "display_name": "List Send-As Signatures",
+            "description": "List the signature currently bound to each of the user's send-as addresses (their primary inbox plus any aliases). Important limitation: the Gmail API only exposes the signature that is set as the new-mail default on a given send-as address. If the user has signatures saved in Gmail's web UI but none is assigned as the default for a send-as address, that address's `signature` will come back as an empty string. The Gmail API does not expose the user's full saved-signatures library.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "description": "The user's email address. Special value 'me' indicates the authenticated user.",
+                        "default": "me"
+                    }
+                }
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {
+                    "signatures": {
+                        "type": "array",
+                        "description": "One entry per send-as address the user can send from, with the signature currently bound to it as the new-mail default.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "send_as_email": {
+                                    "type": "string",
+                                    "description": "The send-as email address (e.g. the user's inbox address or an alias like support@example.com)."
+                                },
+                                "display_name": {
+                                    "type": "string",
+                                    "description": "Display name configured for this send-as address. Empty string if not set."
+                                },
+                                "is_primary": {
+                                    "type": "boolean",
+                                    "description": "True if this is the user's primary inbox address."
+                                },
+                                "is_default": {
+                                    "type": "boolean",
+                                    "description": "True if this send-as address is selected as the user's default sending address. (This is the 'default send-as', distinct from the per-address default signature returned in the `signature` field.)"
+                                },
+                                "signature": {
+                                    "type": "string",
+                                    "description": "HTML fragment of the signature currently bound as the new-mail default for this send-as address. Empty string if no signature is bound."
+                                },
+                                "reply_to_address": {
+                                    "type": "string",
+                                    "description": "Reply-to address configured for this send-as alias. Empty string if not set."
+                                }
+                            },
+                            "required": [
+                                "send_as_email",
+                                "is_primary",
+                                "is_default",
+                                "signature"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "signatures"
+                ]
             }
         }
     }

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -440,11 +440,11 @@
                     },
                     "after": {
                         "type": "string",
-                        "description": "Optional: ISO 8601 datetime (e.g. '2024-01-01' or '2024-01-01T15:30:00Z'). Filters to emails received strictly after this instant. UTC is assumed when no timezone offset is supplied."
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly after this instant. Accepted formats: 'YYYY-MM-DD' (interpreted as midnight UTC), full datetime with 'Z' (e.g. '2026-05-27T12:00:00Z'), or with an explicit offset (e.g. '2026-05-28T00:00:00+12:00').\n\nIMPORTANT — timezone caveat: Gmail evaluates this bound in UTC, NOT in the user's local timezone. When filtering by a user-local calendar day (e.g. 'yesterday in the user's timezone'), convert both bounds to UTC first; do not pass the user-local bare date. Example for a UTC+12 user filtering local-day 2026-05-28: after='2026-05-27T12:00:00Z', before='2026-05-28T12:00:00Z'. Passing the bare local dates '2026-05-28' / '2026-05-29' would catch messages from adjacent local-time days because of the offset."
                     },
                     "before": {
                         "type": "string",
-                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same format and timezone behavior as 'after'."
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same accepted formats as 'after'. The same UTC-evaluation caveat applies — see the 'after' description for the full timezone-conversion guidance. For relative-date queries, always pass UTC-converted bounds derived from the user's local timezone."
                     },
                     "q": {
                         "type": "string",
@@ -552,11 +552,11 @@
                     },
                     "after": {
                         "type": "string",
-                        "description": "Optional: ISO 8601 datetime (e.g. '2024-01-01' or '2024-01-01T15:30:00Z'). Filters to emails received strictly after this instant. UTC is assumed when no timezone offset is supplied."
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly after this instant. Accepted formats: 'YYYY-MM-DD' (interpreted as midnight UTC), full datetime with 'Z' (e.g. '2026-05-27T12:00:00Z'), or with an explicit offset (e.g. '2026-05-28T00:00:00+12:00').\n\nIMPORTANT — timezone caveat: Gmail evaluates this bound in UTC, NOT in the user's local timezone. When filtering by a user-local calendar day (e.g. 'yesterday in the user's timezone'), convert both bounds to UTC first; do not pass the user-local bare date. Example for a UTC+12 user filtering local-day 2026-05-28: after='2026-05-27T12:00:00Z', before='2026-05-28T12:00:00Z'. Passing the bare local dates '2026-05-28' / '2026-05-29' would catch messages from adjacent local-time days because of the offset."
                     },
                     "before": {
                         "type": "string",
-                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same format and timezone behavior as 'after'."
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same accepted formats as 'after'. The same UTC-evaluation caveat applies — see the 'after' description for the full timezone-conversion guidance. For relative-date queries, always pass UTC-converted bounds derived from the user's local timezone."
                     },
                     "q": {
                         "type": "string",
@@ -742,11 +742,11 @@
                     },
                     "after": {
                         "type": "string",
-                        "description": "Optional: ISO 8601 datetime (e.g. '2024-01-01' or '2024-01-01T15:30:00Z'). Filters to emails received strictly after this instant. UTC is assumed when no timezone offset is supplied."
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly after this instant. Accepted formats: 'YYYY-MM-DD' (interpreted as midnight UTC), full datetime with 'Z' (e.g. '2026-05-27T12:00:00Z'), or with an explicit offset (e.g. '2026-05-28T00:00:00+12:00').\n\nIMPORTANT — timezone caveat: Gmail evaluates this bound in UTC, NOT in the user's local timezone. When filtering by a user-local calendar day (e.g. 'yesterday in the user's timezone'), convert both bounds to UTC first; do not pass the user-local bare date. Example for a UTC+12 user filtering local-day 2026-05-28: after='2026-05-27T12:00:00Z', before='2026-05-28T12:00:00Z'. Passing the bare local dates '2026-05-28' / '2026-05-29' would catch messages from adjacent local-time days because of the offset."
                     },
                     "before": {
                         "type": "string",
-                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same format and timezone behavior as 'after'."
+                        "description": "Optional: ISO 8601 datetime. Filters to emails received strictly before this instant. Same accepted formats as 'after'. The same UTC-evaluation caveat applies — see the 'after' description for the full timezone-conversion guidance. For relative-date queries, always pass UTC-converted bounds derived from the user's local timezone."
                     },
                     "q": {
                         "type": "string",

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -1,5 +1,6 @@
 from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult, ActionError
 
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -12,6 +13,38 @@ import html2text
 import bleach
 
 gmail = Integration.load()
+
+
+def build_date_clause(after: str = "", before: str = "") -> str:
+    """Translate ISO 8601 datetime bounds into a Gmail-search-syntax fragment.
+
+    Returns an empty string when both inputs are empty/None. Raises ValueError
+    on a malformed input — the calling handler wraps that in ``ActionError``.
+
+    Why unix-seconds and not Gmail's ``YYYY/MM/DD`` form: the date form is
+    interpreted in the account's local timezone, which is opaque to the caller.
+    Unix timestamps are unambiguous UTC, and give second-level precision for free.
+    """
+
+    def _to_unix_seconds(value: str, which: str) -> int:
+        # ``datetime.fromisoformat`` accepts a bare ``Z`` suffix only on Python
+        # 3.11+. Normalize to ``+00:00`` so we run on older runtimes too.
+        normalized = value.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError(f"Invalid '{which}' datetime '{value}': {exc}") from exc
+        # Treat naive datetimes as UTC for caller predictability.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+
+    fragments = []
+    if after:
+        fragments.append(f"after:{_to_unix_seconds(after, 'after')}")
+    if before:
+        fragments.append(f"before:{_to_unix_seconds(before, 'before')}")
+    return " ".join(fragments)
 
 
 def create_email_message(body: str, files: list = None, is_html: bool = False) -> MIMEMultipart:
@@ -159,6 +192,22 @@ def create_email_message(body: str, files: list = None, is_html: bool = False) -
     return message
 
 
+def append_signature(body: str, signature: str = "", is_html: bool = False) -> str:
+    """Append a signature to an email body using format-appropriate separators.
+
+    Plain text uses the conventional ``\\n\\n-- \\n`` separator (RFC 3676);
+    HTML uses ``<br><br>-- <br>`` so the separator survives rendering. Returns
+    the body unchanged when no signature is provided.
+    """
+    body = body or ""
+    signature = signature or ""
+    if not signature:
+        return body
+    if is_html:
+        return f"{body}<br><br>-- <br>{signature}" if body else signature
+    return f"{body}\n\n-- \n{signature}" if body else signature
+
+
 def _normalize_addresses(value) -> str:
     """Accept either a string or a list of strings and return a comma-joined header value.
 
@@ -201,7 +250,7 @@ def build_raw_email(
     body_format = inputs.get("body_format", "text")
     is_html = body_format == "html"
     input_files = inputs.get("files", [])
-    body = inputs.get("body", "")
+    body = append_signature(inputs.get("body", ""), inputs.get("signature", ""), is_html)
     message = create_email_message(body, input_files, is_html)
 
     # From — skip the "me" sentinel used by SendEmail
@@ -594,11 +643,15 @@ class ReadInbox(ActionHandler):
             scope = inputs.get("scope", "all")
 
             if scope == "unread":
-                query = "is:unread in:inbox"
+                scope_clause = "is:unread in:inbox"
             elif scope == "read":
-                query = "-is:unread in:inbox"
+                scope_clause = "-is:unread in:inbox"
             else:  # 'all'
-                query = "in:inbox"
+                scope_clause = "in:inbox"
+
+            date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
+            raw_q = inputs.get("q", "")
+            query = " ".join(part for part in (scope_clause, date_clause, raw_q) if part)
 
             request_params = {"userId": user_id, "q": query}
             if "pageToken" in inputs:
@@ -641,11 +694,15 @@ class ReadAllMail(ActionHandler):
             scope = inputs.get("scope", "all")
 
             if scope == "unread":
-                query = "is:unread"
+                scope_clause = "is:unread"
             elif scope == "read":
-                query = "-is:unread"
+                scope_clause = "-is:unread"
             else:  # 'all'
-                query = ""
+                scope_clause = ""
+
+            date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
+            raw_q = inputs.get("q", "")
+            query = " ".join(part for part in (scope_clause, date_clause, raw_q) if part)
 
             request_params = {"userId": user_id, "includeSpamTrash": include_spam_trash}
             if query:
@@ -732,8 +789,12 @@ class ListEmailsByLabel(ActionHandler):
                 if not inbox_already_specified:
                     label_query += " in:inbox"
 
+            date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
+            raw_q = inputs.get("q", "")
+            query = " ".join(part for part in (label_query, date_clause, raw_q) if part)
+
             # Build request parameters
-            request_params = {"userId": user_id, "q": label_query}
+            request_params = {"userId": user_id, "q": query}
 
             if "pageToken" in inputs:
                 request_params["pageToken"] = inputs["pageToken"]
@@ -1204,6 +1265,34 @@ class DeleteDraft(ActionHandler):
             request.execute()
 
             return ActionResult(data={}, cost_usd=0.0)
+
+        except Exception as e:
+            return ActionError(message=str(e))
+
+
+@gmail.action("list_send_as_signatures")
+class ListSendAsSignatures(ActionHandler):
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
+        try:
+            service = build_gmail_service(context)
+            user_id = inputs.get("user_id", "me")
+
+            response = service.users().settings().sendAs().list(userId=user_id).execute()
+            aliases = response.get("sendAs", [])
+
+            signatures = [
+                {
+                    "send_as_email": alias.get("sendAsEmail", ""),
+                    "display_name": alias.get("displayName", ""),
+                    "is_primary": alias.get("isPrimary", False),
+                    "is_default": alias.get("isDefault", False),
+                    "signature": alias.get("signature") or "",
+                    "reply_to_address": alias.get("replyToAddress", ""),
+                }
+                for alias in aliases
+            ]
+
+            return ActionResult(data={"signatures": signatures}, cost_usd=0.0)
 
         except Exception as e:
             return ActionError(message=str(e))

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -47,6 +47,20 @@ def build_date_clause(after: str = "", before: str = "") -> str:
     return " ".join(fragments)
 
 
+def compose_messages_query(base_clause: str, inputs: Dict[str, Any]) -> str:
+    """Compose the ``q`` value for ``messages.list`` from a per-action base
+    clause plus the shared optional ``after`` / ``before`` / ``q`` inputs.
+
+    Shared by ``read_inbox``, ``read_all_mail``, and ``list_emails_by_label``
+    so the AND-join order (base → date → raw) and empty-fragment handling
+    stay consistent. Returns an empty string when every fragment is empty —
+    callers decide whether to drop the ``q`` kwarg entirely in that case.
+    """
+    date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
+    raw_q = inputs.get("q", "")
+    return " ".join(part for part in (base_clause, date_clause, raw_q) if part)
+
+
 def create_email_message(body: str, files: list = None, is_html: bool = False) -> MIMEMultipart:
     """Create email message with optional files and HTML support.
 
@@ -649,9 +663,7 @@ class ReadInbox(ActionHandler):
             else:  # 'all'
                 scope_clause = "in:inbox"
 
-            date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
-            raw_q = inputs.get("q", "")
-            query = " ".join(part for part in (scope_clause, date_clause, raw_q) if part)
+            query = compose_messages_query(scope_clause, inputs)
 
             request_params = {"userId": user_id, "q": query}
             if "pageToken" in inputs:
@@ -700,9 +712,7 @@ class ReadAllMail(ActionHandler):
             else:  # 'all'
                 scope_clause = ""
 
-            date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
-            raw_q = inputs.get("q", "")
-            query = " ".join(part for part in (scope_clause, date_clause, raw_q) if part)
+            query = compose_messages_query(scope_clause, inputs)
 
             request_params = {"userId": user_id, "includeSpamTrash": include_spam_trash}
             if query:
@@ -789,9 +799,7 @@ class ListEmailsByLabel(ActionHandler):
                 if not inbox_already_specified:
                     label_query += " in:inbox"
 
-            date_clause = build_date_clause(inputs.get("after", ""), inputs.get("before", ""))
-            raw_q = inputs.get("q", "")
-            query = " ".join(part for part in (label_query, date_clause, raw_q) if part)
+            query = compose_messages_query(label_query, inputs)
 
             # Build request parameters
             request_params = {"userId": user_id, "q": query}

--- a/gmail/tests/test_gmail_integration.py
+++ b/gmail/tests/test_gmail_integration.py
@@ -124,6 +124,38 @@ class TestReadInbox:
         )
         assert second.type == ResultType.ACTION
 
+    @pytest.mark.asyncio
+    async def test_after_filter_accepts_iso_datetime(self, live_context):
+        # ``after`` filters to messages received strictly after the given
+        # instant. Using "one hour ago" keeps the response small and avoids
+        # account-dependent assertions on specific message content.
+        from datetime import datetime, timedelta, timezone
+
+        one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        result = await gmail.execute_action(
+            "read_inbox",
+            {"user_id": "me", "scope": "all", "after": one_hour_ago},
+            live_context,
+        )
+        # Either zero results or some results — both are valid. We just want
+        # to confirm Gmail accepted the composed query and the integration
+        # returned a clean ActionResult, not an ActionError.
+        assert result.type == ResultType.ACTION
+        assert isinstance(result.result.data["emails"], list)
+
+    @pytest.mark.asyncio
+    async def test_raw_q_passthrough_is_anded(self, live_context):
+        # Raw ``q`` is ANDed into the query. ``label:INBOX`` is redundant with
+        # the scope clause but should not break anything — a no-op extra
+        # constraint that confirms the passthrough wiring.
+        result = await gmail.execute_action(
+            "read_inbox",
+            {"user_id": "me", "scope": "all", "q": "label:INBOX"},
+            live_context,
+        )
+        assert result.type == ResultType.ACTION
+        assert isinstance(result.result.data["emails"], list)
+
 
 class TestReadAllMail:
     """Lists messages across the entire mailbox."""
@@ -201,6 +233,36 @@ class TestListEmailsByLabelChained:
         )
         assert result.type == ResultType.ACTION
         assert isinstance(result.result.data["emails"], list)
+
+
+class TestListSendAsSignatures:
+    """Read-only — lists each send-as address (primary + aliases) and the
+    signature currently bound to it as the new-mail default. The Gmail API
+    does not expose the full saved-signature library, only this per-address
+    default."""
+
+    @pytest.mark.asyncio
+    async def test_returns_at_least_primary_address(self, live_context):
+        result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, live_context)
+        assert result.type == ResultType.ACTION
+        data = result.result.data
+        assert "signatures" in data
+        assert isinstance(data["signatures"], list)
+        # Every account has at least its own inbox address as a send-as.
+        assert len(data["signatures"]) >= 1
+        primary = next((s for s in data["signatures"] if s["is_primary"]), None)
+        assert primary is not None, "expected exactly one primary send-as address"
+
+    @pytest.mark.asyncio
+    async def test_each_entry_has_required_fields(self, live_context):
+        result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, live_context)
+        assert result.type == ResultType.ACTION
+        for entry in result.result.data["signatures"]:
+            # Required-by-schema fields with correct types.
+            assert isinstance(entry["send_as_email"], str) and entry["send_as_email"]
+            assert isinstance(entry["is_primary"], bool)
+            assert isinstance(entry["is_default"], bool)
+            assert isinstance(entry["signature"], str)  # may be empty if no default bound
 
 
 # ============================================================
@@ -334,6 +396,61 @@ class TestSendEmailLifecycle:
         assert read_result.type == ResultType.ACTION
 
         # 3. Cleanup: archive (remove from inbox)
+        archive_result = await gmail.execute_action(
+            "archive_emails",
+            {"user_id": "me", "ids": [sent_message_id]},
+            live_context,
+        )
+        assert archive_result.type == ResultType.ACTION
+
+
+@pytest.mark.destructive
+class TestSendEmailWithSignatureLifecycle:
+    """LIFECYCLE: sends a real email with the ``signature`` input set, reads
+    it back to confirm the signature was appended to the body, then archives
+    it.
+
+    What is created: 1 outbound email + 1 inbound email (same message, sent
+    and received by the same account). Subject: "[AH integration test {pid}]
+    gmail signature self-test". Cleanup: the inbound copy is archived.
+    """
+
+    @pytest.mark.asyncio
+    async def test_signature_appears_in_sent_body(self, live_context):
+        profile = await gmail.execute_action("get_user_info", {"user_id": "me"}, live_context)
+        my_address = profile.result.data["user_info"]["email_address"]
+
+        # Unique signature token so we can grep for it in the body unambiguously.
+        sig_token = f"sig-token-{os.getpid()}"
+        subject = f"[AH integration test {os.getpid()}] gmail signature self-test"
+
+        send_result = await gmail.execute_action(
+            "send_email",
+            {
+                "to": [my_address],
+                "subject": subject,
+                "body": "Signed message from the integration test suite.",
+                "signature": f"Best,\nIntegration Test {sig_token}",
+            },
+            live_context,
+        )
+        assert send_result.type == ResultType.ACTION, send_result
+        sent_message_id = send_result.result.data["id"]
+        assert sent_message_id
+
+        # Read the message back and confirm the signature landed in the body.
+        read_result = await gmail.execute_action(
+            "read_email",
+            {"user_id": "me", "email_id": sent_message_id},
+            live_context,
+        )
+        assert read_result.type == ResultType.ACTION
+        body = read_result.result.data["email"]["body"]
+        assert sig_token in body, f"signature token not found in body: {body!r}"
+        # Standard plain-text signature separator should also be present.
+        assert "-- " in body
+
+        # Cleanup: archive (remove from inbox).
         archive_result = await gmail.execute_action(
             "archive_emails",
             {"user_id": "me", "ids": [sent_message_id]},

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from autohive_integrations_sdk.integration import ResultType
 
-from gmail.gmail import gmail, create_email_message, build_raw_email
+from gmail.gmail import gmail, create_email_message, build_raw_email, build_date_clause, append_signature
 
 pytestmark = pytest.mark.unit
 
@@ -213,6 +213,123 @@ class TestBuildRawEmail:
             )
         )
         assert msg["References"] == "<old@example.com> <new@example.com>"
+
+
+class TestAppendSignature:
+    """Tests for the append_signature helper."""
+
+    def test_text_separator(self):
+        assert append_signature("Hello", "Best,\nMe", is_html=False) == "Hello\n\n-- \nBest,\nMe"
+
+    def test_html_separator(self):
+        result = append_signature("<p>Hi</p>", "<p>Best,<br>Me</p>", is_html=True)
+        assert result == "<p>Hi</p><br><br>-- <br><p>Best,<br>Me</p>"
+
+    def test_empty_signature_returns_body_unchanged(self):
+        assert append_signature("Hello", "", is_html=False) == "Hello"
+        assert append_signature("Hello", "", is_html=True) == "Hello"
+
+    def test_none_signature_returns_body_unchanged(self):
+        # Defensive: ``inputs.get("signature", "")`` could pass through ``None``
+        # if a caller sends ``"signature": null`` explicitly.
+        assert append_signature("Hello", None, is_html=False) == "Hello"
+
+    def test_empty_body_returns_signature_only(self):
+        assert append_signature("", "Best,\nMe", is_html=False) == "Best,\nMe"
+        assert append_signature("", "<p>Me</p>", is_html=True) == "<p>Me</p>"
+
+    def test_none_body_treated_as_empty(self):
+        assert append_signature(None, "Best,\nMe", is_html=False) == "Best,\nMe"
+
+    def test_both_empty_returns_empty(self):
+        assert append_signature("", "", is_html=False) == ""
+
+
+class TestBuildRawEmailSignature:
+    """End-to-end signature wiring through build_raw_email — every send/reply/
+    draft handler funnels through this helper, so a single point of coverage
+    here proves signatures land on all four actions."""
+
+    def test_plain_text_body_includes_signature(self):
+        msg = _decode_raw(
+            build_raw_email(
+                {
+                    "to": "alice@example.com",
+                    "subject": "Hi",
+                    "body": "Hello Alice",
+                    "signature": "Best,\nMe",
+                }
+            )
+        )
+        rendered = _decoded_text(msg)
+        assert "Hello Alice" in rendered
+        assert "-- " in rendered
+        assert "Best," in rendered
+
+    def test_html_body_includes_signature_in_html_part(self):
+        msg = _decode_raw(
+            build_raw_email(
+                {
+                    "to": "alice@example.com",
+                    "subject": "Hi",
+                    "body": "<p>Hello Alice</p>",
+                    "body_format": "html",
+                    "signature": "<p>Best, <b>Me</b></p>",
+                }
+            )
+        )
+        # Walk multipart, find the text/html part specifically.
+        html_payload = next(
+            part.get_payload(decode=True).decode("utf-8")
+            for part in msg.walk()
+            if part.get_content_type() == "text/html"
+        )
+        assert "Hello Alice" in html_payload
+        assert "<b>Me</b>" in html_payload
+
+    def test_no_signature_input_leaves_body_unchanged(self):
+        msg = _decode_raw(build_raw_email({"to": "alice@example.com", "subject": "Hi", "body": "Hello Alice"}))
+        rendered = _decoded_text(msg)
+        assert "Hello Alice" in rendered
+        assert "-- " not in rendered
+
+
+class TestBuildDateClause:
+    """Tests for the build_date_clause helper that translates ISO 8601 bounds
+    into Gmail's ``after:<unix> before:<unix>`` search-syntax fragment."""
+
+    def test_bare_date_after_only(self):
+        # 2024-01-01 00:00 UTC == 1704067200 seconds since the epoch.
+        assert build_date_clause(after="2024-01-01") == "after:1704067200"
+
+    def test_bare_date_before_only(self):
+        assert build_date_clause(before="2024-01-01") == "before:1704067200"
+
+    def test_full_datetime_with_z_suffix(self):
+        # 2024-01-01T12:00:00Z == 1704067200 + 43200 = 1704110400.
+        assert build_date_clause(after="2024-01-01T12:00:00Z") == "after:1704110400"
+
+    def test_full_datetime_with_offset(self):
+        assert build_date_clause(after="2024-01-01T12:00:00+00:00") == "after:1704110400"
+
+    def test_naive_datetime_treated_as_utc(self):
+        # No timezone in input — must be interpreted as UTC, not local.
+        assert build_date_clause(after="2024-01-01T12:00:00") == "after:1704110400"
+
+    def test_both_bounds_after_first(self):
+        result = build_date_clause(after="2024-01-01", before="2024-02-01")
+        assert result == "after:1704067200 before:1706745600"
+
+    def test_empty_inputs_return_empty(self):
+        assert build_date_clause() == ""
+        assert build_date_clause(after="", before="") == ""
+        assert build_date_clause(after=None, before=None) == ""
+
+    def test_malformed_input_raises_value_error(self):
+        with pytest.raises(ValueError, match="after"):
+            build_date_clause(after="not a date")
+        with pytest.raises(ValueError, match="before"):
+            build_date_clause(before="2024-13-99")
 
 
 # ============================================================
@@ -449,6 +566,83 @@ class TestReadInbox:
             result = await gmail.execute_action("read_inbox", {"user_id": "me", "scope": "all"}, mock_context)
         assert result.type == ResultType.ACTION_ERROR
 
+    @pytest.mark.asyncio
+    async def test_after_only_appends_date_clause(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_inbox",
+                {"user_id": "me", "scope": "all", "after": "2024-01-01"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        # Scope clause first, then date clause, no raw q.
+        assert call.kwargs["q"] == "in:inbox after:1704067200"
+
+    @pytest.mark.asyncio
+    async def test_before_only(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_inbox",
+                {"user_id": "me", "scope": "all", "before": "2024-02-01"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "in:inbox before:1706745600"
+
+    @pytest.mark.asyncio
+    async def test_raw_q_appended_to_scope(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_inbox",
+                {"user_id": "me", "scope": "unread", "q": "has:attachment"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "is:unread in:inbox has:attachment"
+
+    @pytest.mark.asyncio
+    async def test_combined_scope_date_and_raw_q(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_inbox",
+                {
+                    "user_id": "me",
+                    "scope": "unread",
+                    "after": "2024-01-01",
+                    "before": "2024-02-01",
+                    "q": "has:attachment",
+                },
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        # Order: scope, date, raw.
+        assert call.kwargs["q"] == "is:unread in:inbox after:1704067200 before:1706745600 has:attachment"
+
+    @pytest.mark.asyncio
+    async def test_malformed_after_returns_action_error(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            result = await gmail.execute_action(
+                "read_inbox",
+                {"user_id": "me", "scope": "all", "after": "not a date"},
+                mock_context,
+            )
+        assert result.type == ResultType.ACTION_ERROR
+        assert "after" in result.result.message.lower()
+
 
 class TestReadAllMail:
     @pytest.mark.asyncio
@@ -470,6 +664,87 @@ class TestReadAllMail:
             service.users().messages().list().execute.side_effect = Exception("error")
             result = await gmail.execute_action("read_all_mail", {"user_id": "me", "scope": "all"}, mock_context)
         assert result.type == ResultType.ACTION_ERROR
+
+    @pytest.mark.asyncio
+    async def test_no_filters_omits_q_entirely(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_all_mail",
+                {"user_id": "me", "scope": "all"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        # scope=all with no date/q → preserve existing behavior: no ``q`` kwarg.
+        assert "q" not in call.kwargs
+
+    @pytest.mark.asyncio
+    async def test_after_only(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_all_mail",
+                {"user_id": "me", "scope": "all", "after": "2024-01-01"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "after:1704067200"
+
+    @pytest.mark.asyncio
+    async def test_combined_scope_date_and_raw_q(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_all_mail",
+                {
+                    "user_id": "me",
+                    "scope": "read",
+                    "after": "2024-01-01",
+                    "q": "from:alice@example.com",
+                },
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "-is:unread after:1704067200 from:alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_include_spam_trash_passthrough_preserved(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "read_all_mail",
+                {
+                    "user_id": "me",
+                    "scope": "all",
+                    "include_spam_trash": True,
+                    "after": "2024-01-01",
+                },
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "after:1704067200"
+        assert call.kwargs["includeSpamTrash"] is True
+
+    @pytest.mark.asyncio
+    async def test_malformed_before_returns_action_error(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            result = await gmail.execute_action(
+                "read_all_mail",
+                {"user_id": "me", "scope": "all", "before": "not a date"},
+                mock_context,
+            )
+        assert result.type == ResultType.ACTION_ERROR
+        assert "before" in result.result.message.lower()
 
 
 # ============================================================
@@ -724,6 +999,107 @@ class TestListEmailsByLabel:
             )
         assert result.type == ResultType.ACTION_ERROR
 
+    @pytest.mark.asyncio
+    async def test_single_label_with_after(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "list_emails_by_label",
+                {"user_id": "me", "label_names": "Work", "after": "2024-01-01"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        # Default behavior pins to inbox unless include_archived=True.
+        assert call.kwargs["q"] == "label:Work in:inbox after:1704067200"
+
+    @pytest.mark.asyncio
+    async def test_multiple_labels_with_date_range(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "list_emails_by_label",
+                {
+                    "user_id": "me",
+                    "label_names": ["Work", "STARRED"],
+                    "after": "2024-01-01",
+                    "before": "2024-02-01",
+                },
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "label:Work label:STARRED in:inbox after:1704067200 before:1706745600"
+
+    @pytest.mark.asyncio
+    async def test_include_archived_drops_inbox_clause(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "list_emails_by_label",
+                {
+                    "user_id": "me",
+                    "label_names": "Work",
+                    "include_archived": True,
+                    "after": "2024-01-01",
+                },
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "label:Work after:1704067200"
+
+    @pytest.mark.asyncio
+    async def test_explicit_inbox_label_avoids_double_inbox_clause(self, mock_context):
+        # Existing behavior: when the user explicitly asks for INBOX, the
+        # handler does NOT append ``in:inbox`` again. Confirm date still slots in.
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "list_emails_by_label",
+                {"user_id": "me", "label_names": "INBOX", "after": "2024-01-01"},
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "label:INBOX after:1704067200"
+
+    @pytest.mark.asyncio
+    async def test_combined_label_date_and_raw_q(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().messages().list().execute.return_value = {"messages": []}
+            await gmail.execute_action(
+                "list_emails_by_label",
+                {
+                    "user_id": "me",
+                    "label_names": "Work",
+                    "after": "2024-01-01",
+                    "q": "from:alice@example.com",
+                },
+                mock_context,
+            )
+        call = service.users().messages().list.call_args
+        assert call.kwargs["q"] == "label:Work in:inbox after:1704067200 from:alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_malformed_after_returns_action_error(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            result = await gmail.execute_action(
+                "list_emails_by_label",
+                {"user_id": "me", "label_names": "Work", "after": "not a date"},
+                mock_context,
+            )
+        assert result.type == ResultType.ACTION_ERROR
+        assert "after" in result.result.message.lower()
+
 
 # ============================================================
 #  Thread actions
@@ -955,3 +1331,137 @@ class TestDeleteDraft:
             service.users().drafts().delete().execute.side_effect = Exception("not found")
             result = await gmail.execute_action("delete_draft", {"user_id": "me", "draft_id": "x"}, mock_context)
         assert result.type == ResultType.ACTION_ERROR
+
+
+# ============================================================
+#  Send-as signature listing
+# ============================================================
+
+
+class TestListSendAsSignatures:
+    """Lists the signature currently bound as the new-mail default on each
+    of the user's send-as addresses. The Gmail API does not expose the full
+    saved-signatures library — only this per-address default."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_two_aliases(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().settings().sendAs().list().execute.return_value = {
+                "sendAs": [
+                    {
+                        "sendAsEmail": "me@example.com",
+                        "displayName": "Me",
+                        "isPrimary": True,
+                        "isDefault": True,
+                        "signature": "<p>Primary sig</p>",
+                        "replyToAddress": "reply@example.com",
+                    },
+                    {
+                        "sendAsEmail": "support@example.com",
+                        "displayName": "Support",
+                        "isPrimary": False,
+                        "isDefault": False,
+                        "signature": "<p>Support sig</p>",
+                        "replyToAddress": "",
+                    },
+                ]
+            }
+            result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, mock_context)
+
+        assert result.type == ResultType.ACTION
+        data = result.result.data
+        assert len(data["signatures"]) == 2
+
+        primary = data["signatures"][0]
+        assert primary["send_as_email"] == "me@example.com"
+        assert primary["display_name"] == "Me"
+        assert primary["is_primary"] is True
+        assert primary["is_default"] is True
+        assert primary["signature"] == "<p>Primary sig</p>"
+        assert primary["reply_to_address"] == "reply@example.com"
+
+        alias = data["signatures"][1]
+        assert alias["is_primary"] is False
+        assert alias["is_default"] is False
+
+    @pytest.mark.asyncio
+    async def test_missing_optional_fields_default_to_empty(self, mock_context):
+        # Gmail omits ``displayName``, ``replyToAddress``, ``signature`` etc.
+        # when they're not configured. Confirm we surface defaults rather than
+        # ``None`` or ``KeyError``.
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().settings().sendAs().list().execute.return_value = {
+                "sendAs": [
+                    {
+                        "sendAsEmail": "me@example.com",
+                        "isPrimary": True,
+                        "isDefault": True,
+                    }
+                ]
+            }
+            result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, mock_context)
+
+        assert result.type == ResultType.ACTION
+        entry = result.result.data["signatures"][0]
+        assert entry["display_name"] == ""
+        assert entry["signature"] == ""
+        assert entry["reply_to_address"] == ""
+        assert entry["is_primary"] is True
+        assert entry["is_default"] is True
+
+    @pytest.mark.asyncio
+    async def test_empty_send_as_list(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().settings().sendAs().list().execute.return_value = {}
+            result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, mock_context)
+        assert result.type == ResultType.ACTION
+        assert result.result.data == {"signatures": []}
+
+    @pytest.mark.asyncio
+    async def test_null_signature_becomes_empty_string(self, mock_context):
+        # Gmail can return ``"signature": null`` for a send-as that has no
+        # default signature bound. The handler must coerce to ``""`` — not the
+        # string ``"None"``, and not leave it as ``None``.
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().settings().sendAs().list().execute.return_value = {
+                "sendAs": [
+                    {
+                        "sendAsEmail": "me@example.com",
+                        "isPrimary": True,
+                        "isDefault": True,
+                        "signature": None,
+                    }
+                ]
+            }
+            result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, mock_context)
+        entry = result.result.data["signatures"][0]
+        assert entry["signature"] == ""
+        assert entry["signature"] != "None"
+
+    @pytest.mark.asyncio
+    async def test_defaults_user_id_to_me(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().settings().sendAs().list().execute.return_value = {"sendAs": []}
+            await gmail.execute_action("list_send_as_signatures", {}, mock_context)
+        call = service.users().settings().sendAs().list.call_args
+        assert call.kwargs == {"userId": "me"}
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_action_error(self, mock_context):
+        with _patched_service() as mock_build:
+            service = _make_service()
+            mock_build.return_value = service
+            service.users().settings().sendAs().list().execute.side_effect = Exception("403")
+            result = await gmail.execute_action("list_send_as_signatures", {"user_id": "me"}, mock_context)
+        assert result.type == ResultType.ACTION_ERROR
+        assert "403" in result.result.message

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -11,7 +11,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from autohive_integrations_sdk.integration import ResultType
 
-from gmail.gmail import gmail, create_email_message, build_raw_email, build_date_clause, append_signature
+from gmail.gmail import (
+    gmail,
+    create_email_message,
+    build_raw_email,
+    build_date_clause,
+    append_signature,
+    compose_messages_query,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -330,6 +337,40 @@ class TestBuildDateClause:
             build_date_clause(after="not a date")
         with pytest.raises(ValueError, match="before"):
             build_date_clause(before="2024-13-99")
+
+
+class TestComposeMessagesQuery:
+    """Shared composer for the three list-action ``q`` values. Verifies the
+    AND-join order (base → date → raw) and empty-fragment dropping."""
+
+    def test_base_only(self):
+        assert compose_messages_query("in:inbox", {}) == "in:inbox"
+
+    def test_base_plus_after(self):
+        assert compose_messages_query("in:inbox", {"after": "2024-01-01"}) == "in:inbox after:1704067200"
+
+    def test_base_plus_raw_q(self):
+        assert compose_messages_query("in:inbox", {"q": "has:attachment"}) == "in:inbox has:attachment"
+
+    def test_all_three_fragments_in_order(self):
+        result = compose_messages_query(
+            "is:unread in:inbox",
+            {"after": "2024-01-01", "before": "2024-02-01", "q": "has:attachment"},
+        )
+        assert result == "is:unread in:inbox after:1704067200 before:1706745600 has:attachment"
+
+    def test_empty_base_with_filters(self):
+        # ``read_all_mail`` scope="all" passes ``base_clause=""`` — date and raw
+        # should still slot in without a leading space.
+        assert compose_messages_query("", {"after": "2024-01-01"}) == "after:1704067200"
+
+    def test_all_empty_returns_empty_string(self):
+        # All-empty case lets ``read_all_mail`` drop the ``q`` kwarg entirely.
+        assert compose_messages_query("", {}) == ""
+
+    def test_malformed_after_propagates_value_error(self):
+        with pytest.raises(ValueError, match="after"):
+            compose_messages_query("in:inbox", {"after": "not a date"})
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Adds three Gmail enhancements on top of #325 (SDK 2.0 upgrade):

- **Time-window querying** — optional `after` / `before` (ISO 8601 datetime) and raw `q` (Gmail search syntax) inputs on `read_inbox`, `read_all_mail`, and `list_emails_by_label`. Datetimes are parsed and converted to unix seconds (unambiguous UTC) before being ANDed into the query. Scope clause is preserved; raw `q` passes through verbatim.
- **Body signatures** — optional `signature` input on `send_email`, `reply_to_thread`, `create_draft`, and `update_draft`. Wired through the shared `build_raw_email`, so a single helper (`append_signature`) covers all four send/reply/draft paths.
- **`list_send_as_signatures`** — new action that lists each of the user's send-as addresses (primary inbox + aliases) along with the signature currently bound to it as the new-mail default. Uses the existing `gmail.modify` scope; no new auth surface.

## Design notes

- **Why `list_send_as_signatures`, not `list_signatures`?** The Gmail API does not expose the user's full saved-signature library — only the signature currently bound to each send-as address (the per-address "new mail default" in the Gmail UI). The longer name makes that constraint explicit, and the action description spells out the limitation so callers don't expect to retrieve unbound signatures.
- **Why unix seconds for `after`/`before`, not `YYYY/MM/DD`?** Gmail's date form is interpreted in the account's local timezone, which is opaque to the caller. Unix seconds are unambiguous UTC and give second-level precision.
- **No auto-apply for signatures.** Considered a `use_account_signature: true` flag that would internally fetch and inject. Chose against it — keeps the integration composable. Callers compose `list_send_as_signatures` + `send_email` themselves.
- **Raw `q` alongside structured inputs.** Structured for ergonomics and LLM-friendly schemas; raw for power users who need `from:`, `has:attachment`, etc. The handler joins scope → date → raw with `AND` semantics in that order.

## Test plan

- [x] **Unit tests** — 40 new, 103 total, all green (`pytest gmail/tests/test_gmail_unit.py`)
- [x] **`ruff check` + `ruff format`** clean
- [x] **Config-code sync** — all 22 config actions resolve to registered handlers (enforced by the SDK at decorator import time)
- [x] **Integration tests for the new features** — 5 new live tests added:
  - `TestListSendAsSignatures` (read-only, 2 tests) — shape + presence of primary send-as
  - `TestReadInbox::test_after_filter_accepts_iso_datetime` + `test_raw_q_passthrough_is_anded` (read-only)
  - `TestSendEmailWithSignatureLifecycle` (destructive) — sends with `signature`, reads message back, asserts signature token + separator land in the body, archives
- [x] **Read-only integration suite** (safe — copy-paste-able for reviewers):

  ```bash
  pytest gmail/tests/test_gmail_integration.py -m "integration and not destructive"
  ```

  Requires `GMAIL_ACCESS_TOKEN` in `.env` with the `https://www.googleapis.com/auth/gmail.modify` scope.

- [ ] **Destructive integration suite** — ⚠️ mutates real data on the connected account (sends two self-emails, creates/deletes a label, creates/deletes a draft). Run only on a throwaway account:

  ```bash
  pytest gmail/tests/test_gmail_integration.py -m "integration and destructive"
  ```
