### PR TITLE
fix(google-sheets): add HTTP timeout and cancellation handling against Unhandled Lambda crash

### DIFF
--- a/google-sheets/README.md
+++ b/google-sheets/README.md
@@ -41,7 +41,8 @@ No additional configuration fields are required beyond the OAuth connection.
 - Description: Fetch spreadsheet properties, sheets, and named ranges.
 - Inputs:
   - `spreadsheet_id` (string, required)
-  - `include_grid_data` (boolean, optional)
+  - `include_grid_data` (boolean, optional). If true, `ranges` is required to avoid unbounded full-grid responses that can exceed Lambda time or memory limits.
+  - `ranges` (array[string], optional). A1 ranges such as `Sheet1!A1:D100` used to bound returned grid data when `include_grid_data` is true.
 - Outputs: `spreadsheet` (object), `result` (boolean), `error` (string)
 
 ### `sheets_list_sheets`

--- a/google-sheets/config.json
+++ b/google-sheets/config.json
@@ -50,7 +50,12 @@
           "spreadsheet_id": { "type": "string" },
           "include_grid_data": {
             "type": "boolean",
-            "description": "If true, returns cell data (may be large)."
+            "description": "If true, returns cell data. Requires 'ranges' to bound the response, otherwise the action errors (an unbounded full-grid fetch can exceed the Lambda time/memory limit)."
+          },
+          "ranges": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "A1 ranges (e.g. [\"Sheet1!A1:D100\"]) to bound the grid data returned when include_grid_data is true."
           }
         },
         "required": ["spreadsheet_id"]

--- a/google-sheets/config.json
+++ b/google-sheets/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Google Sheets",
   "display_name": "Google Sheets",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "entry_point": "google_sheets.py",
   "description": "Read and write Google Sheets with safe, deterministic operations and basic formatting.",
   "auth": {

--- a/google-sheets/google_sheets.py
+++ b/google-sheets/google_sheets.py
@@ -6,13 +6,26 @@ from autohive_integrations_sdk import (
     ActionError,
 )
 from typing import Dict, Any, List
+from functools import wraps
+import asyncio
+import logging
+
+import httplib2
+from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from google.oauth2.credentials import Credentials
 
+logger = logging.getLogger(__name__)
+
 google_sheets = Integration.load()
 
 SPREADSHEET_MIMETYPE = "application/vnd.google-apps.spreadsheet"
+
+# httplib2's default timeout is None (block indefinitely), but the
+# integration Lambda is killed after 30s — a stalled Google API call must
+# fail cleanly before that, not crash the Lambda with "Unhandled".
+HTTP_TIMEOUT_SECONDS = 25
 
 
 def build_credentials(context: ExecutionContext) -> Credentials:
@@ -20,18 +33,46 @@ def build_credentials(context: ExecutionContext) -> Credentials:
     return Credentials(token=access_token, token_uri="https://oauth2.googleapis.com/token")  # nosec B106
 
 
-def build_sheets_service(context: ExecutionContext):
+def _build_authorized_http(context: ExecutionContext) -> AuthorizedHttp:
     creds = build_credentials(context)
-    return build("sheets", "v4", credentials=creds)
+    return AuthorizedHttp(creds, http=httplib2.Http(timeout=HTTP_TIMEOUT_SECONDS))
+
+
+def build_sheets_service(context: ExecutionContext):
+    return build("sheets", "v4", http=_build_authorized_http(context))
 
 
 def build_drive_service(context: ExecutionContext):
-    creds = build_credentials(context)
-    return build("drive", "v3", credentials=creds)
+    return build("drive", "v3", http=_build_authorized_http(context))
+
+
+def handle_cancellation(action_name: str):
+    """Convert cooperative task cancellation reaching the action coroutine
+    into a clean ActionError. asyncio.CancelledError is a BaseException, so
+    the actions' `except Exception` blocks let it slip through and the
+    Lambda returned "Unhandled". This does not catch Lambda hard timeouts,
+    which kill the OS process with no catchable Python exception."""
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(self, inputs: Dict[str, Any], context: ExecutionContext):
+            try:
+                return await func(self, inputs, context)
+            except asyncio.CancelledError:
+                logger.warning(
+                    "CancelledError caught in action %s — cooperative cancellation reached the action coroutine",
+                    action_name,
+                )
+                return ActionError(message=f"Action '{action_name}' was cancelled before completing. Please try again.")
+
+        return wrapper
+
+    return decorator
 
 
 @google_sheets.action("sheets_list_spreadsheets")
 class ListSpreadsheets(ActionHandler):
+    @handle_cancellation("sheets_list_spreadsheets")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             drive = build_drive_service(context)
@@ -74,11 +115,19 @@ class ListSpreadsheets(ActionHandler):
 
 @google_sheets.action("sheets_get_spreadsheet")
 class GetSpreadsheet(ActionHandler):
+    @handle_cancellation("sheets_get_spreadsheet")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             service = build_sheets_service(context)
             spreadsheet_id = inputs["spreadsheet_id"]
             include_grid = bool(inputs.get("include_grid_data", False))
+            if include_grid:
+                # Full grid data on large spreadsheets can exceed the Lambda
+                # time/size limits; log so production behavior is observable.
+                logger.warning(
+                    "sheets_get_spreadsheet called with include_grid_data=True (spreadsheet %s)",
+                    spreadsheet_id,
+                )
             request = service.spreadsheets().get(spreadsheetId=spreadsheet_id, includeGridData=include_grid)
             spreadsheet = request.execute()
             return ActionResult(data={"spreadsheet": spreadsheet}, cost_usd=0.0)
@@ -90,6 +139,7 @@ class GetSpreadsheet(ActionHandler):
 
 @google_sheets.action("sheets_list_sheets")
 class ListSheets(ActionHandler):
+    @handle_cancellation("sheets_list_sheets")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             service = build_sheets_service(context)
@@ -113,6 +163,7 @@ class ListSheets(ActionHandler):
 
 @google_sheets.action("sheets_read_range")
 class ReadRange(ActionHandler):
+    @handle_cancellation("sheets_read_range")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             service = build_sheets_service(context)
@@ -141,6 +192,7 @@ class ReadRange(ActionHandler):
 
 @google_sheets.action("sheets_write_range")
 class WriteRange(ActionHandler):
+    @handle_cancellation("sheets_write_range")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             spreadsheet_id = inputs["spreadsheet_id"]
@@ -198,6 +250,7 @@ class WriteRange(ActionHandler):
 
 @google_sheets.action("sheets_append_rows")
 class AppendRows(ActionHandler):
+    @handle_cancellation("sheets_append_rows")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             service = build_sheets_service(context)
@@ -227,6 +280,7 @@ class AppendRows(ActionHandler):
 
 @google_sheets.action("sheets_format_range")
 class FormatRange(ActionHandler):
+    @handle_cancellation("sheets_format_range")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             service = build_sheets_service(context)
@@ -256,6 +310,7 @@ class FormatRange(ActionHandler):
 
 @google_sheets.action("sheets_freeze")
 class FreezePanes(ActionHandler):
+    @handle_cancellation("sheets_freeze")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             service = build_sheets_service(context)
@@ -294,6 +349,7 @@ class FreezePanes(ActionHandler):
 
 @google_sheets.action("sheets_batch_update")
 class SheetsBatchUpdate(ActionHandler):
+    @handle_cancellation("sheets_batch_update")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             spreadsheet_id = inputs["spreadsheet_id"]
@@ -322,6 +378,7 @@ class SheetsBatchUpdate(ActionHandler):
 
 @google_sheets.action("sheets_duplicate_spreadsheet")
 class DuplicateSpreadsheet(ActionHandler):
+    @handle_cancellation("sheets_duplicate_spreadsheet")
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
         try:
             drive = build_drive_service(context)

--- a/google-sheets/google_sheets.py
+++ b/google-sheets/google_sheets.py
@@ -121,14 +121,24 @@ class GetSpreadsheet(ActionHandler):
             service = build_sheets_service(context)
             spreadsheet_id = inputs["spreadsheet_id"]
             include_grid = bool(inputs.get("include_grid_data", False))
-            if include_grid:
-                # Full grid data on large spreadsheets can exceed the Lambda
-                # time/size limits; log so production behavior is observable.
-                logger.warning(
-                    "sheets_get_spreadsheet called with include_grid_data=True (spreadsheet %s)",
-                    spreadsheet_id,
+            ranges = inputs.get("ranges") or []
+            if include_grid and not ranges:
+                # An unbounded full-grid fetch on a large spreadsheet can stream
+                # and parse long enough to exhaust the 30s Lambda budget/memory
+                # (the per-socket HTTP timeout does not cap total payload). Force
+                # the caller to bound the response with explicit ranges.
+                return ActionError(
+                    message=(
+                        "include_grid_data=True requires 'ranges' to bound the response: "
+                        "an unbounded full-grid fetch can exceed the Lambda time/memory limit. "
+                        'Provide one or more A1 ranges (e.g. "Sheet1!A1:D100"), '
+                        "or use sheets_read_range to read cell data."
+                    )
                 )
-            request = service.spreadsheets().get(spreadsheetId=spreadsheet_id, includeGridData=include_grid)
+            get_kwargs: Dict[str, Any] = {"spreadsheetId": spreadsheet_id, "includeGridData": include_grid}
+            if include_grid and ranges:
+                get_kwargs["ranges"] = ranges
+            request = service.spreadsheets().get(**get_kwargs)
             spreadsheet = request.execute()
             return ActionResult(data={"spreadsheet": spreadsheet}, cost_usd=0.0)
         except HttpError as e:

--- a/google-sheets/requirements.txt
+++ b/google-sheets/requirements.txt
@@ -3,3 +3,4 @@ autohive-integrations-sdk~=2.0.0
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
+httplib2

--- a/google-sheets/tests/test_google_sheets_crash_hardening_unit.py
+++ b/google-sheets/tests/test_google_sheets_crash_hardening_unit.py
@@ -4,7 +4,6 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from autohive_integrations_sdk.integration import ResultType
 
-import google_sheets as gs_module
 from google_sheets import google_sheets, build_sheets_service, build_drive_service, HTTP_TIMEOUT_SECONDS
 
 pytestmark = pytest.mark.unit
@@ -99,39 +98,42 @@ class TestCancellation:
         assert "boom" in result.result.message
 
 
-# ---- include_grid_data observability ----
+# ---- include_grid_data payload guard ----
 
 
-class TestGridDataWarning:
+class TestGridDataGuard:
     @pytest.mark.asyncio
     @patch("google_sheets.build")
-    async def test_include_grid_data_logs_warning(self, mock_build, mock_context, caplog):
+    async def test_include_grid_data_without_ranges_rejected(self, mock_build, mock_context):
         service = MagicMock()
         mock_build.return_value = service
         service.spreadsheets().get().execute.return_value = {"spreadsheetId": "sid"}
 
-        with caplog.at_level("WARNING", logger=gs_module.logger.name):
-            result = await google_sheets.execute_action(
-                "sheets_get_spreadsheet",
-                {"spreadsheet_id": "sid", "include_grid_data": True},
-                mock_context,
-            )
+        result = await google_sheets.execute_action(
+            "sheets_get_spreadsheet",
+            {"spreadsheet_id": "sid", "include_grid_data": True},
+            mock_context,
+        )
+
+        # Unbounded full-grid fetch is rejected deterministically before the API call.
+        assert result.type == ResultType.ACTION_ERROR
+        assert "ranges" in result.result.message
+        service.spreadsheets().get().execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("google_sheets.build")
+    async def test_include_grid_data_with_ranges_allowed(self, mock_build, mock_context):
+        service = MagicMock()
+        mock_build.return_value = service
+        service.spreadsheets().get().execute.return_value = {"spreadsheetId": "sid"}
+
+        result = await google_sheets.execute_action(
+            "sheets_get_spreadsheet",
+            {"spreadsheet_id": "sid", "include_grid_data": True, "ranges": ["Sheet1!A1:D100"]},
+            mock_context,
+        )
 
         assert result.type == ResultType.ACTION
-        assert any("include_grid_data" in rec.message for rec in caplog.records)
-
-    @pytest.mark.asyncio
-    @patch("google_sheets.build")
-    async def test_no_warning_without_grid_data(self, mock_build, mock_context, caplog):
-        service = MagicMock()
-        mock_build.return_value = service
-        service.spreadsheets().get().execute.return_value = {"spreadsheetId": "sid"}
-
-        with caplog.at_level("WARNING", logger=gs_module.logger.name):
-            await google_sheets.execute_action(
-                "sheets_get_spreadsheet",
-                {"spreadsheet_id": "sid"},
-                mock_context,
-            )
-
-        assert not any("include_grid_data" in rec.message for rec in caplog.records)
+        service.spreadsheets().get.assert_called_with(
+            spreadsheetId="sid", includeGridData=True, ranges=["Sheet1!A1:D100"]
+        )

--- a/google-sheets/tests/test_google_sheets_crash_hardening_unit.py
+++ b/google-sheets/tests/test_google_sheets_crash_hardening_unit.py
@@ -1,0 +1,137 @@
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from autohive_integrations_sdk.integration import ResultType
+
+import google_sheets as gs_module
+from google_sheets import google_sheets, build_sheets_service, build_drive_service, HTTP_TIMEOUT_SECONDS
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "PlatformOauth2",
+        "credentials": {"access_token": "test_token"},  # nosec B105
+    }
+    return ctx
+
+
+# ---- HTTP timeout cap ----
+
+
+class TestHttpTimeout:
+    def test_timeout_is_below_lambda_timeout(self):
+        # httplib2's default timeout is None (block indefinitely); the
+        # integration Lambda is killed after 30s, so a stalled Google API
+        # call must fail before that instead of crashing with "Unhandled".
+        assert HTTP_TIMEOUT_SECONDS < 30
+
+    @patch("google_sheets.build")
+    def test_sheets_service_uses_timeout_capped_http(self, mock_build, mock_context):
+        build_sheets_service(mock_context)
+
+        http_arg = mock_build.call_args.kwargs["http"]
+        assert http_arg.http.timeout == HTTP_TIMEOUT_SECONDS
+
+    @patch("google_sheets.build")
+    def test_drive_service_uses_timeout_capped_http(self, mock_build, mock_context):
+        build_drive_service(mock_context)
+
+        http_arg = mock_build.call_args.kwargs["http"]
+        assert http_arg.http.timeout == HTTP_TIMEOUT_SECONDS
+
+
+# ---- Cancellation handling ----
+
+
+class TestCancellation:
+    @pytest.mark.asyncio
+    @patch("google_sheets.build")
+    async def test_cancelled_action_returns_action_error(self, mock_build, mock_context):
+        # asyncio.CancelledError is a BaseException, so the actions'
+        # `except Exception` blocks let it slip through and the Lambda
+        # returned "Unhandled". The handle_cancellation decorator must
+        # convert it to a clean ActionError.
+        mock_build.side_effect = asyncio.CancelledError()
+
+        result = await google_sheets.execute_action(
+            "sheets_read_range",
+            {"spreadsheet_id": "sid", "range": "A1"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "cancelled" in result.result.message.lower()
+
+    @pytest.mark.asyncio
+    @patch("google_sheets.build")
+    async def test_cancelled_write_returns_action_error(self, mock_build, mock_context):
+        mock_build.side_effect = asyncio.CancelledError()
+
+        result = await google_sheets.execute_action(
+            "sheets_write_range",
+            {"spreadsheet_id": "sid", "range": "A1", "values": [["x"]]},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "cancelled" in result.result.message.lower()
+
+    @pytest.mark.asyncio
+    @patch("google_sheets.build")
+    async def test_normal_error_still_returns_action_error(self, mock_build, mock_context):
+        # Regression guard: the decorator must not swallow or alter the
+        # existing Exception -> ActionError behavior.
+        mock_build.side_effect = Exception("boom")
+
+        result = await google_sheets.execute_action(
+            "sheets_read_range",
+            {"spreadsheet_id": "sid", "range": "A1"},
+            mock_context,
+        )
+
+        assert result.type == ResultType.ACTION_ERROR
+        assert "boom" in result.result.message
+
+
+# ---- include_grid_data observability ----
+
+
+class TestGridDataWarning:
+    @pytest.mark.asyncio
+    @patch("google_sheets.build")
+    async def test_include_grid_data_logs_warning(self, mock_build, mock_context, caplog):
+        service = MagicMock()
+        mock_build.return_value = service
+        service.spreadsheets().get().execute.return_value = {"spreadsheetId": "sid"}
+
+        with caplog.at_level("WARNING", logger=gs_module.logger.name):
+            result = await google_sheets.execute_action(
+                "sheets_get_spreadsheet",
+                {"spreadsheet_id": "sid", "include_grid_data": True},
+                mock_context,
+            )
+
+        assert result.type == ResultType.ACTION
+        assert any("include_grid_data" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    @patch("google_sheets.build")
+    async def test_no_warning_without_grid_data(self, mock_build, mock_context, caplog):
+        service = MagicMock()
+        mock_build.return_value = service
+        service.spreadsheets().get().execute.return_value = {"spreadsheetId": "sid"}
+
+        with caplog.at_level("WARNING", logger=gs_module.logger.name):
+            await google_sheets.execute_action(
+                "sheets_get_spreadsheet",
+                {"spreadsheet_id": "sid"},
+                mock_context,
+            )
+
+        assert not any("include_grid_data" in rec.message for rec in caplog.records)

--- a/google-sheets/tests/test_google_sheets_spreadsheets_unit.py
+++ b/google-sheets/tests/test_google_sheets_spreadsheets_unit.py
@@ -184,11 +184,13 @@ class TestGetSpreadsheet:
 
         await google_sheets.execute_action(
             "sheets_get_spreadsheet",
-            {"spreadsheet_id": "sid1", "include_grid_data": True},
+            {"spreadsheet_id": "sid1", "include_grid_data": True, "ranges": ["Sheet1!A1:D100"]},
             mock_context,
         )
 
-        service.spreadsheets().get.assert_called_with(spreadsheetId="sid1", includeGridData=True)
+        service.spreadsheets().get.assert_called_with(
+            spreadsheetId="sid1", includeGridData=True, ranges=["Sheet1!A1:D100"]
+        )
 
     @pytest.mark.asyncio
     @patch("google_sheets.build")


### PR DESCRIPTION
> **Reviewer: @TheRealAgentK** — **PR 2 of 2** in the Unhandled-Lambda hardening series (PR 1: #346 xero). This is the integration named in the **2026-06-04 production crash** (Raygun Unhandled group). Note: google-analytics also appears in the group (May 29 event) with a confirmed crash mechanism, but its fix is inseparable from its pending SDK 2.0 migration, which is owned separately - findings are documented for whoever picks that up.

## Context

The Raygun error `Lambda function {FunctionName} returned error: Unhandled` is a template group collecting crashes from all integrations. The Jun 4 event names `integration-google-sheets` (real customer run). The integration Lambda is killed after 30s; google-sheets had two open vectors that fit the crash signature. (#289 previously fixed a different vector — error-path schema validation.)

**Evidence note:** Raygun only forwards the .NET wrapper stack, not the Python traceback, so the exact cause is inferred — same evidence standard #334 shipped with. Both changes harden real crash paths regardless, and the new warning logs make any recurrence diagnosable from CloudWatch.

## Crash vectors fixed

1. **No timeout on any Google API call.** All actions use the synchronous `googleapiclient`; httplib2 defaults to `timeout=None` (block indefinitely), so a stalled call ran until the 30s Lambda kill. Services are now built with `AuthorizedHttp(creds, http=httplib2.Http(timeout=25))` — stalled calls fail cleanly as `ActionError` before the kill. (`httplib2` added explicitly to requirements since it is now imported directly.)
2. **`asyncio.CancelledError` slipped through every `except Exception`** (it is a `BaseException`). New `handle_cancellation` decorator applied to all 10 actions — mirrors the #334 catch, same comment wording (cooperative cancellation reaching the action coroutine; does not catch Lambda hard timeouts) and `logger.warning` observability.
3. **Deterministic payload guard for the other suspected vector:** `sheets_get_spreadsheet` with `include_grid_data=True` can return an enormous payload on large spreadsheets. The per-socket HTTP timeout caps *stalls*, not total download/parse time, so an unbounded full-grid fetch can still exhaust the 30s budget/memory. It now **requires** bounding `ranges` — an unbounded full-grid request is rejected with an `ActionError` directing the caller to provide A1 `ranges` or use `sheets_read_range`, mirroring GitHub's `max_pages` deterministic-cap pattern. (Addresses @TheRealAgentK's should-fix review note.)

Not needed here: no pagination loops (single-request actions with pageToken passthrough), no connected-account handler exists.

## Tests & validation

- 8 new regression tests in `tests/test_google_sheets_crash_hardening_unit.py`: timeout cap pinned below the Lambda timeout on both sheets/drive services, cancellation → ActionError (two actions), normal-error regression guard, and the `include_grid_data` payload guard (unbounded grid rejected / bounded grid with `ranges` allowed).
- 65/65 unit tests pass; `validate_integration` / `check_code` (ruff, bandit, pip-audit, config sync) all pass.
- config.json version bumped 2.0.0 → 2.0.1 for the version-check CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
