### PR TITLE
fix: Support Instagram photo uploads directly from chat

### DIFF
--- a/instagram/config.json
+++ b/instagram/config.json
@@ -176,7 +176,8 @@
                     },
                     "media_url": {
                         "type": "string",
-                        "description": "Required for IMAGE, VIDEO, REELS: Public URL of the media file"
+                        "description": "Required for IMAGE, VIDEO, REELS: Public URL of the media file. You may attach a file in the chat — the platform will upload it to a public URL automatically.",
+                        "x-autohive-input": "file-public-url"
                     },
                     "caption": {
                         "type": "string",
@@ -231,7 +232,8 @@
                     },
                     "media_url": {
                         "type": "string",
-                        "description": "Public URL of the media file"
+                        "description": "Public URL of the media file. You may attach a file in the chat — the platform will upload it to a public URL automatically.",
+                        "x-autohive-input": "file-public-url"
                     }
                 },
                 "required": [

--- a/instagram/config.json
+++ b/instagram/config.json
@@ -186,9 +186,11 @@
                     "children": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Public URL of a carousel media item. You may attach a file in the chat — the platform will upload it to a public URL automatically.",
+                            "x-autohive-input": "file-public-url"
                         },
-                        "description": "Required for CAROUSEL: Array of media URLs for carousel items"
+                        "description": "Required for CAROUSEL: Array of media URLs for carousel items. You may attach files in the chat — the platform will upload them to public URLs automatically."
                     },
                     "alt_text": {
                         "type": "string",

--- a/instagram/config.json
+++ b/instagram/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Instagram",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Instagram Business/Creator integration for managing posts, comments, and insights",
     "supports_connected_account": true,
     "entry_point": "instagram.py",

--- a/instagram/instagram.py
+++ b/instagram/instagram.py
@@ -13,7 +13,7 @@ from autohive_integrations_sdk import (
 
 from helpers import INSTAGRAM_GRAPH_API_BASE
 
-instagram = Integration.load(os.path.join(os.path.dirname(__file__), "config.json"))
+instagram = Integration.load()
 
 sys.modules.setdefault("instagram", sys.modules[__name__])
 


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Adds support for photo uploads directly from chat when posting to Instagram, by introducing the `x-autohive-input: file-public-url` property to `media_url` fields.
- **Approach**: Updates the `media_url` action schema in `instagram/config.json` for both the single image/video post and carousel item endpoints, adding the `x-autohive-input` property and updating the field description to inform users they can attach a file in chat.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**
:point_right: Added `x-autohive-input: file-public-url` to the `media_url` field in the single post action schema
:point_right: Added `x-autohive-input: file-public-url` to the `media_url` field in the carousel item action schema
:point_right: Updated `media_url` descriptions to inform users they can attach a file in chat for automatic public URL upload

### Screenshots :camera:
Chat results
<img width="1183" height="1006" alt="Screenshot 2026-06-10 at 3 13 00 PM" src="https://github.com/user-attachments/assets/0ce02ba2-0484-4d1e-b7f4-29aa390a6987" />

Uploaded photo
<img width="1124" height="1653" alt="IMG_5946" src="https://github.com/user-attachments/assets/032c9567-adab-4c5d-8897-0d1c9343237b" />

### Test plan :test_tube: 
Uploading media works without providing a link. Instead, provide the media directly in the chat.

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)