### PR TITLE
fix(microsoft-planner): add User.ReadBasic.All scope for user lookups

### DIFF
--- a/microsoft-planner/README.md
+++ b/microsoft-planner/README.md
@@ -23,7 +23,8 @@ This integration uses **OAuth 2.0 Platform Authentication** through Microsoft's 
 **Required Scopes:**
 - `Tasks.ReadWrite` - Read and write access to Planner tasks
 - `Group.ReadWrite.All` - Access to Microsoft 365 groups
-- `User.Read` - Read user profile information
+- `User.Read` - Read the signed-in user's profile
+- `User.ReadBasic.All` - Read basic profiles (name, email, ID) of other users to resolve them for task assignments
 - `offline_access` - Maintain access via refresh tokens
 
 **Setup Steps:**

--- a/microsoft-planner/config.json
+++ b/microsoft-planner/config.json
@@ -11,6 +11,7 @@
             "Tasks.ReadWrite",
             "Group.ReadWrite.All",
             "User.Read",
+            "User.ReadBasic.All",
             "offline_access"
         ]
     },

--- a/microsoft-planner/config.json
+++ b/microsoft-planner/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Microsoft Planner",
     "display_name": "Microsoft Planner",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Microsoft Planner integration for managing plans, tasks, and buckets in Microsoft 365",
     "entry_point": "microsoft_planner.py",
     "auth": {

--- a/microsoft-planner/microsoft_planner.py
+++ b/microsoft-planner/microsoft_planner.py
@@ -147,7 +147,6 @@ class SearchUsersAction(ActionHandler):
                     "user_id": user.get("id"),
                     "display_name": user.get("displayName"),
                     "email": user.get("mail") or user.get("userPrincipalName"),
-                    "job_title": user.get("jobTitle"),
                 }
                 for user in users
             ]

--- a/microsoft-planner/tests/test_microsoft_planner.py
+++ b/microsoft-planner/tests/test_microsoft_planner.py
@@ -20,7 +20,6 @@ class TestMicrosoftPlannerIntegration(unittest.TestCase):
                     "displayName": "John Doe",
                     "mail": "john.doe@example.com",
                     "userPrincipalName": "john.doe@example.com",
-                    "jobTitle": "Software Engineer",
                 }
             ]
         }
@@ -62,13 +61,13 @@ class TestMicrosoftPlannerIntegration(unittest.TestCase):
                     "id": "user-id-1",
                     "displayName": "John Doe",
                     "mail": "john.doe@example.com",
-                    "jobTitle": "Software Engineer",
+                    "userPrincipalName": "john.doe@example.com",
                 },
                 {
                     "id": "user-id-2",
                     "displayName": "Jane Doe",
                     "mail": "jane.doe@example.com",
-                    "jobTitle": "Product Manager",
+                    "userPrincipalName": "jane.doe@example.com",
                 },
             ]
         }


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Fixes a 403 Authorization Denied error when resolving users for task assignments by adding the `User.ReadBasic.All` OAuth scope to the Microsoft Planner integration.
- **Approach**: Adds the new scope to the configuration and documentation. Removes the `job_title` field from user search functionality and tests, as it is not covered by the basic scope and would return null.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Updates**
:point_right: Added `User.ReadBasic.All` to required OAuth scopes in `config.json` and `README.md`
:point_right: Removed `job_title` field from `search_users` output in `microsoft_planner.py`
:point_right: Updated unit tests to reflect the removal of `jobTitle` from user responses

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
1. Reconnect the Microsoft Planner integration to accept the new `User.ReadBasic.All` scope.
2. Attempt to assign a task using a user's email via `get_user_by_email` or `search_users`.
3. Verify that the user lookup succeeds without a 403 Authorization Denied error.
4. Verify that the user search response does not include the `job_title` field.

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)