### PR TITLE
docs: add integration engineering charter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,6 @@ Reviewers are expected to hold integration PRs to this charter.
 
 A PR may be sent back even if CI passes when the author has not demonstrated API understanding, intentional scope, safe permissions, meaningful tests, maintainable Python, or adequate self-review.
 
-The goal is not to slow down integration development. The goal is to avoid shipping code we do not understand, cannot maintain, or cannot safely stand behind.
+The goal is not to slow down integration development. The goal is to decrease time to develop and maintenance by avoiding shipping code we do not understand, cannot maintain long term, or cannot safely stand behind.
+
+If you are unsure about anything on the above to help you move forward in the integration, reach out to a peer to get clarity

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Author commitment
+
+Before opening an integration PR, I confirm that:
+
+- I understand the third-party API areas I implemented.
+- I can explain every action, endpoint, permission, dependency, and important helper.
+- I used the documented Autohive SDK process and repository conventions.
+- I reviewed the generated or written code myself.
+- I removed dead code, generic boilerplate, hallucinated behavior, and unnecessary abstractions.
+- I tested the integration with meaningful mocked tests.
+- I included real API integration tests where safe and practical, or documented why not.
+- I ran local validation and fixed issues before requesting review.
+- I documented the integration clearly for users and future maintainers.
+
+If I cannot honestly confirm these points, the PR is not ready.
+
+
+## Review standard
+
+Reviewers are expected to hold integration PRs to this charter.
+
+A PR may be sent back even if CI passes when the author has not demonstrated API understanding, intentional scope, safe permissions, meaningful tests, maintainable Python, or adequate self-review.
+
+The goal is not to slow down integration development. The goal is to avoid shipping code we do not understand, cannot maintain, or cannot safely stand behind.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ Do NOT guess the integration structure or conventions. Read the existing documen
 - **[Integration Structure Reference](https://github.com/autohive-ai/integrations-sdk/blob/master/docs/manual/integration_structure.md)** — directory layout, required files, `config.json` schema
 - **[Patterns](https://github.com/autohive-ai/integrations-sdk/blob/master/docs/manual/patterns.md)** — common patterns and best practices
 - **[Starter Template](https://github.com/autohive-ai/integrations-sdk/tree/master/samples/template)** — copy this as the starting point for any new integration
+- **[Integration Engineering Charter](integration-engineering-charter.md)** — engineering principles, author commitment, and reviewer standard for integration PRs
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — PR process, local validation setup, and CI details for this repo
+- **[Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md)** — author commitment and review standard that must be completed for PRs
 - **[Tooling README](https://github.com/autohive-ai/autohive-integrations-tooling/blob/master/README.md)** — validation scripts and CI pipeline
 - **[Local Development](https://github.com/autohive-ai/autohive-integrations-tooling/blob/master/LOCAL_DEVELOPMENT.md)** — local development workflow and documentation map
 - **[Integration Checklist](https://github.com/autohive-ai/autohive-integrations-tooling/blob/master/INTEGRATION_CHECKLIST.md)** — manual review checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,9 +291,11 @@ See the SDK's [Integration Structure Reference](https://github.com/autohive-ai/i
 
 1. **Create a branch** following conventional naming (`feat/my-integration`)
 2. **Add your integration** following the structure in the SDK docs
-3. **Run validation locally** before pushing
-4. **Update the main README.md** — add your integration to the list
-5. **Use a conventional commit PR title**
-6. **One integration per PR** — keep PRs focused
+3. **Read and follow the [Integration Engineering Charter](integration-engineering-charter.md)**
+4. **Run validation locally** before pushing
+5. **Update the main README.md** — add your integration to the list
+6. **Complete the [pull request template](.github/PULL_REQUEST_TEMPLATE.md)**
+7. **Use a conventional commit PR title**
+8. **One integration per PR** — keep PRs focused
 
 All CI checks must pass before merge.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository hosts Autohive integrations made and maintained by the Autohive 
 ## Getting Started
 
 - 📖 **[Building Your First Integration](https://github.com/autohive-ai/integrations-sdk/blob/master/docs/manual/building_your_first_integration.md)** — tutorial, API reference, and patterns (SDK repo)
+- 🧭 **[Integration Engineering Charter](integration-engineering-charter.md)** — principles for API understanding, safe permissions, testing, documentation, and review readiness
 - ✅ **[Validation & CI](https://github.com/autohive-ai/autohive-integrations-tooling)** — tooling that checks every PR (tooling repo)
 - 🤝 **[Contributing](CONTRIBUTING.md)** — PR process, local setup, and CI details for this repo
 

--- a/integration-engineering-charter.md
+++ b/integration-engineering-charter.md
@@ -5,7 +5,7 @@
 
 Autohive integrations connect our users' workflows to third-party systems they rely on. A poor integration does not only produce bad code; it can break customer workflows, mishandle data, request excessive permissions or create long-term maintenance burden for the team.
 
-AI-assisted development is welcome, but authorship cannot be delegated to AI. The person opening the PR is responsible for understanding the provider API, the Autohive SDK, the implementation choices, the tests, the security implications, and the user experience.
+AI-assisted development is a requirement, but authorship cannot be delegated to AI. The person opening the PR is responsible for understanding the provider API, the Autohive SDK, the implementation choices, the tests, the security implications, and the user experience.
 
 Passing CI is the minimum technical gate. It is not proof that an integration is well-designed, well-understood, safe, or maintainable.
 

--- a/integration-engineering-charter.md
+++ b/integration-engineering-charter.md
@@ -3,7 +3,7 @@
 
 ## Preamble
 
-Autohive integrations connect our users' workflows to third-party systems they rely on. A poor integration does not only produce bad code; it can break customer workflows, mishandle data, request excessive permissions or create long-term maintenance burden for the team.
+Autohive integrations connect our users' workflows to third-party systems they rely on. A poor integration does not only produce bad code; it can break customer workflows, mishandle data, requesting permissions/scopes not used in the integration or create long-term maintenance burden for the team.
 
 AI-assisted development is a requirement, but authorship cannot be delegated to AI. The person opening the PR is responsible for understanding the provider API, the Autohive SDK, the implementation choices, the tests, the security implications, and the user experience.
 

--- a/integration-engineering-charter.md
+++ b/integration-engineering-charter.md
@@ -42,7 +42,7 @@ We avoid unnecessary abstractions, complicated cleverness, dead code, broad exce
 
 Scopes, permissions, credentials, files, and user data require care. Integrations should request the correct access needed for the implemented actions.
 
-Secrets must never be committed. Test data must be safe. Provider responses should not leak credentials or sensitive data through logs, errors, or outputs.
+Secrets must never be committed in this repo. Test data must be safe. Provider responses should not leak credentials or sensitive data through logs, errors, or outputs.
 
 ### 6. We verify behavior, not just syntax
 

--- a/integration-engineering-charter.md
+++ b/integration-engineering-charter.md
@@ -40,7 +40,7 @@ We avoid unnecessary abstractions, complicated cleverness, dead code, broad exce
 
 ### 5. We treat auth and permissions as security decisions
 
-Scopes, permissions, credentials, files, and user data require care. Integrations should request the minimum access needed for the implemented actions.
+Scopes, permissions, credentials, files, and user data require care. Integrations should request the correct access needed for the implemented actions.
 
 Secrets must never be committed. Test data must be safe. Provider responses should not leak credentials or sensitive data through logs, errors, or outputs.
 

--- a/integration-engineering-charter.md
+++ b/integration-engineering-charter.md
@@ -58,6 +58,6 @@ Documentation should describe the integration as shipped, not as imagined future
 
 ### 8. We self-review before asking others to review
 
-Opening a PR is a request for another person's time and judgment. Authors should review their own diff first, remove low-quality artifacts, run local validation, check tests, and ensure the PR is focused.
+Opening a PR is a request for another person's time and judgment. Authors should review their own diff first, run the review skill, remove low-quality artifacts, run local validation, check tests, and ensure the PR is focused.
 
 Reviewers should not be the first people to discover obvious AI boilerplate, unused code, missing tests, hallucinated endpoints, excessive scopes, or unverified behavior.

--- a/integration-engineering-charter.md
+++ b/integration-engineering-charter.md
@@ -1,0 +1,63 @@
+# Integration Engineering Charter
+
+
+## Preamble
+
+Autohive integrations connect our users' workflows to third-party systems they rely on. A poor integration does not only produce bad code; it can break customer workflows, mishandle data, request excessive permissions or create long-term maintenance burden for the team.
+
+AI-assisted development is welcome, but authorship cannot be delegated to AI. The person opening the PR is responsible for understanding the provider API, the Autohive SDK, the implementation choices, the tests, the security implications, and the user experience.
+
+Passing CI is the minimum technical gate. It is not proof that an integration is well-designed, well-understood, safe, or maintainable.
+
+
+## Our principles
+
+### 1. We understand the API before we wrap it
+
+An integration author must read the provider's official API documentation and understand the endpoints, authentication model, scopes, pagination, rate limits, errors, and provider-specific behavior they are implementing.
+
+We do not build integrations by guessing from examples, copying generated code, or trusting AI output without verification.
+
+### 2. We build for user workflows, not endpoint coverage
+
+A good integration is not a mechanical mirror of a 3rd-party API. It exposes actions that make sense for real Autohive workflows.
+
+We intentionally choose what to include, what to leave out, and how to present actions so users can succeed without needing to understand the provider API.
+
+### 3. We own AI-generated code
+
+AI can help draft, explore, refactor, and test. It cannot fully own correctness.
+
+If AI generated part of an integration, the author is responsible for reviewing it, simplifying it, removing hallucinated behavior, checking it against documentation, and making sure they can explain it.
+
+Code that the author cannot explain is not ready for review.
+
+### 4. We write maintainable Python
+
+Integrations should be idiomatic, readable Python. The code should use simple data structures, clear control flow, accurate type hints where useful, and appropriate async patterns.
+
+We avoid unnecessary abstractions, complicated cleverness, dead code, broad exception swallowing, hidden side effects, and dependencies that are not clearly justified.
+
+### 5. We treat auth and permissions as security decisions
+
+Scopes, permissions, credentials, files, and user data require care. Integrations should request the minimum access needed for the implemented actions.
+
+Secrets must never be committed. Test data must be safe. Provider responses should not leak credentials or sensitive data through logs, errors, or outputs.
+
+### 6. We verify behavior, not just syntax
+
+Tests should prove that actions behave correctly, handle errors, and match real provider response shapes.
+
+Mocked tests are necessary, but they are not enough for integrations that depend on third-party APIs. Where credentials and safe test data are available, integration tests should exercise real API behavior. If real API tests are not included, the PR should explain why and describe how the real API behavior was verified.
+
+### 7. We document what future maintainers need to know
+
+A good README explains what the integration does, how authentication works, where the official API docs are, what actions exist, and any important provider limitations.
+
+Documentation should describe the integration as shipped, not as imagined future work.
+
+### 8. We self-review before asking others to review
+
+Opening a PR is a request for another person's time and judgment. Authors should review their own diff first, remove low-quality artifacts, run local validation, check tests, and ensure the PR is focused.
+
+Reviewers should not be the first people to discover obvious AI boilerplate, unused code, missing tests, hallucinated endpoints, excessive scopes, or unverified behavior.


### PR DESCRIPTION
## Summary
- add the Integration Engineering Charter as a repository markdown document
- add the author commitment and review standard to the pull request template
- reference the charter/template from README, CONTRIBUTING, and AGENTS guidance

## Testing
- `git diff --check`

Closes #399