### PR TITLE
feat: Projectworks rename casing, add search actions, field projection, and default page size

### DIFF
--- a/projectworks/README.md
+++ b/projectworks/README.md
@@ -42,7 +42,19 @@ Projectworks uses HTTP Basic authentication with an API account (the Consumer Ke
 | `get_expense_claim` | Get a single expense claim | `expense_claim_id` | `expense_claim` |
 | `list_offices` | List offices | `name` | `offices[]` |
 
-All `list_*` actions accept `page` (default 1) and `page_size` (default 100) for pagination. Many also accept `modified_since_date` (ISO 8601) for incremental syncing.
+All `list_*` actions accept `page` (default 1) and `page_size` (default 50) for pagination. Many also accept `modified_since_date` (ISO 8601) for incremental syncing.
+
+All `list_*` actions also accept an optional `fields` array of response field names (PascalCase, e.g. `["UserID", "FirstName", "Email"]`). When supplied, each returned record is trimmed to just those fields — useful for keeping large result sets small in a consuming LLM's context window. Omit it to get full records, or call the matching `get_*` action once a record of interest is found.
+
+### Search
+
+Projectworks' API exposes only structured (exact-match) list filters, so these actions provide free-text, case-insensitive substring lookup as a convenience layer over the list endpoints. Each scans one page (`page_size`, default 200) and returns up to `limit` (default 10) lean matches; they also accept the same `fields` projection. For exhaustive enumeration, use the matching `list_*` action with explicit filters and pagination.
+
+| Action | Description | Key Inputs | Matched On | Key Outputs |
+|---|---|---|---|---|
+| `search_users` | Find users by name or email | `query`, `limit`, `fields` | `FirstName`, `LastName`, `Name`, `Email` (a multi-word query like `Jane Doe` also matches `FirstName` + `LastName` together) | `users[]` |
+| `search_clients` | Find clients by name | `query`, `limit`, `fields` | `Name` | `clients[]` |
+| `search_projects` | Find projects by name or number | `query`, `limit`, `fields` | `Name`, `ProjectNumber` | `projects[]` |
 
 ### Write
 

--- a/projectworks/README.md
+++ b/projectworks/README.md
@@ -1,12 +1,12 @@
-# ProjectWorks
+# Projectworks
 
-[ProjectWorks](https://www.projectworks.com) is a professional services automation (PSA) platform covering projects, resourcing, timesheets, leave, invoicing, and expenses. This integration provides full read and write access to the core ProjectWorks entities — listing and fetching records, creating/updating/deleting them, and managing sub-resources such as task assignments, user roles, leave balances, postings, and custom fields.
+[Projectworks](https://www.projectworks.com) is a professional services automation (PSA) platform covering projects, resourcing, timesheets, leave, invoicing, and expenses. This integration provides full read and write access to the core Projectworks entities — listing and fetching records, creating/updating/deleting them, and managing sub-resources such as task assignments, user roles, leave balances, postings, and custom fields.
 
 ## Auth Setup
 
-ProjectWorks uses HTTP Basic authentication with an API account (the Consumer Key/Secret pair — **not** your normal login).
+Projectworks uses HTTP Basic authentication with an API account (the Consumer Key/Secret pair — **not** your normal login).
 
-1. Log in to ProjectWorks and go to **Profile icon → Admin → API Accounts**
+1. Log in to Projectworks and go to **Profile icon → Admin → API Accounts**
 2. Click **+** to create a new API account, then **Add** to generate it
 3. Open **Three Dots → Details** and copy the **Consumer Key** and **Consumer Secret**
 4. Paste them into the **Consumer Key** and **Consumer Secret** fields when connecting
@@ -73,13 +73,13 @@ All `list_*` actions accept `page` (default 1) and `page_size` (default 100) for
 
 `update_user_roles` and `update_user_leave_balances` return an empty body from the API on success; the integration echoes the applied state plus `updated: true`.
 
-> Reference IDs (office, currency, project/task type, status, leave type, role, etc.) come from the corresponding `list_*` actions or your ProjectWorks configuration, and must already exist in your account. Array inputs use the API's field names:
+> Reference IDs (office, currency, project/task type, status, leave type, role, etc.) come from the corresponding `list_*` actions or your Projectworks configuration, and must already exist in your account. Array inputs use the API's field names:
 > - `create_leave` → `days`: `[{ "date": ISO8601, "typeID": int, "hours": number }]` — `typeID` is a **leave type ID** that must exist in your config (see Admin → Leave Types).
 > - `update_user_leave_balances` → `balances`: `[{ "leaveTypeID": int, "balance": number, "unit": "Hours"|"Days" }]` — requires the user to have an active **posting** first (use `update_user_postings`).
 > - `update_task_placeholder` → `role_id` is **required** and must be a configured role ID (look it up with `list_roles`); an unrecognised role ID makes the API return HTTP 500.
 > - `update_user_postings` → `capacity_days`: `[{ "dayOfWeekID": int, "hours": number }]`
 > - `set_custom_fields` → `fields`: `[{ "fieldID": int, "value": str, "multiSelectValues": [str] }]`
-> - `create_expense_claim` / `update_expense_claim` → attach a receipt with `file`: `{ "name": "receipt.pdf", "content": "<base64>" }`. The file must be supplied as base64 `content` (the standard Autohive file object). Most ProjectWorks accounts reject an expense claim with no file (`HTTP 400: Must include at least one file`).
+> - `create_expense_claim` / `update_expense_claim` → attach a receipt with `file`: `{ "name": "receipt.pdf", "content": "<base64>" }`. The file must be supplied as base64 `content` (the standard Autohive file object). Most Projectworks accounts reject an expense claim with no file (`HTTP 400: Must include at least one file`).
 
 ## API Info
 
@@ -116,7 +116,7 @@ path (`POST`/`PATCH`/`PUT`/`DELETE`) for timesheets, clients, and modules + task
 | Error | Cause | Fix |
 |---|---|---|
 | `401 Unauthorized` | Invalid Consumer Key/Secret, or using your web login | Use an API account's Consumer Key/Secret from Admin → API Accounts |
-| `403 Forbidden` | API account lacks permission for the resource | Check the API account's role/permissions in ProjectWorks |
+| `403 Forbidden` | API account lacks permission for the resource | Check the API account's role/permissions in Projectworks |
 | Empty result list | Filters too narrow, or beyond the last page | Loosen filters; page until a partial (< `page_size`) page is returned |
 | `create_leave` rejects the request | The `typeID` in `days` is not a leave type configured in your account | Use a real leave type ID (Admin → Leave Types) |
 | `update_task_placeholder` returns HTTP 500 | The `role_id` is not a configured role in your account | Use a valid role ID from `list_roles` |

--- a/projectworks/__init__.py
+++ b/projectworks/__init__.py
@@ -1,4 +1,4 @@
-# ProjectWorks Integration for Autohive
+# Projectworks Integration for Autohive
 from .projectworks import projectworks
 
 __all__ = ["projectworks"]

--- a/projectworks/config.json
+++ b/projectworks/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Projectworks",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Projectworks integration for reading users, clients, projects, modules, tasks, resourcing, timesheets, leave, invoices, and expense claims from your professional services automation account.",
   "display_name": "Projectworks",
   "supports_connected_account": false,
@@ -64,8 +64,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -128,8 +135,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -184,8 +198,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -276,8 +297,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -360,8 +388,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -452,8 +487,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -552,8 +594,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -648,8 +697,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -712,8 +768,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -784,8 +847,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -852,8 +922,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -968,8 +1045,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -1048,8 +1132,15 @@
           },
           "page_size": {
             "type": "integer",
-            "description": "Results per page (default 100)",
+            "description": "Results per page (default 50)",
             "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
           }
         },
         "required": []
@@ -1064,6 +1155,156 @@
         },
         "required": [
           "offices"
+        ]
+      }
+    },
+    "search_users": {
+      "display_name": "Search Users",
+      "description": "Free-text search for users by name or email. Scans one page (default 200 records) and returns up to `limit` lean matches. A convenience layer over list_users for \"find the user called ...\" flows; for exhaustive enumeration use list_users with explicit filters and pagination.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Case-insensitive substring matched against the user's name or email"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of matches to return (default 10)",
+            "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Page to scan (default 1). Increase to scan further into large data sets.",
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Number of records to scan in one page (default 200)",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "description": "Matching users"
+          }
+        },
+        "required": [
+          "users"
+        ]
+      }
+    },
+    "search_clients": {
+      "display_name": "Search Clients",
+      "description": "Free-text search for clients by name. Scans one page (default 200 records) and returns up to `limit` lean matches. A convenience layer over list_clients for \"find the client called ...\" flows; for exhaustive enumeration use list_clients with explicit filters and pagination.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Case-insensitive substring matched against the client's name"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of matches to return (default 10)",
+            "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Page to scan (default 1). Increase to scan further into large data sets.",
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Number of records to scan in one page (default 200)",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "clients": {
+            "type": "array",
+            "description": "Matching clients"
+          }
+        },
+        "required": [
+          "clients"
+        ]
+      }
+    },
+    "search_projects": {
+      "display_name": "Search Projects",
+      "description": "Free-text search for projects by name or project number. Scans one page (default 200 records) and returns up to `limit` lean matches. A convenience layer over list_projects for \"find the project called ...\" flows; for exhaustive enumeration use list_projects with explicit filters and pagination.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Case-insensitive substring matched against the project's name or project number"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of matches to return (default 10)",
+            "minimum": 1
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of response field names (PascalCase, e.g. [\"UserID\", \"FirstName\", \"Email\"]) to return for each record. When omitted, full records are returned. Use this to keep large result sets small for an LLM context window, then call the matching get_* action for the full record."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Page to scan (default 1). Increase to scan further into large data sets.",
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Number of records to scan in one page (default 200)",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "projects": {
+            "type": "array",
+            "description": "Matching projects"
+          }
+        },
+        "required": [
+          "projects"
         ]
       }
     },

--- a/projectworks/config.json
+++ b/projectworks/config.json
@@ -1166,7 +1166,9 @@
         "properties": {
           "query": {
             "type": "string",
-            "description": "Case-insensitive substring matched against the user's name or email"
+            "description": "Case-insensitive substring matched against the user's name or email",
+            "minLength": 1,
+            "pattern": "\\S"
           },
           "limit": {
             "type": "integer",
@@ -1216,7 +1218,9 @@
         "properties": {
           "query": {
             "type": "string",
-            "description": "Case-insensitive substring matched against the client's name"
+            "description": "Case-insensitive substring matched against the client's name",
+            "minLength": 1,
+            "pattern": "\\S"
           },
           "limit": {
             "type": "integer",
@@ -1266,7 +1270,9 @@
         "properties": {
           "query": {
             "type": "string",
-            "description": "Case-insensitive substring matched against the project's name or project number"
+            "description": "Case-insensitive substring matched against the project's name or project number",
+            "minLength": 1,
+            "pattern": "\\S"
           },
           "limit": {
             "type": "integer",

--- a/projectworks/config.json
+++ b/projectworks/config.json
@@ -1,20 +1,20 @@
 {
-  "name": "ProjectWorks",
-  "version": "1.0.0",
-  "description": "ProjectWorks integration for reading users, clients, projects, modules, tasks, resourcing, timesheets, leave, invoices, and expense claims from your professional services automation account.",
-  "display_name": "ProjectWorks",
+  "name": "Projectworks",
+  "version": "1.0.1",
+  "description": "Projectworks integration for reading users, clients, projects, modules, tasks, resourcing, timesheets, leave, invoices, and expense claims from your professional services automation account.",
+  "display_name": "Projectworks",
   "supports_connected_account": false,
   "entry_point": "projectworks.py",
   "auth": {
     "type": "custom",
-    "title": "ProjectWorks API Account",
+    "title": "Projectworks API Account",
     "fields": {
       "type": "object",
       "properties": {
         "consumer_key": {
           "type": "string",
           "label": "Consumer Key",
-          "help_text": "From ProjectWorks -> Admin -> API Accounts -> create an account -> Details. Used as the Basic auth username."
+          "help_text": "From Projectworks -> Admin -> API Accounts -> create an account -> Details. Used as the Basic auth username."
         },
         "consumer_secret": {
           "type": "string",
@@ -2220,7 +2220,7 @@
           },
           "file": {
             "type": "object",
-            "description": "Receipt/invoice file to attach. ProjectWorks usually requires at least one file when creating an expense claim. Supply the file as base64 'content'.",
+            "description": "Receipt/invoice file to attach. Projectworks usually requires at least one file when creating an expense claim. Supply the file as base64 'content'.",
             "properties": {
               "content": {
                 "type": "string",

--- a/projectworks/projectworks.py
+++ b/projectworks/projectworks.py
@@ -7,6 +7,16 @@ projectworks = Integration.load()
 
 BASE_URL = "https://api.projectworksapp.com/api/v1"
 
+# Cap an unparameterised list call so it cannot dump hundreds of full records
+# into a consuming LLM's context window. Callers can still page explicitly.
+DEFAULT_PAGE_SIZE = 50
+
+# search_* actions scan a single page client-side; this is how many records that
+# page holds (larger than DEFAULT_PAGE_SIZE so a free-text scan has more to match
+# against) and how many matches are returned by default.
+DEFAULT_SEARCH_SCAN = 200
+DEFAULT_SEARCH_LIMIT = 10
+
 
 def _resolve_file_bytes(file_obj: Dict[str, Any]) -> bytes:
     """Resolve raw bytes from a standard Autohive file object.
@@ -87,7 +97,31 @@ def _clean(d: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in d.items() if v is not None}
 
 
-async def _list(context: ExecutionContext, path: str, result_key: str, params: Dict[str, Any]) -> ActionResult:
+def _project(records: List[Any], fields: Any) -> List[Any]:
+    """Trim each record down to the requested field names.
+
+    ``fields`` is an optional list of API response keys (PascalCase, e.g.
+    ``["UserID", "FirstName", "Email"]``). When omitted, records pass through
+    unchanged. This lets a caller keep list payloads small for a consuming LLM's
+    context window and fall back to the matching ``get_*`` action for the full
+    record once a row of interest is identified. Unknown keys are simply absent.
+    """
+    if not fields:
+        return records
+    wanted = set(fields)
+    return [{k: v for k, v in r.items() if k in wanted} if isinstance(r, dict) else r for r in records]
+
+
+async def _list(
+    context: ExecutionContext,
+    path: str,
+    result_key: str,
+    params: Dict[str, Any],
+    fields: Any = None,
+) -> ActionResult:
+    # Apply a conservative default page size so a filter-less call stays small.
+    if params.get("pageSize") is None:
+        params["pageSize"] = DEFAULT_PAGE_SIZE
     response = await context.fetch(
         f"{BASE_URL}/{path}",
         method="GET",
@@ -95,7 +129,7 @@ async def _list(context: ExecutionContext, path: str, result_key: str, params: D
         params=_clean(params),
     )
     _check_response(response)
-    return ActionResult(data={result_key: _as_list(response.data)}, cost_usd=0.0)
+    return ActionResult(data={result_key: _project(_as_list(response.data), fields)}, cost_usd=0.0)
 
 
 async def _get(
@@ -145,6 +179,69 @@ async def _delete(
     return ActionResult(data={deleted_key: deleted_value, "deleted": True}, cost_usd=0.0)
 
 
+def _matches_query(
+    record: Dict[str, Any],
+    query: str,
+    search_fields: List[str],
+    composed_fields: List[List[str]] | None = None,
+) -> bool:
+    q = query.casefold()
+    for field in search_fields:
+        value = record.get(field)
+        if isinstance(value, str) and q in value.casefold():
+            return True
+    # composed_fields lets a multi-word query (e.g. "Jane Doe") match against
+    # several fields joined together (e.g. FirstName + LastName), which no single
+    # field would satisfy on its own.
+    for group in composed_fields or []:
+        joined = " ".join(v for v in (record.get(f) for f in group) if isinstance(v, str))
+        if joined and q in joined.casefold():
+            return True
+    return False
+
+
+async def _search(
+    context: ExecutionContext,
+    path: str,
+    result_key: str,
+    query: str,
+    search_fields: List[str],
+    limit: Any = None,
+    page: Any = None,
+    page_size: Any = None,
+    fields: Any = None,
+    composed_fields: List[List[str]] | None = None,
+) -> ActionResult:
+    """Free-text convenience search over a list endpoint.
+
+    Projectworks exposes only structured (exact) list filters, so this scans one
+    page of records and matches ``query`` case-insensitively as a substring
+    against ``search_fields`` (and any ``composed_fields`` groups joined with a
+    space), returning at most ``limit`` lean results. It is a convenience layer
+    over ``list_*`` for "find the X called ..." flows — for exhaustive
+    enumeration use the matching ``list_*`` action with explicit filters and
+    pagination.
+    """
+    params = {
+        "page": page,
+        "pageSize": page_size or DEFAULT_SEARCH_SCAN,
+    }
+    response = await context.fetch(
+        f"{BASE_URL}/{path}",
+        method="GET",
+        headers=_get_headers(context),
+        params=_clean(params),
+    )
+    _check_response(response)
+    cap = limit or DEFAULT_SEARCH_LIMIT
+    matched = [
+        r
+        for r in _as_list(response.data)
+        if isinstance(r, dict) and _matches_query(r, query, search_fields, composed_fields)
+    ]
+    return ActionResult(data={result_key: _project(matched[:cap], fields)}, cost_usd=0.0)
+
+
 # =============================================================================
 # USERS / EMPLOYEES
 # =============================================================================
@@ -168,6 +265,7 @@ class ListUsersAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -195,6 +293,7 @@ class ListRolesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -223,6 +322,7 @@ class ListClientsAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -262,6 +362,7 @@ class ListProjectsAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -299,6 +400,7 @@ class ListModulesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -338,6 +440,7 @@ class ListTasksAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -379,6 +482,7 @@ class ListResourcesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -419,6 +523,7 @@ class ListTimesheetsAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -449,6 +554,7 @@ class ListLeavesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -478,6 +584,7 @@ class ListLeaveTypesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -509,6 +616,7 @@ class ListInvoicesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -554,6 +662,7 @@ class ListExpenseClaimsAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))
@@ -600,6 +709,70 @@ class ListOfficesAction(ActionHandler):
                     "page": inputs.get("page"),
                     "pageSize": inputs.get("page_size"),
                 },
+                fields=inputs.get("fields"),
+            )
+        except Exception as e:
+            return ActionError(message=str(e))
+
+
+# =============================================================================
+# SEARCH (free-text convenience over list endpoints)
+# =============================================================================
+
+
+@projectworks.action("search_users")
+class SearchUsersAction(ActionHandler):
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
+        try:
+            return await _search(
+                context,
+                "Users",
+                "users",
+                inputs["query"],
+                ["FirstName", "LastName", "Name", "Email"],
+                limit=inputs.get("limit"),
+                page=inputs.get("page"),
+                page_size=inputs.get("page_size"),
+                fields=inputs.get("fields"),
+                composed_fields=[["FirstName", "LastName"]],
+            )
+        except Exception as e:
+            return ActionError(message=str(e))
+
+
+@projectworks.action("search_clients")
+class SearchClientsAction(ActionHandler):
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
+        try:
+            return await _search(
+                context,
+                "Clients",
+                "clients",
+                inputs["query"],
+                ["Name", "ClientName"],
+                limit=inputs.get("limit"),
+                page=inputs.get("page"),
+                page_size=inputs.get("page_size"),
+                fields=inputs.get("fields"),
+            )
+        except Exception as e:
+            return ActionError(message=str(e))
+
+
+@projectworks.action("search_projects")
+class SearchProjectsAction(ActionHandler):
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
+        try:
+            return await _search(
+                context,
+                "Projects",
+                "projects",
+                inputs["query"],
+                ["Name", "ProjectName", "ProjectNumber"],
+                limit=inputs.get("limit"),
+                page=inputs.get("page"),
+                page_size=inputs.get("page_size"),
+                fields=inputs.get("fields"),
             )
         except Exception as e:
             return ActionError(message=str(e))

--- a/projectworks/projectworks.py
+++ b/projectworks/projectworks.py
@@ -222,6 +222,9 @@ async def _search(
     enumeration use the matching ``list_*`` action with explicit filters and
     pagination.
     """
+    query = query.strip()
+    if not query:
+        raise ValueError("query must not be blank")
     params = {
         "page": page,
         "pageSize": page_size or DEFAULT_SEARCH_SCAN,

--- a/projectworks/projectworks.py
+++ b/projectworks/projectworks.py
@@ -33,7 +33,7 @@ def _get_headers(context: ExecutionContext) -> Dict[str, str]:
     # compatible with whatever shape the platform passes, while a missing/blank
     # credential fails with a clear message instead of an unauthenticated request.
     if not consumer_key or not consumer_secret:
-        raise ValueError("ProjectWorks Consumer Key and Consumer Secret are required")
+        raise ValueError("Projectworks Consumer Key and Consumer Secret are required")
     token = base64.b64encode(f"{consumer_key}:{consumer_secret}".encode()).decode()
     return {
         "Authorization": f"Basic {token}",
@@ -50,11 +50,11 @@ def _check_response(response: Any) -> None:
             msg = data.get("message") or data.get("error") or data.get("title") or str(data)
         else:
             msg = str(data)
-        raise RuntimeError(f"ProjectWorks error {response.status}: {msg}")
+        raise RuntimeError(f"Projectworks error {response.status}: {msg}")
 
 
 def _as_list(data: Any) -> List[Any]:
-    """ProjectWorks list endpoints return a bare JSON array."""
+    """Projectworks list endpoints return a bare JSON array."""
     if isinstance(data, list):
         return data
     if isinstance(data, dict):
@@ -68,7 +68,7 @@ def _as_list(data: Any) -> List[Any]:
 def _as_object(data: Any) -> Dict[str, Any]:
     """Normalise a single-record response to an object.
 
-    Some ProjectWorks single-record endpoints return a one-element array
+    Some Projectworks single-record endpoints return a one-element array
     (or, on an empty result, a null/empty body) rather than a bare object.
     """
     if isinstance(data, list):

--- a/projectworks/tests/conftest.py
+++ b/projectworks/tests/conftest.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.fixture
 def mock_context():
-    """Mock ExecutionContext pre-loaded with ProjectWorks custom-auth credentials."""
+    """Mock ExecutionContext pre-loaded with Projectworks custom-auth credentials."""
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {

--- a/projectworks/tests/test_projectworks_integration.py
+++ b/projectworks/tests/test_projectworks_integration.py
@@ -300,6 +300,79 @@ class TestListOffices:
         assert isinstance(data["offices"], list)
 
 
+# ---- List field projection / page size (read-only) ----
+
+
+class TestListFieldProjection:
+    async def test_fields_trims_returned_records(self, live_context):
+        # Ask for a lean projection and confirm every returned record carries only
+        # the requested keys (or fewer, if a key is absent on a given record).
+        result = await projectworks.execute_action(
+            "list_users", {"page_size": 3, "fields": ["UserID", "Email"]}, live_context
+        )
+        users = ok_data(result)["users"]
+        if not users:
+            pytest.skip("No users in account to test projection with")
+        for user in users:
+            assert set(user).issubset({"UserID", "Email"})
+
+    async def test_default_page_size_bounds_results(self, live_context):
+        # With no page_size the handler applies DEFAULT_PAGE_SIZE (50), so an
+        # unparameterised call cannot dump an unbounded page.
+        result = await projectworks.execute_action("list_users", {}, live_context)
+        assert len(ok_data(result)["users"]) <= 50
+
+
+# ---- Search (free-text convenience, read-only) ----
+
+
+class TestSearchUsers:
+    async def test_search_matches_listed_user(self, live_context):
+        # Derive a real query term from a listed user, then confirm search finds them.
+        listed = ok_data(await projectworks.execute_action("list_users", {"page_size": 5}, live_context))["users"]
+        if not listed:
+            pytest.skip("No users in account to search")
+        target = listed[0]
+        term = target.get("FirstName") or target.get("Name") or target.get("Email")
+        if not term:
+            pytest.skip("Listed user has no name/email field to search on")
+
+        result = await projectworks.execute_action("search_users", {"query": term, "fields": ["UserID"]}, live_context)
+        users = ok_data(result)["users"]
+        assert isinstance(users, list)
+        assert all(set(u).issubset({"UserID"}) for u in users)
+
+    async def test_unmatched_query_returns_empty(self, live_context):
+        result = await projectworks.execute_action("search_users", {"query": "zzz-nonexistent-user-zzz"}, live_context)
+        assert ok_data(result)["users"] == []
+
+
+class TestSearchClients:
+    async def test_search_matches_listed_client(self, live_context):
+        listed = ok_data(await projectworks.execute_action("list_clients", {"page_size": 5}, live_context))["clients"]
+        if not listed:
+            pytest.skip("No clients in account to search")
+        term = listed[0].get("Name")
+        if not term:
+            pytest.skip("Listed client has no Name field to search on")
+
+        result = await projectworks.execute_action("search_clients", {"query": term}, live_context)
+        assert isinstance(ok_data(result)["clients"], list)
+
+
+class TestSearchProjects:
+    async def test_search_matches_listed_project(self, live_context):
+        listed = ok_data(await projectworks.execute_action("list_projects", {"page_size": 5}, live_context))["projects"]
+        if not listed:
+            pytest.skip("No projects in account to search")
+        term = listed[0].get("Name")
+        if not term:
+            pytest.skip("Listed project has no Name field to search on")
+
+        result = await projectworks.execute_action("search_projects", {"query": term}, live_context)
+        assert isinstance(ok_data(result)["projects"], list)
+
+
 # ---- Destructive Tests (Write Operations) ----
 # These create, update, and delete real data on the connected account.
 # Only run deliberately with: pytest -m "integration and destructive"

--- a/projectworks/tests/test_projectworks_integration.py
+++ b/projectworks/tests/test_projectworks_integration.py
@@ -336,11 +336,13 @@ class TestSearchUsers:
         term = target.get("FirstName") or target.get("Name") or target.get("Email")
         if not term:
             pytest.skip("Listed user has no name/email field to search on")
+        target_id = target.get("UserID")
 
         result = await projectworks.execute_action("search_users", {"query": term, "fields": ["UserID"]}, live_context)
         users = ok_data(result)["users"]
         assert isinstance(users, list)
         assert all(set(u).issubset({"UserID"}) for u in users)
+        assert any(u.get("UserID") == target_id for u in users)
 
     async def test_unmatched_query_returns_empty(self, live_context):
         result = await projectworks.execute_action("search_users", {"query": "zzz-nonexistent-user-zzz"}, live_context)
@@ -355,9 +357,12 @@ class TestSearchClients:
         term = listed[0].get("Name")
         if not term:
             pytest.skip("Listed client has no Name field to search on")
+        target_id = listed[0].get("ClientID")
 
         result = await projectworks.execute_action("search_clients", {"query": term}, live_context)
-        assert isinstance(ok_data(result)["clients"], list)
+        clients = ok_data(result)["clients"]
+        assert isinstance(clients, list)
+        assert any(c.get("ClientID") == target_id for c in clients)
 
 
 class TestSearchProjects:
@@ -368,9 +373,12 @@ class TestSearchProjects:
         term = listed[0].get("Name")
         if not term:
             pytest.skip("Listed project has no Name field to search on")
+        target_id = listed[0].get("ProjectID")
 
         result = await projectworks.execute_action("search_projects", {"query": term}, live_context)
-        assert isinstance(ok_data(result)["projects"], list)
+        projects = ok_data(result)["projects"]
+        assert isinstance(projects, list)
+        assert any(p.get("ProjectID") == target_id for p in projects)
 
 
 # ---- Destructive Tests (Write Operations) ----

--- a/projectworks/tests/test_projectworks_integration.py
+++ b/projectworks/tests/test_projectworks_integration.py
@@ -1,7 +1,7 @@
 """
-End-to-end integration tests for the ProjectWorks integration.
+End-to-end integration tests for the Projectworks integration.
 
-These tests call the real ProjectWorks API and require valid API-account
+These tests call the real Projectworks API and require valid API-account
 credentials set in the environment (via .env or export):
 
     PROJECTWORKS_CONSUMER_KEY
@@ -314,7 +314,7 @@ class TestTimesheetLifecycle:
     """
 
     async def test_full_lifecycle(self, live_context):
-        # ProjectWorks only accepts time from a user assigned to the task's timecode.
+        # Projectworks only accepts time from a user assigned to the task's timecode.
         # A task's Users array does not reliably reflect that assignment, so derive a
         # known-valid (user, task) pair from an existing timesheet entry instead.
         existing = ok_data(await projectworks.execute_action("list_timesheets", {"page_size": 1}, live_context))[

--- a/projectworks/tests/test_projectworks_unit.py
+++ b/projectworks/tests/test_projectworks_unit.py
@@ -13,6 +13,7 @@ from projectworks.projectworks import (
     _get_headers,
     _matches_query,
     _project,
+    _search,
     BASE_URL,
     DEFAULT_PAGE_SIZE,
     DEFAULT_SEARCH_SCAN,
@@ -1297,6 +1298,25 @@ class TestSearchUsers:
         mock_context.fetch.return_value = ok([])
         result = await projectworks.execute_action("search_users", {}, mock_context)
         assert result.type == ResultType.VALIDATION_ERROR
+        mock_context.fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_query_is_a_validation_error(self, mock_context):
+        # The schema's minLength/pattern reject a whitespace-only query before
+        # the handler runs, so it never falls through to matching every record.
+        mock_context.fetch.return_value = ok([{"UserID": 1, "Name": "Jane"}])
+        result = await projectworks.execute_action("search_users", {"query": "   "}, mock_context)
+        assert result.type == ResultType.VALIDATION_ERROR
+        mock_context.fetch.assert_not_called()
+
+
+class TestSearchBlankQueryGuard:
+    @pytest.mark.asyncio
+    async def test_search_rejects_blank_query_at_runtime(self, mock_context):
+        # Defensive runtime guard in `_search` itself, in case a caller
+        # bypasses schema validation (e.g. direct SDK use).
+        with pytest.raises(ValueError, match="query must not be blank"):
+            await _search(mock_context, "Users", "users", "   ", ["Name"])
         mock_context.fetch.assert_not_called()
 
 

--- a/projectworks/tests/test_projectworks_unit.py
+++ b/projectworks/tests/test_projectworks_unit.py
@@ -6,7 +6,17 @@ import pytest
 from autohive_integrations_sdk import FetchResponse
 from autohive_integrations_sdk.integration import ResultType
 
-from projectworks.projectworks import projectworks, _as_list, _clean, _get_headers, BASE_URL
+from projectworks.projectworks import (
+    projectworks,
+    _as_list,
+    _clean,
+    _get_headers,
+    _matches_query,
+    _project,
+    BASE_URL,
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_SEARCH_SCAN,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -1162,3 +1172,147 @@ class TestSetCustomFields:
             "set_custom_fields", {"entity_type": "user", "entity_id": 1, "fields": []}, mock_context
         )
         assert result.type == ResultType.ACTION_ERROR
+
+
+# =============================================================================
+# CONTEXT-WINDOW HELPERS: default page size + field projection
+# =============================================================================
+
+
+class TestProject:
+    def test_none_fields_passes_records_through(self):
+        records = [{"UserID": 1, "Name": "Jane"}]
+        assert _project(records, None) == records
+
+    def test_empty_fields_passes_records_through(self):
+        records = [{"UserID": 1, "Name": "Jane"}]
+        assert _project(records, []) == records
+
+    def test_trims_to_requested_fields(self):
+        records = [{"UserID": 1, "Name": "Jane", "Email": "j@x.com"}]
+        assert _project(records, ["UserID", "Name"]) == [{"UserID": 1, "Name": "Jane"}]
+
+    def test_unknown_field_simply_absent(self):
+        records = [{"UserID": 1}]
+        assert _project(records, ["UserID", "Missing"]) == [{"UserID": 1}]
+
+    def test_non_dict_records_passthrough(self):
+        assert _project([1, "x"], ["UserID"]) == [1, "x"]
+
+
+class TestListPageSizeAndProjection:
+    @pytest.mark.asyncio
+    async def test_default_page_size_applied_when_unset(self, mock_context):
+        mock_context.fetch.return_value = ok([])
+        await projectworks.execute_action("list_users", {}, mock_context)
+        assert mock_context.fetch.call_args.kwargs["params"]["pageSize"] == DEFAULT_PAGE_SIZE
+
+    @pytest.mark.asyncio
+    async def test_explicit_page_size_overrides_default(self, mock_context):
+        mock_context.fetch.return_value = ok([])
+        await projectworks.execute_action("list_users", {"page_size": 5}, mock_context)
+        assert mock_context.fetch.call_args.kwargs["params"]["pageSize"] == 5
+
+    @pytest.mark.asyncio
+    async def test_fields_projects_list_records(self, mock_context):
+        mock_context.fetch.return_value = ok(
+            [{"UserID": 1, "FirstName": "Jane", "Email": "j@x.com", "Department": "Eng"}]
+        )
+        result = await projectworks.execute_action("list_users", {"fields": ["UserID", "Email"]}, mock_context)
+        assert result.result.data["users"] == [{"UserID": 1, "Email": "j@x.com"}]
+
+
+# =============================================================================
+# SEARCH (free-text convenience over list endpoints)
+# =============================================================================
+
+
+class TestMatchesQuery:
+    def test_case_insensitive_substring(self):
+        assert _matches_query({"Name": "Acme Corp"}, "acme", ["Name"])
+
+    def test_no_match(self):
+        assert not _matches_query({"Name": "Acme Corp"}, "globex", ["Name"])
+
+    def test_ignores_non_string_and_missing_fields(self):
+        assert not _matches_query({"Name": 123, "Other": None}, "1", ["Name", "Other", "Absent"])
+
+    def test_composed_fields_match_multi_word_query(self):
+        # "jane doe" matches neither FirstName nor LastName alone, but does match
+        # the two joined together.
+        record = {"FirstName": "Jane", "LastName": "Doe"}
+        assert not _matches_query(record, "jane doe", ["FirstName", "LastName"])
+        assert _matches_query(record, "jane doe", ["FirstName", "LastName"], [["FirstName", "LastName"]])
+
+
+class TestSearchUsers:
+    @pytest.mark.asyncio
+    async def test_filters_client_side_by_name_or_email(self, mock_context):
+        mock_context.fetch.return_value = ok(
+            [
+                {"UserID": 1, "FirstName": "Jane", "LastName": "Doe", "Email": "jane@x.com"},
+                {"UserID": 2, "FirstName": "John", "LastName": "Smith", "Email": "john@x.com"},
+                {"UserID": 3, "FirstName": "Janet", "LastName": "Roe", "Email": "janet@x.com"},
+            ]
+        )
+        result = await projectworks.execute_action("search_users", {"query": "jan"}, mock_context)
+        ids = [u["UserID"] for u in result.result.data["users"]]
+        assert ids == [1, 3]
+
+    @pytest.mark.asyncio
+    async def test_matches_full_name_across_first_and_last(self, mock_context):
+        mock_context.fetch.return_value = ok(
+            [
+                {"UserID": 1, "FirstName": "Jane", "LastName": "Doe", "Email": "jane@x.com"},
+                {"UserID": 2, "FirstName": "John", "LastName": "Smith", "Email": "john@x.com"},
+            ]
+        )
+        result = await projectworks.execute_action("search_users", {"query": "Jane Doe"}, mock_context)
+        assert [u["UserID"] for u in result.result.data["users"]] == [1]
+
+    @pytest.mark.asyncio
+    async def test_default_scan_page_size(self, mock_context):
+        mock_context.fetch.return_value = ok([])
+        await projectworks.execute_action("search_users", {"query": "x"}, mock_context)
+        assert mock_context.fetch.call_args.kwargs["params"]["pageSize"] == DEFAULT_SEARCH_SCAN
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_results(self, mock_context):
+        mock_context.fetch.return_value = ok([{"UserID": i, "Name": "match"} for i in range(20)])
+        result = await projectworks.execute_action("search_users", {"query": "match", "limit": 3}, mock_context)
+        assert len(result.result.data["users"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_fields_projection_applied(self, mock_context):
+        mock_context.fetch.return_value = ok([{"UserID": 1, "Name": "Acme", "Email": "a@x.com"}])
+        result = await projectworks.execute_action(
+            "search_users", {"query": "acme", "fields": ["UserID"]}, mock_context
+        )
+        assert result.result.data["users"] == [{"UserID": 1}]
+
+    @pytest.mark.asyncio
+    async def test_missing_query_is_validation_error(self, mock_context):
+        # `query` is required in the schema, so the framework rejects the call
+        # before the handler runs and never hits the API.
+        mock_context.fetch.return_value = ok([])
+        result = await projectworks.execute_action("search_users", {}, mock_context)
+        assert result.type == ResultType.VALIDATION_ERROR
+        mock_context.fetch.assert_not_called()
+
+
+class TestSearchClientsAndProjects:
+    @pytest.mark.asyncio
+    async def test_search_clients_matches_name(self, mock_context):
+        mock_context.fetch.return_value = ok([{"ClientID": 1, "Name": "Acme"}, {"ClientID": 2, "Name": "Globex"}])
+        result = await projectworks.execute_action("search_clients", {"query": "glob"}, mock_context)
+        assert [c["ClientID"] for c in result.result.data["clients"]] == [2]
+        assert mock_context.fetch.call_args.args[0] == f"{BASE_URL}/Clients"
+
+    @pytest.mark.asyncio
+    async def test_search_projects_matches_number(self, mock_context):
+        mock_context.fetch.return_value = ok(
+            [{"ProjectID": 1, "Name": "Site", "ProjectNumber": "P-100"}, {"ProjectID": 2, "Name": "App"}]
+        )
+        result = await projectworks.execute_action("search_projects", {"query": "p-100"}, mock_context)
+        assert [p["ProjectID"] for p in result.result.data["projects"]] == [1]
+        assert mock_context.fetch.call_args.args[0] == f"{BASE_URL}/Projects"

--- a/projectworks/tests/test_projectworks_unit.py
+++ b/projectworks/tests/test_projectworks_unit.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ProjectWorks integration using a mocked fetch."""
+"""Unit tests for the Projectworks integration using a mocked fetch."""
 
 import base64
 


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Renames the integration from "ProjectWorks" to "Projectworks" (correct brand casing), adds free-text search actions for users, clients, and projects, introduces optional field projection on all `list_*` actions, and applies a conservative default page size to prevent unbounded list responses.
- **Approach**: A `_project()` helper trims list records to caller-specified fields. A `_search()` helper scans one page client-side and matches a query substring against relevant fields (with composed-field support for full-name matching). `DEFAULT_PAGE_SIZE` (50) is applied when no `page_size` is provided; `DEFAULT_SEARCH_SCAN` (200) is used for search scans. All changes are covered by new unit and integration tests.

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**
:point_right: Renamed all references from "ProjectWorks" to "Projectworks" across config, source, README, and tests; bumped version to `1.1.0`
:point_right: Added `search_users`, `search_clients`, and `search_projects` actions — free-text, case-insensitive substring search over a single scanned page with `limit` and `fields` support
:point_right: Added optional `fields` projection to all `list_*` actions and applied `DEFAULT_PAGE_SIZE = 50` so unparameterised calls stay bounded

### Screenshots :camera:
{Image here of before and after - if applicable}

### Test plan :test_tube:
*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*

- Run unit tests: `pytest -m unit` — covers `_project`, `_matches_query`, default page size enforcement, field projection on `list_users`, and all three search actions including limit capping, composed-field matching, and validation errors.
- Run integration tests (requires valid `.env` credentials): `pytest -m integration` — covers `TestListFieldProjection` (projection + default page size bounds) and `TestSearchUsers/Clients/Projects` against the live API.
- Manually verify the renamed display name appears correctly in the Autohive UI when the integration is loaded.

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)