### PR TITLE
test(instagram): add chat upload schema tests

### DIFF
--- a/instagram/tests/test_instagram_unit.py
+++ b/instagram/tests/test_instagram_unit.py
@@ -2,6 +2,7 @@
 Unit tests for the Instagram integration using mocked fetch.
 """
 
+import json
 import os
 import sys
 
@@ -334,6 +335,35 @@ async def test_get_posts_after_cursor_forwarded():
 # =============================================================================
 # CREATE POST
 # =============================================================================
+
+
+def test_chat_file_upload_metadata_present_on_instagram_media_inputs():
+    config_path = os.path.join(_parent, "config.json")
+    with open(config_path, encoding="utf-8") as config_file:
+        config = json.load(config_file)
+
+    create_post_properties = config["actions"]["create_post"]["input_schema"]["properties"]
+    assert create_post_properties["media_url"]["x-autohive-input"] == "file-public-url"
+    assert create_post_properties["children"]["type"] == "array"
+    assert create_post_properties["children"]["items"]["type"] == "string"
+    assert create_post_properties["children"]["items"]["x-autohive-input"] == "file-public-url"
+
+    create_story_properties = config["actions"]["create_story"]["input_schema"]["properties"]
+    assert create_story_properties["media_url"]["x-autohive-input"] == "file-public-url"
+
+
+def test_chat_file_upload_descriptions_are_user_facing():
+    config_path = os.path.join(_parent, "config.json")
+    with open(config_path, encoding="utf-8") as config_file:
+        config = json.load(config_file)
+
+    create_post_properties = config["actions"]["create_post"]["input_schema"]["properties"]
+    create_story_properties = config["actions"]["create_story"]["input_schema"]["properties"]
+
+    assert "attach a file" in create_post_properties["media_url"]["description"]
+    assert "attach files" in create_post_properties["children"]["description"]
+    assert "attach a file" in create_post_properties["children"]["items"]["description"]
+    assert "attach a file" in create_story_properties["media_url"]["description"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add unit/config regression coverage for Instagram chat file upload schema metadata
- Assert `x-autohive-input: file-public-url` is present on post media, carousel children, and story media inputs
- Assert the user-facing descriptions mention chat file attachments

Follow-up to #355.

## Validation
- `python3 ../autohive-integrations-tooling/scripts/validate_integration.py instagram`
- `uv run ruff check instagram/tests/test_instagram_unit.py`
- `python3 -m compileall -q instagram/tests/test_instagram_unit.py`

Not run locally:
- `python3 -m pytest instagram/tests/test_instagram_unit.py -m unit -q` — local system Python is missing pytest in this environment; CI should run the suite.