### PR TITLE
feat(ci): add per-integration unit test coverage reporting on PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,8 @@ name: Unit Test Coverage
 on:
   pull_request:
     branches: [master, main]
+  push:
+    branches: [master, main]
 
 permissions:
   contents: read
@@ -21,16 +23,17 @@ jobs:
       - name: Detect changed integrations
         id: changed
         run: |
-          # Get all changed files vs base branch
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          if [ "${{ github.event_name }}" = "push" ]; then
+            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          fi
 
-          # Extract unique top-level integration directories that have a config.json
-          # (excludes .github, conftest.py, pyproject.toml, etc.)
           INTEGRATIONS=$(echo "$CHANGED_FILES" \
             | grep -oE '^[^/]+' \
             | sort -u \
             | while read dir; do
-                if [ -f "$dir/config.json" ] && [ -f "$dir/tests/$(ls $dir/tests/ 2>/dev/null | grep 'unit' | head -1)" ]; then
+                if [ -f "$dir/config.json" ] && ls "$dir/tests/"*unit*.py 2>/dev/null | grep -q .; then
                   echo "$dir"
                 fi
               done \
@@ -55,7 +58,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
@@ -63,7 +66,9 @@ jobs:
 
       - name: Run unit tests with coverage
         id: run_tests
+        shell: bash
         run: |
+          set -o pipefail
           python -m pytest ${{ matrix.integration }}/tests/test_*_unit.py \
             --cov=${{ matrix.integration }} \
             --cov-report=json:coverage.json \
@@ -72,14 +77,13 @@ jobs:
             --tb=short \
             -q 2>&1 | tee test_output.txt
 
-          # Extract coverage % from json report
           COVERAGE=$(python -c "
-          import json, sys
+          import json
           try:
               data = json.load(open('coverage.json'))
               pct = data['totals']['percent_covered']
               print(f'{pct:.1f}')
-          except Exception as e:
+          except Exception:
               print('0.0')
           ")
           echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
@@ -95,10 +99,7 @@ jobs:
       - name: Fetch master baseline coverage
         id: baseline
         run: |
-          # Try to download master coverage artifact from the most recent successful run on master
           BASELINE="N/A"
-
-          # Check if a baseline artifact exists from a previous cache
           if [ -f ".coverage-baselines/${{ matrix.integration }}.json" ]; then
             BASELINE=$(python -c "
           import json
@@ -110,7 +111,6 @@ jobs:
               print('N/A')
           ")
           fi
-
           echo "baseline=$BASELINE" >> $GITHUB_OUTPUT
 
       - name: Build coverage summary
@@ -119,29 +119,27 @@ jobs:
           COVERAGE=${{ steps.run_tests.outputs.coverage }}
           BASELINE=${{ steps.baseline.outputs.baseline }}
 
-          # Calculate trend
           if [ "$BASELINE" = "N/A" ]; then
-            TREND="⚪ (no baseline)"
+            TREND="⚪ (no baseline yet)"
           else
-            DIFF=$(python -c "
+            TREND=$(python -c "
           try:
               diff = float('$COVERAGE') - float('$BASELINE')
               if diff > 0:
-                  print(f'🟢 ↑ +{diff:.1f}%')
+                  print(f'🟢 ↑ +{diff:.1f}% vs master ({float(\"$BASELINE\"):.1f}%)')
               elif diff < 0:
-                  print(f'🔴 ↓ {diff:.1f}%')
+                  print(f'🔴 ↓ {diff:.1f}% vs master ({float(\"$BASELINE\"):.1f}%)')
               else:
-                  print('➡️ no change')
+                  print(f'➡️ no change vs master ({float(\"$BASELINE\"):.1f}%)')
           except:
               print('⚪')
           ")
-            TREND="$DIFF vs master ($BASELINE%)"
           fi
 
           echo "trend=$TREND" >> $GITHUB_OUTPUT
-          echo "Integration: ${{ matrix.integration }} | Coverage: $COVERAGE% | $TREND"
 
       - name: Post coverage comment
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -179,7 +177,7 @@ jobs:
 
   update-baseline:
     needs: coverage
-    if: github.ref_name == 'master' && always()
+    if: github.event_name == 'push' && (github.ref_name == 'master' || github.ref_name == 'main')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,212 @@
+name: Unit Test Coverage
+
+on:
+  pull_request:
+    branches: [master, main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      integrations: ${{ steps.changed.outputs.integrations }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed integrations
+        id: changed
+        run: |
+          # Get all changed files vs base branch
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # Extract unique top-level integration directories that have a config.json
+          # (excludes .github, conftest.py, pyproject.toml, etc.)
+          INTEGRATIONS=$(echo "$CHANGED_FILES" \
+            | grep -oE '^[^/]+' \
+            | sort -u \
+            | while read dir; do
+                if [ -f "$dir/config.json" ] && [ -f "$dir/tests/$(ls $dir/tests/ 2>/dev/null | grep 'unit' | head -1)" ]; then
+                  echo "$dir"
+                fi
+              done \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          echo "integrations=$INTEGRATIONS" >> $GITHUB_OUTPUT
+          echo "Changed integrations: $INTEGRATIONS"
+
+  coverage:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.integrations != '[]' && needs.detect-changes.outputs.integrations != ''
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        integration: ${{ fromJson(needs.detect-changes.outputs.integrations) }}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -r ${{ matrix.integration }}/requirements.txt -r requirements-test.txt
+
+      - name: Run unit tests with coverage
+        id: run_tests
+        run: |
+          python -m pytest ${{ matrix.integration }}/tests/test_*_unit.py \
+            --cov=${{ matrix.integration }} \
+            --cov-report=json:coverage.json \
+            --cov-report=term-missing \
+            -m unit \
+            --tb=short \
+            -q 2>&1 | tee test_output.txt
+
+          # Extract coverage % from json report
+          COVERAGE=$(python -c "
+          import json, sys
+          try:
+              data = json.load(open('coverage.json'))
+              pct = data['totals']['percent_covered']
+              print(f'{pct:.1f}')
+          except Exception as e:
+              print('0.0')
+          ")
+          echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+          echo "Coverage: $COVERAGE%"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.integration }}
+          path: coverage.json
+          retention-days: 7
+
+      - name: Fetch master baseline coverage
+        id: baseline
+        run: |
+          # Try to download master coverage artifact from the most recent successful run on master
+          BASELINE="N/A"
+
+          # Check if a baseline artifact exists from a previous cache
+          if [ -f ".coverage-baselines/${{ matrix.integration }}.json" ]; then
+            BASELINE=$(python -c "
+          import json
+          try:
+              data = json.load(open('.coverage-baselines/${{ matrix.integration }}.json'))
+              pct = data['totals']['percent_covered']
+              print(f'{pct:.1f}')
+          except:
+              print('N/A')
+          ")
+          fi
+
+          echo "baseline=$BASELINE" >> $GITHUB_OUTPUT
+
+      - name: Build coverage summary
+        id: summary
+        run: |
+          COVERAGE=${{ steps.run_tests.outputs.coverage }}
+          BASELINE=${{ steps.baseline.outputs.baseline }}
+
+          # Calculate trend
+          if [ "$BASELINE" = "N/A" ]; then
+            TREND="⚪ (no baseline)"
+          else
+            DIFF=$(python -c "
+          try:
+              diff = float('$COVERAGE') - float('$BASELINE')
+              if diff > 0:
+                  print(f'🟢 ↑ +{diff:.1f}%')
+              elif diff < 0:
+                  print(f'🔴 ↓ {diff:.1f}%')
+              else:
+                  print('➡️ no change')
+          except:
+              print('⚪')
+          ")
+            TREND="$DIFF vs master ($BASELINE%)"
+          fi
+
+          echo "trend=$TREND" >> $GITHUB_OUTPUT
+          echo "Integration: ${{ matrix.integration }} | Coverage: $COVERAGE% | $TREND"
+
+      - name: Post coverage comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const integration = '${{ matrix.integration }}';
+            const coverage = '${{ steps.run_tests.outputs.coverage }}';
+            const trend = '${{ steps.summary.outputs.trend }}';
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+
+            const marker = `<!-- coverage-${integration} -->`;
+            const body = `${marker}\n## Unit test coverage — \`${integration}\`\n\n**Coverage: ${coverage}%** ${trend}\n\n[Full report](${runUrl})`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  update-baseline:
+    needs: coverage
+    if: github.ref_name == 'master' && always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+
+      - name: Update baselines
+        run: |
+          mkdir -p .coverage-baselines
+          for dir in coverage-artifacts/coverage-*/; do
+            integration=$(basename "$dir" | sed 's/^coverage-//')
+            if [ -f "$dir/coverage.json" ]; then
+              cp "$dir/coverage.json" ".coverage-baselines/$integration.json"
+              echo "Updated baseline for $integration"
+            fi
+          done
+
+      - name: Commit updated baselines
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .coverage-baselines/
+          git diff --staged --quiet || git commit -m "chore: update coverage baselines [skip ci]"
+          git push

--- a/instagram/requirements.txt
+++ b/instagram/requirements.txt
@@ -1,1 +1,2 @@
 autohive-integrations-sdk~=2.0.0
+


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/coverage.yml` that runs on every PR targeting `master`
- Detects which integration directories changed and runs coverage only for those (scoped, not full repo)
- Posts a PR comment per integration showing coverage % with trend vs master baseline (🟢↑ / 🔴↓)
- Updates `.coverage-baselines/` on merge to master so future PRs have a comparison point
- Uses existing `requirements-test.txt` which already has `pytest-cov` — no per-integration changes needed

## How it works

1. **Detect** — finds changed integration dirs (must have `config.json` + unit tests)
2. **Matrix job** — one job per changed integration, installs deps + runs `pytest --cov`
3. **Comment** — posts/updates a coverage comment on the PR with the result
4. **Baseline** — on merge to master, saves coverage JSON to `.coverage-baselines/<integration>.json`

## Test plan

- [ ] Open a PR that touches an integration with unit tests and verify the coverage comment appears
- [ ] Push a new commit to the same PR and verify the comment updates in place (not duplicated)
- [ ] Merge to master and verify `.coverage-baselines/` is updated