### PR TITLE
fix(lumin-pdf): always default page=1 and limit=10 for list actions

### DIFF
--- a/lumin-pdf/README.md
+++ b/lumin-pdf/README.md
@@ -321,6 +321,7 @@ pytest lumin-pdf/tests/test_lumin_pdf_integration.py -m "integration and destruc
 
 ## Version History
 
+- **v1.2.1** — Fixed `list_templates` and `list_workspace_members` always sending `page=1` and `limit=10` defaults, preventing 400 errors when called without pagination params
 - **v1.2.0** — Fixed pagination params (page+limit must be sent together), clamped limit to accepted values (10/25/50), fixed `send_from_template` signer normalization to use `signer_role` field, fixed `download_signed_document`/`download_agreement`/`generate_document_from_template` binary decode errors with Accept header, fixed `create_agreement` response double-nesting
 - **v1.1.0** — Added `send_from_template`, `update_signature_request`, `upload_document`, `generate_document_from_template`, `create_agreement`, `download_agreement` actions
 - **v1.0.0** — Initial release with signature request lifecycle, workspace, and template actions

--- a/lumin-pdf/config.json
+++ b/lumin-pdf/config.json
@@ -1,7 +1,7 @@
 {
   "name": "LuminPDF",
   "display_name": "Lumin PDF",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Integration with Lumin PDF for document management, eSignature workflows, and PDF generation.",
   "entry_point": "lumin_pdf.py",
   "auth": {

--- a/lumin-pdf/lumin_pdf.py
+++ b/lumin-pdf/lumin_pdf.py
@@ -81,12 +81,10 @@ class GetWorkspaceAction(ActionHandler):
 class ListWorkspaceMembersAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            has_page = inputs.get("page") is not None
-            has_limit = inputs.get("limit") is not None
-            params: Dict[str, Any] = {}
-            if has_page or has_limit:
-                params["page"] = int(inputs["page"]) if has_page else 1
-                params["limit"] = _clamp_limit(int(inputs["limit"])) if has_limit else 10
+            params: Dict[str, Any] = {
+                "page": int(inputs["page"]) if inputs.get("page") is not None else 1,
+                "limit": _clamp_limit(int(inputs["limit"])) if inputs.get("limit") is not None else 10,
+            }
             response = await context.fetch(
                 f"{BASE_URL}/workspaces/members",
                 method="GET",
@@ -108,12 +106,10 @@ class ListWorkspaceMembersAction(ActionHandler):
 class ListTemplatesAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            has_page = inputs.get("page") is not None
-            has_limit = inputs.get("limit") is not None
-            params: Dict[str, Any] = {}
-            if has_page or has_limit:
-                params["page"] = int(inputs["page"]) if has_page else 1
-                params["limit"] = _clamp_limit(int(inputs["limit"])) if has_limit else 10
+            params: Dict[str, Any] = {
+                "page": int(inputs["page"]) if inputs.get("page") is not None else 1,
+                "limit": _clamp_limit(int(inputs["limit"])) if inputs.get("limit") is not None else 10,
+            }
             response = await context.fetch(
                 f"{BASE_URL}/templates",
                 method="GET",

--- a/lumin-pdf/tests/test_lumin_pdf_unit.py
+++ b/lumin-pdf/tests/test_lumin_pdf_unit.py
@@ -88,15 +88,15 @@ class TestListWorkspaceMembers:
 
         assert result.result.data["members"] == members
 
-    async def test_omits_params_when_not_provided(self, make_context):
+    async def test_defaults_page_and_limit_when_not_provided(self, make_context):
         ctx = make_context(auth={"api_key": API_KEY})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_workspace_members", {}, ctx)
 
         params = ctx.fetch.call_args.kwargs["params"]
-        assert "page" not in params
-        assert "limit" not in params
+        assert params["page"] == 1
+        assert params["limit"] == 10
 
     async def test_limit_only_defaults_page_to_1(self, make_context):
         ctx = make_context(auth={"api_key": API_KEY})
@@ -132,15 +132,15 @@ class TestListTemplates:
 
         assert result.result.data["templates"] == templates
 
-    async def test_omits_params_when_not_provided(self, make_context):
+    async def test_defaults_page_and_limit_when_not_provided(self, make_context):
         ctx = make_context(auth={"api_key": API_KEY})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_templates", {}, ctx)
 
         params = ctx.fetch.call_args.kwargs["params"]
-        assert "page" not in params
-        assert "limit" not in params
+        assert params["page"] == 1
+        assert params["limit"] == 10
 
     async def test_limit_only_defaults_page_to_1(self, make_context):
         ctx = make_context(auth={"api_key": API_KEY})


### PR DESCRIPTION
## Summary

`list_templates` and `list_workspace_members` were failing with a 400 error when called without pagination params because the Lumin API requires `page` as a mandatory query parameter. The v1.2.0 refactor introduced a regression where both `page` and `limit` were only sent when the user explicitly provided them — previously `page` defaulted to `1` unconditionally.

Both actions now always send `page=1` and `limit=10` as defaults, with user-supplied values overriding them.

## Root Cause

Introduced in PR #348 (`sj/lumin-fixes`). The original code used `{"page": int(inputs.get("page", 1))}` (always defaulted). The refactor changed this to only include params when the user provided them, breaking no-arg calls.

## Changes

- `lumin_pdf.py` — `list_workspace_members` and `list_templates` now always include `page` (default `1`) and `limit` (default `10`) in the request params
- `tests/test_lumin_pdf_unit.py` — updated two tests that asserted the old broken behaviour (`page` omitted when not provided) to assert the correct defaults instead