### PR TITLE
fix(xero): harden rate limiter, connected account, and downloads against Unhandled Lambda crash

### DIFF
--- a/xero/config.json
+++ b/xero/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Xero",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Xero accounting integration for invoice and bill management, purchase orders, reporting, file attachments, and PDF invoice retrieval",
     "entry_point": "xero.py",
     "supports_connected_account": true,

--- a/xero/tests/test_xero_crash_hardening_unit.py
+++ b/xero/tests/test_xero_crash_hardening_unit.py
@@ -211,3 +211,39 @@ class TestHttpTimeout:
         # Direct aiohttp downloads (PDF/attachments/file URLs) must time out
         # before the 30s Lambda kill; aiohttp's default is 300s.
         assert _mod.HTTP_TIMEOUT.total < 30
+
+
+# ---- Empty-string required inputs ----
+
+
+_SAMPLE_FILE = {"name": "test.pdf", "contentType": "application/pdf", "content": "Zm9v"}
+
+
+class TestEmptyStringValidation:
+    # The schemas mark these fields required but set no `minLength`, so an
+    # empty string passes schema validation and reaches the handler. The
+    # handler's `if not value: raise ValueError(...)` used to fire *before*
+    # the try block; since the SDK's execute_action only converts
+    # ValidationError, that ValueError escaped as an "Unhandled" Lambda crash.
+    # The checks now live inside the try, so an empty required string must
+    # come back as a clean ActionError.
+    @pytest.mark.parametrize(
+        "action_name,inputs",
+        [
+            ("get_invoice_pdf", {"tenant_id": "t-001", "invoice_id": ""}),
+            ("attach_file_to_invoice", {"tenant_id": "", "invoice_id": "inv-001", "file": _SAMPLE_FILE}),
+            ("attach_file_to_bill", {"tenant_id": "t-001", "bill_id": "", "file": _SAMPLE_FILE}),
+            (
+                "get_attachment_content",
+                {"tenant_id": "t-001", "endpoint": "Invoices", "guid": "g-001", "file_name": ""},
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_empty_required_string_returns_action_error(self, mock_context, action_name, inputs):
+        result = await xero.execute_action(action_name, inputs, mock_context)
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "is required" in result.result.message
+        # Validation must short-circuit before any network call is attempted.
+        mock_context.fetch.assert_not_awaited()

--- a/xero/tests/test_xero_crash_hardening_unit.py
+++ b/xero/tests/test_xero_crash_hardening_unit.py
@@ -1,0 +1,213 @@
+import asyncio
+import importlib.util
+import os
+import sys
+
+_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_deps = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies"))
+sys.path.insert(0, _parent)
+sys.path.insert(0, _deps)
+
+import pytest  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+from autohive_integrations_sdk import FetchResponse  # noqa: E402
+from autohive_integrations_sdk.integration import ResultType  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("xero_mod", os.path.join(_parent, "xero.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+xero = _mod.xero
+XeroRateLimiter = _mod.XeroRateLimiter
+XeroRateLimitExceededException = _mod.XeroRateLimitExceededException
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+class FakeRateLimitError(Exception):
+    """Mimics an HTTP 429 error from context.fetch with a Retry-After header."""
+
+    def __init__(self, retry_after=None):
+        super().__init__("429 Too Many Requests")
+        self.headers = {"Retry-After": str(retry_after)} if retry_after is not None else {}
+
+
+SAMPLE_CONNECTIONS = [
+    {"tenantId": "tenant-001", "tenantName": "Acme Corp", "tenantType": "ORGANISATION"},
+]
+
+
+# ---- Connected Account ----
+
+
+class TestConnectedAccount:
+    @pytest.mark.asyncio
+    async def test_returns_populated_account_info(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=SAMPLE_CONNECTIONS)
+
+        result = await xero.get_connected_account(mock_context)
+
+        assert result.type == ResultType.CONNECTED_ACCOUNT
+        assert result.result.username == "Acme Corp"
+        assert result.result.user_id == "tenant-001"
+
+    @pytest.mark.asyncio
+    async def test_fetch_exception_returns_placeholder_instead_of_crashing(self, mock_context):
+        # Reproduces the Raygun "Unhandled" Lambda crash: an exception raised
+        # by context.fetch (e.g., revoked/expired token, 5xx outage) used to
+        # propagate out of the handler and crash the Lambda. Handler must
+        # absorb it and return a valid placeholder ConnectedAccountInfo.
+        mock_context.fetch.side_effect = Exception("401 Unauthorized")
+
+        result = await xero.get_connected_account(mock_context)
+
+        assert result.type == ResultType.CONNECTED_ACCOUNT
+        assert result.result.username == "Unknown Organization"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_returns_placeholder(self, mock_context):
+        # CancelledError is a BaseException, so a bare `except Exception`
+        # would let it slip through and crash the Lambda.
+        mock_context.fetch.side_effect = asyncio.CancelledError()
+
+        result = await xero.get_connected_account(mock_context)
+
+        assert result.type == ResultType.CONNECTED_ACCOUNT
+        assert result.result.username == "Unknown Organization"
+
+
+# ---- Rate limiter sleep budget ----
+
+
+class TestRateLimiterSleepBudget:
+    def test_defaults_fit_inside_lambda_timeout(self):
+        # The Lambda is killed after 30s. The cumulative sleep budget plus the
+        # default per-retry delay must leave headroom for the requests
+        # themselves; max_wait_time is the cumulative cap.
+        limiter = XeroRateLimiter()
+        assert limiter.max_wait_time <= 15
+        assert limiter.default_retry_delay <= limiter.max_wait_time
+
+    @pytest.mark.asyncio
+    async def test_delay_over_budget_fails_fast_without_sleeping(self, mock_context):
+        # A Retry-After of 60s used to put the Lambda to sleep past its 30s
+        # lifetime ("Unhandled" crash). It must now raise immediately.
+        mock_context.fetch.side_effect = FakeRateLimitError(retry_after=60)
+        limiter = XeroRateLimiter()
+
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            with pytest.raises(XeroRateLimitExceededException):
+                await limiter.make_request(mock_context, "https://api.xero.com/test", "t-001")
+
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cumulative_budget_enforced_across_retries(self, mock_context):
+        # Each individual delay fits the budget, but the running total must
+        # not: 8s sleeps, then 8 + 8 > 10s budget -> fail fast.
+        mock_context.fetch.side_effect = FakeRateLimitError(retry_after=8)
+        limiter = XeroRateLimiter(max_wait_time=10)
+
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            with pytest.raises(XeroRateLimitExceededException):
+                await limiter.make_request(mock_context, "https://api.xero.com/test", "t-001")
+
+        mock_sleep.assert_awaited_once_with(8)
+
+    @pytest.mark.asyncio
+    async def test_short_delay_retries_and_succeeds(self, mock_context):
+        # Happy path: one 429 with a small Retry-After, then success.
+        mock_context.fetch.side_effect = [
+            FakeRateLimitError(retry_after=2),
+            FetchResponse(status=200, headers={}, data={"ok": True}),
+        ]
+        limiter = XeroRateLimiter()
+
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            result = await limiter.make_request(mock_context, "https://api.xero.com/test", "t-001")
+
+        assert result == {"ok": True}
+        mock_sleep.assert_awaited_once_with(2)
+
+    @pytest.mark.asyncio
+    async def test_missing_retry_after_uses_safe_default(self, mock_context):
+        # No Retry-After header -> the default delay must be small enough to
+        # fit the budget (the old default was 60s, which killed the Lambda).
+        mock_context.fetch.side_effect = [
+            FakeRateLimitError(),
+            FetchResponse(status=200, headers={}, data={"ok": True}),
+        ]
+        limiter = XeroRateLimiter()
+
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            result = await limiter.make_request(mock_context, "https://api.xero.com/test", "t-001")
+
+        assert result == {"ok": True}
+        mock_sleep.assert_awaited_once_with(limiter.default_retry_delay)
+        assert limiter.default_retry_delay <= limiter.max_wait_time
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_converted_to_timeout(self, mock_context):
+        # Cooperative cancellation reaching the coroutine must surface as a
+        # regular exception (caught by the actions' `except Exception`)
+        # instead of escaping the Lambda as "Unhandled".
+        mock_context.fetch.side_effect = asyncio.CancelledError()
+        limiter = XeroRateLimiter()
+
+        with pytest.raises(TimeoutError, match="cancelled"):
+            await limiter.make_request(mock_context, "https://api.xero.com/test", "t-001")
+
+
+# ---- Action-level cancellation ----
+
+
+class TestActionCancellation:
+    @pytest.mark.asyncio
+    async def test_action_returns_action_error_when_request_cancelled(self, mock_context):
+        # End-to-end: cancellation inside make_request becomes a clean
+        # ActionError from the action, not an unhandled crash.
+        mock_context.fetch.side_effect = asyncio.CancelledError()
+
+        result = await xero.execute_action("get_accounts", {"tenant_id": "t-001"}, mock_context)
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "cancelled" in result.result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_attach_file_cancellation_returns_action_error(self, mock_context):
+        # Cancellation during the raw file download (outside the rate
+        # limiter) must also be caught by the action itself.
+        with patch.object(_mod, "_resolve_file_bytes", new=AsyncMock(side_effect=asyncio.CancelledError())):
+            result = await xero.execute_action(
+                "attach_file_to_invoice",
+                {
+                    "tenant_id": "t-001",
+                    "invoice_id": "inv-001",
+                    "file": {"name": "test.pdf", "contentType": "application/pdf", "url": "https://example.com/f"},
+                },
+                mock_context,
+            )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "cancelled" in result.result.message.lower()
+
+
+# ---- Direct aiohttp timeout cap ----
+
+
+class TestHttpTimeout:
+    def test_http_timeout_is_below_lambda_timeout(self):
+        # Direct aiohttp downloads (PDF/attachments/file URLs) must time out
+        # before the 30s Lambda kill; aiohttp's default is 300s.
+        assert _mod.HTTP_TIMEOUT.total < 30

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -838,16 +838,16 @@ class GetInvoicePdfAction(ActionHandler):
         - file: Object containing content (base64), contentType, and name
         - success: Boolean indicating if the download was successful
         """
-        # Validate required inputs
-        tenant_id = inputs["tenant_id"]
-        invoice_id = inputs["invoice_id"]
-
-        if not tenant_id:
-            raise ValueError("tenant_id is required")
-        if not invoice_id:
-            raise ValueError("invoice_id is required")
-
         try:
+            # Validate required inputs
+            tenant_id = inputs["tenant_id"]
+            invoice_id = inputs["invoice_id"]
+
+            if not tenant_id:
+                raise ValueError("tenant_id is required")
+            if not invoice_id:
+                raise ValueError("invoice_id is required")
+
             # Build URL for specific invoice
             url = f"https://api.xero.com/api.xro/2.0/Invoices/{invoice_id}"
 
@@ -1354,16 +1354,16 @@ class AttachFileToInvoiceAction(ActionHandler):
         Optional fields:
         - include_online: Whether to include the attachment in online invoice (default: true)
         """
-        # Validate required inputs
-        tenant_id = inputs["tenant_id"]
-        invoice_id = inputs["invoice_id"]
-
-        if not tenant_id:
-            raise ValueError("tenant_id is required")
-        if not invoice_id:
-            raise ValueError("invoice_id is required")
-
         try:
+            # Validate required inputs
+            tenant_id = inputs["tenant_id"]
+            invoice_id = inputs["invoice_id"]
+
+            if not tenant_id:
+                raise ValueError("tenant_id is required")
+            if not invoice_id:
+                raise ValueError("invoice_id is required")
+
             # Debug: Log what inputs we're receiving
             # Get file object from inputs
             file_obj = inputs.get("file")
@@ -1452,16 +1452,16 @@ class AttachFileToBillAction(ActionHandler):
         Optional fields:
         - include_online: Whether to include the attachment in online bill (default: true)
         """
-        # Validate required inputs
-        tenant_id = inputs["tenant_id"]
-        bill_id = inputs["bill_id"]
-
-        if not tenant_id:
-            raise ValueError("tenant_id is required")
-        if not bill_id:
-            raise ValueError("bill_id is required")
-
         try:
+            # Validate required inputs
+            tenant_id = inputs["tenant_id"]
+            bill_id = inputs["bill_id"]
+
+            if not tenant_id:
+                raise ValueError("tenant_id is required")
+            if not bill_id:
+                raise ValueError("bill_id is required")
+
             # Get file object from inputs
             file_obj = inputs.get("file")
             files_arr = inputs.get("files")
@@ -1607,22 +1607,22 @@ class GetAttachmentContentAction(ActionHandler):
         - file: Object containing content (base64), contentType, and name
         - success: Boolean indicating if the download was successful
         """
-        # Validate required inputs
-        tenant_id = inputs["tenant_id"]
-        endpoint = inputs["endpoint"]
-        guid = inputs["guid"]
-        file_name = inputs["file_name"]
-
-        if not tenant_id:
-            raise ValueError("tenant_id is required")
-        if not endpoint:
-            raise ValueError("endpoint is required (e.g., 'Invoices', 'Bills')")
-        if not guid:
-            raise ValueError("guid is required")
-        if not file_name:
-            raise ValueError("file_name is required")
-
         try:
+            # Validate required inputs
+            tenant_id = inputs["tenant_id"]
+            endpoint = inputs["endpoint"]
+            guid = inputs["guid"]
+            file_name = inputs["file_name"]
+
+            if not tenant_id:
+                raise ValueError("tenant_id is required")
+            if not endpoint:
+                raise ValueError("endpoint is required (e.g., 'Invoices', 'Bills')")
+            if not guid:
+                raise ValueError("guid is required")
+            if not file_name:
+                raise ValueError("file_name is required")
+
             api_endpoint = endpoint
 
             # Build URL for getting attachment content

--- a/xero/xero.py
+++ b/xero/xero.py
@@ -10,8 +10,17 @@ from autohive_integrations_sdk import (
 from typing import Dict, Any
 import asyncio
 import base64
+import logging
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# Timeout for direct aiohttp calls (PDF/attachment/file downloads). aiohttp's
+# default total timeout is 300s, but the integration Lambda is killed after
+# 30s — a stalled download must fail cleanly before that, not crash the
+# Lambda with "Unhandled".
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=25)
 
 
 async def _resolve_file_bytes(file_obj: dict) -> bytes:
@@ -25,7 +34,7 @@ async def _resolve_file_bytes(file_obj: dict) -> bytes:
 
     url = file_obj.get("url")
     if url:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
             async with session.get(url) as resp:
                 if resp.status != 200:
                     raise ValueError(f"Failed to download file from url: HTTP {resp.status}")
@@ -62,12 +71,26 @@ class XeroConnectedAccountHandler(ConnectedAccountHandler):
 
         Returns:
             ConnectedAccountInfo with organization name as username.
+            Falls back to a placeholder ConnectedAccountInfo when the Xero API
+            call fails (e.g., revoked/expired token, 5xx outage). The SDK does
+            not catch exceptions raised from this handler, so letting one
+            propagate crashes the Lambda with "Unhandled". Auth failures
+            surface to the user the next time they run an action.
         """
-        response = await context.fetch(
-            "https://api.xero.com/connections",
-            method="GET",
-            headers={"Accept": "application/json"},
-        )
+        try:
+            response = await context.fetch(
+                "https://api.xero.com/connections",
+                method="GET",
+                headers={"Accept": "application/json"},
+            )
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException, so a bare `except Exception`
+            # would let it slip through and crash the Lambda.
+            logger.warning("CancelledError while fetching Xero account info — returning placeholder")
+            return ConnectedAccountInfo(username="Unknown Organization")
+        except Exception as e:
+            logger.warning(f"Failed to fetch Xero account info: {e}")
+            return ConnectedAccountInfo(username="Unknown Organization")
 
         if not response or not isinstance(response.data, list) or len(response.data) == 0:
             return ConnectedAccountInfo(username="Unknown Organization")
@@ -101,13 +124,19 @@ class XeroRateLimitExceededException(Exception):
 class XeroRateLimiter:
     def __init__(
         self,
-        default_retry_delay: int = 60,
+        default_retry_delay: int = 5,
         max_retries: int = 3,
-        max_wait_time: int = 60,
+        max_wait_time: int = 10,
     ):
         """
         Handles Xero API rate limiting by retrying requests on 429 errors.
-        Prevents lambda from waiting too long by setting maximum wait time.
+
+        The integration Lambda is killed after 30 seconds, so max_wait_time
+        caps the *cumulative* time spent sleeping across all retries. Any
+        delay that would exceed the budget raises
+        XeroRateLimitExceededException immediately so the action returns a
+        clean ActionError instead of the Lambda being killed mid-sleep
+        ("Unhandled" crash).
         """
         self.default_retry_delay = default_retry_delay
         self.max_retries = max_retries
@@ -132,11 +161,21 @@ class XeroRateLimiter:
         kwargs["headers"] = headers
 
         last_error = None
+        total_waited = 0
 
         for attempt in range(self.max_retries + 1):
             try:
                 response = await context.fetch(url, **kwargs)
                 return response.data
+
+            except asyncio.CancelledError:
+                # Defensive: convert Python-side task cancellation into a
+                # regular exception so action handlers return a clean
+                # ActionError if cancellation reaches the coroutine. This does
+                # not catch Lambda hard timeouts, which kill the OS process
+                # with no catchable Python exception.
+                logger.warning("CancelledError during Xero request to %s — converting to TimeoutError", url)
+                raise TimeoutError(f"Xero request to {url} was cancelled before completing. Please try again.")
 
             except Exception as e:
                 last_error = e
@@ -151,13 +190,21 @@ class XeroRateLimiter:
                     # Get delay from response headers or use default
                     delay = self._extract_retry_delay(e)
 
-                    # Check if delay exceeds maximum wait time
-                    if delay > self.max_wait_time:
-                        # Don't wait - inform LLM about rate limit immediately
+                    # Enforce the cumulative sleep budget: the Lambda only
+                    # lives for 30s, so never sleep past max_wait_time in
+                    # total — inform the LLM about the rate limit immediately
+                    if total_waited + delay > self.max_wait_time:
+                        logger.warning(
+                            "Xero rate-limit delay %ds exceeds remaining budget (%ds waited, %ds max) — failing fast",
+                            delay,
+                            total_waited,
+                            self.max_wait_time,
+                        )
                         raise XeroRateLimitExceededException(delay, self.max_wait_time, tenant_id)
 
                     # Short delay - proceed with waiting and retry
                     await asyncio.sleep(delay)
+                    total_waited += delay
                     continue
 
                 # For non-rate-limit errors, fail immediately
@@ -820,8 +867,9 @@ class GetInvoicePdfAction(ActionHandler):
 
             headers["Authorization"] = f"Bearer {auth_token}"
 
-            # Use aiohttp to download the PDF
-            async with aiohttp.ClientSession() as session:
+            # Use aiohttp to download the PDF (time-capped so a stalled
+            # download fails cleanly instead of hitting the 30s Lambda kill)
+            async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
                 async with session.get(url, headers=headers) as response:
                     if response.status != 200:
                         error_text = await response.text()
@@ -844,6 +892,11 @@ class GetInvoicePdfAction(ActionHandler):
                         }
                     )
 
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException — without this catch it would
+            # propagate out of the Lambda as "Unhandled"
+            logger.warning("CancelledError in get_invoice_pdf — returning ActionError")
+            return ActionError(message="Invoice PDF download was cancelled before completing. Please try again.")
         except XeroRateLimitExceededException as e:
             return ActionError(
                 message=(
@@ -1365,6 +1418,11 @@ class AttachFileToInvoiceAction(ActionHandler):
 
             return ActionResult(data=response)
 
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException — without this catch it would
+            # propagate out of the Lambda as "Unhandled"
+            logger.warning("CancelledError in attach_file_to_invoice — returning ActionError")
+            return ActionError(message="File attachment was cancelled before completing. Please try again.")
         except XeroRateLimitExceededException as e:
             return ActionError(
                 message=(
@@ -1453,6 +1511,11 @@ class AttachFileToBillAction(ActionHandler):
 
             return ActionResult(data=response)
 
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException — without this catch it would
+            # propagate out of the Lambda as "Unhandled"
+            logger.warning("CancelledError in attach_file_to_bill — returning ActionError")
+            return ActionError(message="File attachment was cancelled before completing. Please try again.")
         except XeroRateLimitExceededException as e:
             return ActionError(
                 message=(
@@ -1582,7 +1645,9 @@ class GetAttachmentContentAction(ActionHandler):
                     if "access_token" in credentials:
                         headers["Authorization"] = f"Bearer {credentials['access_token']}"
 
-                async with session.get(url, headers=headers) as response:
+                # Time-capped so a stalled download fails cleanly instead of
+                # hitting the 30s Lambda kill
+                async with session.get(url, headers=headers, timeout=HTTP_TIMEOUT) as response:
                     if response.status != 200:
                         error_text = await response.text()
                         return ActionError(
@@ -1607,6 +1672,11 @@ class GetAttachmentContentAction(ActionHandler):
                 }
             )
 
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException — without this catch it would
+            # propagate out of the Lambda as "Unhandled"
+            logger.warning("CancelledError in get_attachment_content — returning ActionError")
+            return ActionError(message="Attachment download was cancelled before completing. Please try again.")
         except XeroRateLimitExceededException as e:
             return ActionError(
                 message=(


### PR DESCRIPTION
> **Reviewer: @TheRealAgentK** — this is PR 1 of 2 applying the #334 (github) hardening playbook across the integrations named in the recurring Raygun Unhandled group. Since you reviewed #334, requesting you on this series. PR 2 (google-sheets) is #347. Note: google-analytics also appears in the Raygun group (May 29 event) with a confirmed crash mechanism (SDK 1.x error paths returning ActionResult with error/result fields, same as the google-looker #332 fix), but its fix is inseparable from its pending SDK 2.0 migration, which is owned separately - findings are documented for whoever picks that up.

## Context

The Raygun error `Lambda function {FunctionName} returned error: Unhandled` is a template group that collects crashes from **all** integrations. Events examined so far name `integration-github` (fixed in #334), `integration-google-analytics` (May 29), and `integration-google-sheets` (Jun 4).

**Honest scope note:** no examined Raygun event has been confirmed naming xero yet — this PR is *preventive* hardening of the same crash classes #334 fixed, found by auditing `xero.py` with the same lens. Every vector below is a real, test-reproduced crash path; the integration Lambda is killed at 30s.

## Crash vectors fixed

1. **Connected-account handler had no error handling** (`xero.py` `get_account_info`) — identical to the #334 root cause. The SDK does not catch handler exceptions, so a revoked/expired token or 5xx crashed the Lambda. Now falls back to a placeholder `ConnectedAccountInfo` with a warning log.
2. **Rate limiter slept up to 60s per retry** (3×60s worst case) on 429s — guaranteed death mid-sleep in a 30s Lambda. The old `max_wait_time=60` guard only rejected delays *longer* than the Lambda lifetime. Defaults reduced (delay 60s→5s, cap 60s→10s) and the cap now enforces a **cumulative** sleep budget across retries; over-budget delays raise `XeroRateLimitExceededException` immediately → clean `ActionError`.
3. **Raw aiohttp downloads had no timeout** (aiohttp default is 300s) in `get_invoice_pdf`, `get_attachment_content`, and `_resolve_file_bytes`. Added a shared 25s `ClientTimeout`.
4. **`asyncio.CancelledError` slipped through every `except Exception`** (it is a `BaseException`). `make_request` now converts cooperative cancellation to `TimeoutError` (covers all rate-limited actions); the four raw-IO actions catch it directly. Same comment wording and `logger.warning` observability as #334.
5. **Empty-string required inputs validated *before* the `try` block** (`get_invoice_pdf`, `attach_file_to_invoice`, `attach_file_to_bill`, `get_attachment_content`) — addresses review feedback. Required fields are schema-validated, but empty strings pass the schema (no `minLength`), so a `ValueError("... is required")` raised on an empty string escaped the handler (SDK `execute_action()` only converts `ValidationError`) as an Unhandled crash. Validation now lives inside each `try`, returning a clean `ActionError` via the existing `except Exception` path.

Not needed here: xero has no pagination loops (every action is single-request), so no `max_pages` equivalent.

## Tests & validation

- 16 new regression tests in `tests/test_xero_crash_hardening_unit.py`: connected-account fallback (incl. CancelledError), sleep-budget enforcement (fail-fast, cumulative, happy-path retry, safe default), cancellation conversion (unit + end-to-end through an action), timeout cap pin, and empty-string required-input validation across all four raw-I/O actions (ActionError + "is required", no network call attempted).
- 138/138 unit tests pass; `validate_integration` / `check_code` (ruff, bandit, pip-audit, config sync) all pass.
- config.json version bumped 2.0.0 → 2.0.1 for the version-check CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)