### PR TITLE
fix(active-campaign): remove required from auth.fields — fixes ValidationError on all 7 actions

### DIFF
--- a/active-campaign/config.json
+++ b/active-campaign/config.json
@@ -22,7 +22,7 @@
                     "label": "API URL",
                     "description": "Your ActiveCampaign API URL (e.g. https://mycompany.api-us1.com) — found under Settings > Developer"
                 }
-            },
+            }
         }
     },
     "actions": {

--- a/active-campaign/config.json
+++ b/active-campaign/config.json
@@ -1,6 +1,6 @@
 {
     "name": "ActiveCampaign",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "ActiveCampaign email marketing integration for tracking EDM campaign performance including open rates, click rates, bounce rates, and contact engagement.",
     "display_name": "ActiveCampaign",
     "supports_connected_account": false,
@@ -23,7 +23,6 @@
                     "description": "Your ActiveCampaign API URL (e.g. https://mycompany.api-us1.com) — found under Settings > Developer"
                 }
             },
-            "required": ["api_key", "api_url"]
         }
     },
     "actions": {


### PR DESCRIPTION
## Summary

All 7 active-campaign actions were failing with:
```
ValidationError: 'api_key' is a required property, 'api_url' is a required property
```

The `required: ["api_key", "api_url"]` array inside `auth.fields` caused the SDK to validate these as required action inputs rather than auth credentials. Removing it matches the pattern used by all other custom-auth integrations (e.g. Heartbeat, Lumin PDF).

**Root cause:** `required` inside `auth.fields` is not the correct place to enforce credential presence — the SDK handles auth separately.

## Test plan

- [x] No `required` array in `auth.fields` — matches pattern of working integrations
- [ ] Re-test all 7 actions after merge: `list_campaigns`, `list_lists`, `list_contacts`, `get_campaign`, `get_campaign_links`, `get_contact`, `list_contact_activities`