### PR TITLE
fix: read credentials from wrapped auth envelope in flat-reading integrations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,8 +4,6 @@ Root conftest.py — shared fixtures for all integration test suites.
 Provides:
 - mock_context: A pre-configured MagicMock ExecutionContext with AsyncMock fetch
 - make_context: Factory for building mock contexts with custom auth shapes
-- make_custom_auth_context: Factory for mock contexts with the wrapped Custom
-  auth envelope (auth_type + credentials) that production actually sends
 - env_credentials: Helper to load credentials from env/.env files
 
 Also patches Integration.load() so it resolves config.json from the calling
@@ -113,27 +111,6 @@ def make_context():
         ctx.fetch = AsyncMock(name="fetch")
         ctx.auth = auth or {}
         return ctx
-
-    return _factory
-
-
-@pytest.fixture
-def make_custom_auth_context(make_context):
-    """Factory fixture — build a mock context with the wrapped Custom auth envelope.
-
-    This builds the platform-shaped auth envelope that production sends to
-    integrations; custom-auth integration tests should use this instead of
-    passing flat auth dicts.
-
-    Example::
-
-        def test_foo(make_custom_auth_context):
-            ctx = make_custom_auth_context({"api_key": "k"})
-            ctx.fetch.return_value = {...}
-    """
-
-    def _factory(credentials: Dict[str, str]) -> MagicMock:
-        return make_context(auth={"auth_type": "Custom", "credentials": credentials})
 
     return _factory
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,8 @@ Root conftest.py — shared fixtures for all integration test suites.
 Provides:
 - mock_context: A pre-configured MagicMock ExecutionContext with AsyncMock fetch
 - make_context: Factory for building mock contexts with custom auth shapes
+- make_custom_auth_context: Factory for mock contexts with the wrapped Custom
+  auth envelope (auth_type + credentials) that production actually sends
 - env_credentials: Helper to load credentials from env/.env files
 
 Also patches Integration.load() so it resolves config.json from the calling
@@ -97,7 +99,9 @@ def make_context():
     Example::
 
         def test_foo(make_context):
-            ctx = make_context(auth={"credentials": {"api_key": "k"}})
+            ctx = make_context(
+                auth={"auth_type": "Custom", "credentials": {"api_key": "k"}}
+            )
             ctx.fetch.return_value = {...}
     """
 
@@ -109,6 +113,27 @@ def make_context():
         ctx.fetch = AsyncMock(name="fetch")
         ctx.auth = auth or {}
         return ctx
+
+    return _factory
+
+
+@pytest.fixture
+def make_custom_auth_context(make_context):
+    """Factory fixture — build a mock context with the wrapped Custom auth envelope.
+
+    This builds the platform-shaped auth envelope that production sends to
+    integrations; custom-auth integration tests should use this instead of
+    passing flat auth dicts.
+
+    Example::
+
+        def test_foo(make_custom_auth_context):
+            ctx = make_custom_auth_context({"api_key": "k"})
+            ctx.fetch.return_value = {...}
+    """
+
+    def _factory(credentials: Dict[str, str]) -> MagicMock:
+        return make_context(auth={"auth_type": "Custom", "credentials": credentials})
 
     return _factory
 

--- a/freshdesk/config.json
+++ b/freshdesk/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Freshdesk",
     "display_name": "Freshdesk",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Freshdesk integration for managing tickets, contacts, companies, and customer support operations",
     "entry_point": "freshdesk.py",
     "auth": {

--- a/freshdesk/freshdesk.py
+++ b/freshdesk/freshdesk.py
@@ -12,6 +12,11 @@ FRESHDESK_API_VERSION = "v2"
 # ---- Helper Functions ----
 
 
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
+
+
 def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     """
     Build authentication headers for Freshdesk API requests.
@@ -23,7 +28,7 @@ def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     Returns:
         Dictionary with Authorization and Content-Type headers
     """
-    api_key = context.auth.get("api_key", "")
+    api_key = _credentials(context).get("api_key", "")
 
     # Freshdesk requires Basic Auth with format: api_key:X
     auth_string = f"{api_key}:X"
@@ -43,7 +48,7 @@ def get_base_url(context: ExecutionContext) -> str:
     Returns:
         Base URL string (e.g., https://yourcompany.freshdesk.com/api/v2)
     """
-    domain = context.auth.get("domain", "")
+    domain = _credentials(context).get("domain", "")
 
     return f"https://{domain}.freshdesk.com/api/{FRESHDESK_API_VERSION}"
 

--- a/freshdesk/freshdesk.py
+++ b/freshdesk/freshdesk.py
@@ -12,11 +12,6 @@ FRESHDESK_API_VERSION = "v2"
 # ---- Helper Functions ----
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     """
     Build authentication headers for Freshdesk API requests.
@@ -28,7 +23,7 @@ def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     Returns:
         Dictionary with Authorization and Content-Type headers
     """
-    api_key = _credentials(context).get("api_key", "")
+    api_key = context.auth["credentials"].get("api_key", "")
 
     # Freshdesk requires Basic Auth with format: api_key:X
     auth_string = f"{api_key}:X"
@@ -48,7 +43,7 @@ def get_base_url(context: ExecutionContext) -> str:
     Returns:
         Base URL string (e.g., https://yourcompany.freshdesk.com/api/v2)
     """
-    domain = _credentials(context).get("domain", "")
+    domain = context.auth["credentials"].get("domain", "")
 
     return f"https://{domain}.freshdesk.com/api/{FRESHDESK_API_VERSION}"
 

--- a/freshdesk/tests/conftest.py
+++ b/freshdesk/tests/conftest.py
@@ -10,8 +10,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.fixture
 def mock_context():
-    """Mock execution context with the custom auth shape Freshdesk expects."""
+    """Mock execution context with the wrapped Custom auth envelope Freshdesk expects.
+
+    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
+    not make the real ``credentials`` property available; set it explicitly to
+    the unwrapped credentials dict.
+    """
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    credentials = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": credentials}
     return ctx

--- a/freshdesk/tests/conftest.py
+++ b/freshdesk/tests/conftest.py
@@ -10,12 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.fixture
 def mock_context():
-    """Mock execution context with the wrapped Custom auth envelope Freshdesk expects.
-
-    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
-    not make the real ``credentials`` property available; set it explicitly to
-    the unwrapped credentials dict.
-    """
+    """Mock execution context with the wrapped Custom auth envelope Freshdesk expects."""
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     credentials = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105

--- a/freshdesk/tests/test_freshdesk_integration.py
+++ b/freshdesk/tests/test_freshdesk_integration.py
@@ -36,7 +36,8 @@ def live_context(env_credentials, make_context):
                     data = await resp.text()
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"api_key": api_key, "domain": domain})
+    credentials = {"api_key": api_key, "domain": domain}
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": credentials})
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/freshdesk/tests/test_freshdesk_unit.py
+++ b/freshdesk/tests/test_freshdesk_unit.py
@@ -28,9 +28,16 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def mock_context():
+    """Mock execution context with the wrapped Custom auth envelope.
+
+    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
+    not make the real ``credentials`` property available; set it explicitly to
+    the unwrapped credentials dict.
+    """
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    credentials = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": credentials}
     return ctx
 
 
@@ -102,24 +109,6 @@ class TestGetBaseUrl:
     def test_freshdesk_subdomain_format(self, mock_context):
         url = get_base_url(mock_context)
         assert url == "https://testcompany.freshdesk.com/api/v2"
-
-
-class TestWrappedAuthEnvelope:
-    @pytest.mark.asyncio
-    async def test_list_companies_succeeds_with_wrapped_credentials(self, mock_context):
-        mock_context.auth = {
-            "auth_type": "Custom",
-            "credentials": {"api_key": "test_api_key", "domain": "testcompany"},
-        }
-        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_COMPANY])
-
-        result = await freshdesk.execute_action("list_companies", {}, mock_context)
-
-        assert result.type == ResultType.ACTION
-        assert result.result.data["companies"] == [SAMPLE_COMPANY]
-
-        call_args = mock_context.fetch.call_args
-        assert "testcompany.freshdesk.com/api/v2/companies" in call_args.args[0]
 
 
 # ---- Company Tests ----

--- a/freshdesk/tests/test_freshdesk_unit.py
+++ b/freshdesk/tests/test_freshdesk_unit.py
@@ -104,6 +104,24 @@ class TestGetBaseUrl:
         assert url == "https://testcompany.freshdesk.com/api/v2"
 
 
+class TestWrappedAuthEnvelope:
+    @pytest.mark.asyncio
+    async def test_list_companies_succeeds_with_wrapped_credentials(self, mock_context):
+        mock_context.auth = {
+            "auth_type": "Custom",
+            "credentials": {"api_key": "test_api_key", "domain": "testcompany"},
+        }
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_COMPANY])
+
+        result = await freshdesk.execute_action("list_companies", {}, mock_context)
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data["companies"] == [SAMPLE_COMPANY]
+
+        call_args = mock_context.fetch.call_args
+        assert "testcompany.freshdesk.com/api/v2/companies" in call_args.args[0]
+
+
 # ---- Company Tests ----
 
 

--- a/ghost/config.json
+++ b/ghost/config.json
@@ -1,7 +1,7 @@
 {
     "name": "ghost",
     "display_name": "Ghost",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Ghost CMS integration for reading and managing posts, pages, members, and newsletters",
     "entry_point": "ghost.py",
     "auth": {

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -15,8 +15,13 @@ from autohive_integrations_sdk import (
 ghost = Integration.load()
 
 
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
+
+
 def _get_base_url(context: ExecutionContext) -> str:
-    url = context.auth.get("api_url", "")
+    url = _credentials(context).get("api_url", "")
     if not url:
         raise ValueError("api_url is required in auth")
     return url.rstrip("/")
@@ -24,7 +29,7 @@ def _get_base_url(context: ExecutionContext) -> str:
 
 def _content_headers(context: ExecutionContext) -> tuple:
     """Returns (base_url, params_with_key)."""
-    content_key = context.auth.get("content_api_key", "")
+    content_key = _credentials(context).get("content_api_key", "")
     if not content_key:
         raise ValueError("content_api_key is required in auth")
     base = _get_base_url(context)
@@ -32,7 +37,7 @@ def _content_headers(context: ExecutionContext) -> tuple:
 
 
 def _make_admin_jwt(context: ExecutionContext) -> str:
-    admin_key = context.auth.get("admin_api_key", "")
+    admin_key = _credentials(context).get("admin_api_key", "")
     if not admin_key:
         raise ValueError("admin_api_key is required in auth")
     if ":" not in admin_key:

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -15,13 +15,8 @@ from autohive_integrations_sdk import (
 ghost = Integration.load()
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def _get_base_url(context: ExecutionContext) -> str:
-    url = _credentials(context).get("api_url", "")
+    url = context.auth["credentials"].get("api_url", "")
     if not url:
         raise ValueError("api_url is required in auth")
     return url.rstrip("/")
@@ -29,7 +24,7 @@ def _get_base_url(context: ExecutionContext) -> str:
 
 def _content_headers(context: ExecutionContext) -> tuple:
     """Returns (base_url, params_with_key)."""
-    content_key = _credentials(context).get("content_api_key", "")
+    content_key = context.auth["credentials"].get("content_api_key", "")
     if not content_key:
         raise ValueError("content_api_key is required in auth")
     base = _get_base_url(context)
@@ -37,7 +32,7 @@ def _content_headers(context: ExecutionContext) -> tuple:
 
 
 def _make_admin_jwt(context: ExecutionContext) -> str:
-    admin_key = _credentials(context).get("admin_api_key", "")
+    admin_key = context.auth["credentials"].get("admin_api_key", "")
     if not admin_key:
         raise ValueError("admin_api_key is required in auth")
     if ":" not in admin_key:

--- a/ghost/tests/conftest.py
+++ b/ghost/tests/conftest.py
@@ -1,14 +1,12 @@
-from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
 @pytest.fixture
-def mock_context():
-    ctx = MagicMock(name="ExecutionContext")
-    ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {
+def mock_context(make_custom_auth_context):
+    credentials = {
         "api_url": "https://demo.ghost.io",
         "content_api_key": "test_content_key",  # nosec B105
         "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",  # nosec B105
     }
+    ctx = make_custom_auth_context(credentials)
     return ctx

--- a/ghost/tests/conftest.py
+++ b/ghost/tests/conftest.py
@@ -1,12 +1,19 @@
 import pytest
 
+# 32-byte hex secret keeps PyJWT's HS256 key-length warning quiet.
+_ADMIN_API_KEY = "testid00000000000000000a:" + "aabbccddeeff0011" * 4  # nosec B105
+
 
 @pytest.fixture
-def mock_context(make_custom_auth_context):
-    credentials = {
-        "api_url": "https://demo.ghost.io",
-        "content_api_key": "test_content_key",  # nosec B105
-        "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",  # nosec B105
-    }
-    ctx = make_custom_auth_context(credentials)
-    return ctx
+def mock_context(make_context):
+    """Mock execution context with the wrapped Custom auth envelope Ghost expects."""
+    return make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {
+                "api_url": "https://demo.ghost.io",
+                "content_api_key": "test_content_key",  # nosec B105
+                "admin_api_key": _ADMIN_API_KEY,
+            },
+        }
+    )

--- a/ghost/tests/conftest.py
+++ b/ghost/tests/conftest.py
@@ -1,19 +1,20 @@
+from unittest.mock import AsyncMock, MagicMock
 import pytest
 
-# 32-byte hex secret keeps PyJWT's HS256 key-length warning quiet.
+# 32-byte hex secret keeps the line length and PyJWT's HS256 key-length warning in check.
 _ADMIN_API_KEY = "testid00000000000000000a:" + "aabbccddeeff0011" * 4  # nosec B105
 
 
 @pytest.fixture
-def mock_context(make_context):
-    """Mock execution context with the wrapped Custom auth envelope Ghost expects."""
-    return make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {
-                "api_url": "https://demo.ghost.io",
-                "content_api_key": "test_content_key",  # nosec B105
-                "admin_api_key": _ADMIN_API_KEY,
-            },
-        }
-    )
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "api_url": "https://demo.ghost.io",
+            "content_api_key": "test_content_key",  # nosec B105
+            "admin_api_key": _ADMIN_API_KEY,
+        },
+    }
+    return ctx

--- a/ghost/tests/test_ghost_integration.py
+++ b/ghost/tests/test_ghost_integration.py
@@ -39,9 +39,12 @@ def live_context(make_context):
 
     ctx = make_context(
         auth={
-            "api_url": GHOST_API_URL,
-            "content_api_key": GHOST_CONTENT_API_KEY,
-            "admin_api_key": GHOST_ADMIN_API_KEY,
+            "auth_type": "Custom",
+            "credentials": {
+                "api_url": GHOST_API_URL,
+                "content_api_key": GHOST_CONTENT_API_KEY,
+                "admin_api_key": GHOST_ADMIN_API_KEY,
+            },
         }
     )
     ctx.fetch.side_effect = real_fetch

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -204,16 +204,24 @@ async def test_send_newsletter(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_missing_content_api_key(make_custom_auth_context):
-    credentials = {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"}
-    mock_context = make_custom_auth_context(credentials)
+async def test_missing_content_api_key(make_context):
+    mock_context = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"},
+        }
+    )
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 
 @pytest.mark.asyncio
-async def test_missing_api_url(make_custom_auth_context):
-    credentials = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
-    mock_context = make_custom_auth_context(credentials)
+async def test_missing_api_url(make_context):
+    mock_context = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"content_api_key": "key", "admin_api_key": "id:aabbcc"},
+        }
+    )
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -215,3 +215,21 @@ async def test_missing_api_url(mock_context):
     mock_context.auth = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
+
+
+@pytest.mark.asyncio
+async def test_get_posts_with_wrapped_auth_envelope(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "api_url": "https://demo.ghost.io",
+            "content_api_key": "test_content_key",
+            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+        },
+    }
+    mock_context.fetch = AsyncMock(return_value=_fetch_result({"posts": [{"id": "1", "title": "Hello"}], "meta": {}}))
+    result = await ghost.execute_action("get_posts", {}, mock_context)
+    assert result.type == ResultType.ACTION
+    assert len(result.result.data["posts"]) == 1
+    params = mock_context.fetch.call_args[1]["params"]
+    assert params["key"] == "test_content_key"

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -204,24 +204,20 @@ async def test_send_newsletter(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_missing_content_api_key(make_context):
-    mock_context = make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"},
-        }
-    )
+async def test_missing_content_api_key(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"},
+    }
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 
 @pytest.mark.asyncio
-async def test_missing_api_url(make_context):
-    mock_context = make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {"content_api_key": "key", "admin_api_key": "id:aabbcc"},
-        }
-    )
+async def test_missing_api_url(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {"content_api_key": "key", "admin_api_key": "id:aabbcc"},
+    }
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -204,32 +204,16 @@ async def test_send_newsletter(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_missing_content_api_key(mock_context):
-    mock_context.auth = {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"}
+async def test_missing_content_api_key(make_custom_auth_context):
+    credentials = {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"}
+    mock_context = make_custom_auth_context(credentials)
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 
 @pytest.mark.asyncio
-async def test_missing_api_url(mock_context):
-    mock_context.auth = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
+async def test_missing_api_url(make_custom_auth_context):
+    credentials = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
+    mock_context = make_custom_auth_context(credentials)
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
-
-
-@pytest.mark.asyncio
-async def test_get_posts_with_wrapped_auth_envelope(mock_context):
-    mock_context.auth = {
-        "auth_type": "Custom",
-        "credentials": {
-            "api_url": "https://demo.ghost.io",
-            "content_api_key": "test_content_key",
-            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899",
-        },
-    }
-    mock_context.fetch = AsyncMock(return_value=_fetch_result({"posts": [{"id": "1", "title": "Hello"}], "meta": {}}))
-    result = await ghost.execute_action("get_posts", {}, mock_context)
-    assert result.type == ResultType.ACTION
-    assert len(result.result.data["posts"]) == 1
-    params = mock_context.fetch.call_args[1]["params"]
-    assert params["key"] == "test_content_key"

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -224,7 +224,7 @@ async def test_get_posts_with_wrapped_auth_envelope(mock_context):
         "credentials": {
             "api_url": "https://demo.ghost.io",
             "content_api_key": "test_content_key",
-            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899",
         },
     }
     mock_context.fetch = AsyncMock(return_value=_fetch_result({"posts": [{"id": "1", "title": "Hello"}], "meta": {}}))

--- a/rss-reader-feedparser-ah-fetch/config.json
+++ b/rss-reader-feedparser-ah-fetch/config.json
@@ -1,6 +1,6 @@
 {
     "name": "RSS Reader using Feedseeker and authoive-integration-sdk's fetch",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "An integration for reading RSS feeds using Feedseeker and authoive-integration-sdk's fetch",
     "entry_point": "rss_reader.py",
     "auth": {

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -7,11 +7,6 @@ import feedparser
 rss_reader = Integration.load()
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def build_http_basic_auth_url(url: str, user_name: str, password: str) -> str:
     """
     Build a URL with HTTP basic authentication.
@@ -43,7 +38,7 @@ class GetFeedAction(ActionHandler):
         feed_url = inputs["feed_url"]
         limit = inputs.get("limit", 10)
 
-        creds = _credentials(context)
+        creds = context.auth["credentials"]
         user_name = creds.get("user_name")
         password = creds.get("password")
         api_token = creds.get("api_token")

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -1,10 +1,15 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
 # Create the integration using the config.json
 rss_reader = Integration.load()
+
+
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
 
 
 def build_http_basic_auth_url(url: str, user_name: str, password: str) -> str:
@@ -38,9 +43,10 @@ class GetFeedAction(ActionHandler):
         feed_url = inputs["feed_url"]
         limit = inputs.get("limit", 10)
 
-        user_name = context.auth.get("user_name")
-        password = context.auth.get("password")
-        api_token = context.auth.get("api_token")
+        creds = _credentials(context)
+        user_name = creds.get("user_name")
+        password = creds.get("password")
+        api_token = creds.get("api_token")
 
         # Determine authentication method based on available credentials
         # Variables nned to hold None if keys are missing by using .get() before this block
@@ -76,4 +82,6 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(
+            data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        )

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -62,7 +62,8 @@ class GetFeedAction(ActionHandler):
             # No authentication provided or required
             response = await context.fetch(feed_url)
 
-        # Parse feed
+        # Parse feed; on the pinned SDK 1.x fetch() returns the response body
+        # directly (2.x+ wraps it in FetchResponse.data).
         feed = feedparser.parse(response)
 
         # Check for parsing errors

--- a/rss-reader-feedparser-ah-fetch/tests/context.py
+++ b/rss-reader-feedparser-ah-fetch/tests/context.py
@@ -6,4 +6,4 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))
 
-from rss_reader import rss_reader
+from rss_reader import rss_reader  # noqa: F401 — re-exported for test modules

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader.py
@@ -10,13 +10,17 @@ async def test_get_feed():
 
     # Uncomment this to use HTTP Basic Authentication
     auth = {
-        "user_name": "test_user",
-        "password": "test_password",  # nosec B105
+        "auth_type": "Custom",
+        "credentials": {
+            "user_name": "test_user",
+            "password": "test_password",  # nosec B105
+        },
     }
 
     # Uncomment this to use API token authentication
     # auth = {
-    #    "api_token": "test_api_token"
+    #    "auth_type": "Custom",
+    #    "credentials": {"api_token": "test_api_token"},
     # }
 
     # Define test configuration

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -33,11 +33,9 @@ SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-async def test_get_feed_reads_wrapped_credentials(make_context):
-    """Production sends the wrapped Custom auth envelope; the handler must
-    read basic-auth credentials from context.auth["credentials"], not from
-    the top-level auth dict.
-    """
+async def test_get_feed(make_context):
+    """get_feed with HTTP basic auth: parses the feed and bakes the
+    credentials into the fetched URL."""
     ctx = make_context(
         auth={
             "auth_type": "Custom",

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for the RSS Reader integration using mocked fetch.
+
+Run with:
+    pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py -m unit
+"""
+
+import os
+import sys
+
+import pytest
+from autohive_integrations_sdk import ResultType
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from rss_reader import rss_reader  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Entry One</title>
+      <link>https://example.com/1</link>
+      <description>First entry</description>
+      <published>2025-01-01T00:00:00Z</published>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+async def test_get_feed_reads_wrapped_credentials(make_context):
+    """Production sends the wrapped Custom auth envelope; the handler must
+    read basic-auth credentials from context.auth["credentials"], not from
+    the top-level auth dict.
+    """
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"user_name": "test_user", "password": "test_password"},
+        }
+    )
+    ctx.fetch.return_value = SAMPLE_FEED
+    result = await rss_reader.execute_action(
+        "get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx
+    )
+    assert result.type == ResultType.ACTION
+    data = result.result.data
+    assert data["feed_title"] == "Test Feed"
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["title"] == "Entry One"
+    # Basic-auth credentials should have been baked into the fetched URL.
+    fetched_url = ctx.fetch.call_args.args[0]
+    assert "test_user:test_password@" in fetched_url

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -41,14 +41,12 @@ async def test_get_feed_reads_wrapped_credentials(make_context):
     ctx = make_context(
         auth={
             "auth_type": "Custom",
-            "credentials": {"user_name": "test_user", "password": "test_password"},
+            "credentials": {"user_name": "test_user", "password": "test_password"},  # nosec B105
         }
     )
     # Pinned SDK 1.x fetch() returns the body directly, not a FetchResponse.
     ctx.fetch.return_value = SAMPLE_FEED
-    result = await rss_reader.execute_action(
-        "get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx
-    )
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx)
     assert result.type == ResultType.ACTION
     data = result.result.data
     assert data["feed_title"] == "Test Feed"

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -44,6 +44,7 @@ async def test_get_feed_reads_wrapped_credentials(make_context):
             "credentials": {"user_name": "test_user", "password": "test_password"},
         }
     )
+    # Pinned SDK 1.x fetch() returns the body directly, not a FetchResponse.
     ctx.fetch.return_value = SAMPLE_FEED
     result = await rss_reader.execute_action(
         "get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx

--- a/supabase/config.json
+++ b/supabase/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Supabase",
   "display_name": "Supabase",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Integration with Supabase for database operations, storage, and authentication management",
   "entry_point": "supabase.py",
   "auth": {

--- a/supabase/supabase.py
+++ b/supabase/supabase.py
@@ -10,13 +10,8 @@ from typing import Dict, Any
 supabase = Integration.load()
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def get_headers(context: ExecutionContext) -> Dict[str, str]:
-    service_role_secret = _credentials(context).get("service_role_secret", "")
+    service_role_secret = context.auth["credentials"].get("service_role_secret", "")
     return {
         "apikey": service_role_secret,
         "Authorization": f"Bearer {service_role_secret}",
@@ -26,7 +21,7 @@ def get_headers(context: ExecutionContext) -> Dict[str, str]:
 
 
 def get_base_url(context: ExecutionContext) -> str:
-    return _credentials(context).get("host", "").rstrip("/")
+    return context.auth["credentials"].get("host", "").rstrip("/")
 
 
 # ---- Database (PostgREST) Handlers ----

--- a/supabase/supabase.py
+++ b/supabase/supabase.py
@@ -10,8 +10,13 @@ from typing import Dict, Any
 supabase = Integration.load()
 
 
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
+
+
 def get_headers(context: ExecutionContext) -> Dict[str, str]:
-    service_role_secret = context.auth.get("service_role_secret", "")
+    service_role_secret = _credentials(context).get("service_role_secret", "")
     return {
         "apikey": service_role_secret,
         "Authorization": f"Bearer {service_role_secret}",
@@ -21,7 +26,7 @@ def get_headers(context: ExecutionContext) -> Dict[str, str]:
 
 
 def get_base_url(context: ExecutionContext) -> str:
-    return context.auth.get("host", "").rstrip("/")
+    return _credentials(context).get("host", "").rstrip("/")
 
 
 # ---- Database (PostgREST) Handlers ----

--- a/supabase/tests/conftest.py
+++ b/supabase/tests/conftest.py
@@ -1,15 +1,17 @@
 import pytest
+from unittest.mock import MagicMock, AsyncMock
+from autohive_integrations_sdk import ExecutionContext
 
 
 @pytest.fixture
-def mock_context(make_context):
-    """Mock execution context with the wrapped Custom auth envelope Supabase expects."""
-    return make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {
-                "host": "https://test.supabase.co",
-                "service_role_secret": "test-service-role-secret",  # nosec B105
-            },
-        }
-    )
+def mock_context():
+    ctx = MagicMock(spec=ExecutionContext)
+    ctx.fetch = AsyncMock()
+    ctx.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "host": "https://test.supabase.co",
+            "service_role_secret": "test-service-role-secret",  # nosec B105
+        },
+    }
+    return ctx

--- a/supabase/tests/conftest.py
+++ b/supabase/tests/conftest.py
@@ -2,16 +2,14 @@ import pytest
 
 
 @pytest.fixture
-def mock_context(make_custom_auth_context):
-    """Mock execution context with the wrapped Custom auth envelope Supabase expects.
-
-    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
-    not make the real ``credentials`` property available; set it explicitly to
-    the unwrapped credentials dict.
-    """
-    credentials = {
-        "host": "https://test.supabase.co",
-        "service_role_secret": "test-service-role-secret",  # nosec B105
-    }
-    ctx = make_custom_auth_context(credentials)
-    return ctx
+def mock_context(make_context):
+    """Mock execution context with the wrapped Custom auth envelope Supabase expects."""
+    return make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {
+                "host": "https://test.supabase.co",
+                "service_role_secret": "test-service-role-secret",  # nosec B105
+            },
+        }
+    )

--- a/supabase/tests/conftest.py
+++ b/supabase/tests/conftest.py
@@ -1,14 +1,17 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
-from autohive_integrations_sdk import ExecutionContext
 
 
 @pytest.fixture
-def mock_context():
-    ctx = MagicMock(spec=ExecutionContext)
-    ctx.fetch = AsyncMock()
-    ctx.auth = {
+def mock_context(make_custom_auth_context):
+    """Mock execution context with the wrapped Custom auth envelope Supabase expects.
+
+    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
+    not make the real ``credentials`` property available; set it explicitly to
+    the unwrapped credentials dict.
+    """
+    credentials = {
         "host": "https://test.supabase.co",
         "service_role_secret": "test-service-role-secret",  # nosec B105
     }
+    ctx = make_custom_auth_context(credentials)
     return ctx

--- a/supabase/tests/test_supabase_integration.py
+++ b/supabase/tests/test_supabase_integration.py
@@ -74,7 +74,12 @@ def live_context(make_context):
 
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"host": SUPABASE_URL, "service_role_secret": service_role_key})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"host": SUPABASE_URL, "service_role_secret": service_role_key},
+        }
+    )
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/supabase/tests/test_supabase_unit.py
+++ b/supabase/tests/test_supabase_unit.py
@@ -202,22 +202,3 @@ async def test_delete_user(mock_context):
     result = await supabase.execute_action("delete_user", {"user_id": "user-uuid"}, mock_context)
     assert result.type == ResultType.ACTION
     assert result.result.data["deleted"] is True
-
-
-# ---- Wrapped Auth Envelope ----
-
-
-@pytest.mark.asyncio
-async def test_select_records_wrapped_auth(mock_context):
-    mock_context.auth = {
-        "auth_type": "Custom",
-        "credentials": {
-            "host": "https://test.supabase.co",
-            "service_role_secret": "test-service-role-secret",  # nosec B105
-        },
-    }
-    mock_context.fetch = AsyncMock(return_value=MagicMock(data=[{"id": 1, "name": "Alice"}]))
-    result = await supabase.execute_action("select_records", {"table": "users"}, mock_context)
-    assert result.type == ResultType.ACTION
-    assert result.result.data["records"] == [{"id": 1, "name": "Alice"}]
-    assert result.result.data["count"] == 1

--- a/supabase/tests/test_supabase_unit.py
+++ b/supabase/tests/test_supabase_unit.py
@@ -202,3 +202,22 @@ async def test_delete_user(mock_context):
     result = await supabase.execute_action("delete_user", {"user_id": "user-uuid"}, mock_context)
     assert result.type == ResultType.ACTION
     assert result.result.data["deleted"] is True
+
+
+# ---- Wrapped Auth Envelope ----
+
+
+@pytest.mark.asyncio
+async def test_select_records_wrapped_auth(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "host": "https://test.supabase.co",
+            "service_role_secret": "test-service-role-secret",  # nosec B105
+        },
+    }
+    mock_context.fetch = AsyncMock(return_value=MagicMock(data=[{"id": 1, "name": "Alice"}]))
+    result = await supabase.execute_action("select_records", {"table": "users"}, mock_context)
+    assert result.type == ResultType.ACTION
+    assert result.result.data["records"] == [{"id": 1, "name": "Alice"}]
+    assert result.result.data["count"] == 1


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Four custom-auth integrations — **freshdesk, ghost, supabase, rss-reader-feedparser-ah-fetch** — read credential fields directly off `context.auth` (e.g. `context.auth.get("api_key")`). Production sends auth as the wrapped envelope `{"auth_type": "...", "credentials": {...}}` (same root cause family as the ActiveCampaign incident, PR #345), so these handlers receive empty credential values and fail at the external API with bad URLs / 401s. They are broken in production today.
- **Approach**: Handlers read `context.auth["credentials"]` directly — the envelope is what production sends on every SDK version, and once SDK 2.0.1 lands the SDK validates the shape before any handler runs. The four integrations' unit and live test suites are migrated to construct the wrapped envelope with the envelope written literally at each construction site, so every test exercises the production auth shape. Also fixes a second latent bug in rss-reader-feedparser-ah-fetch: its handler returned a bare dict, which every SDK version rejects (`execute_action` requires `ActionResult`), so that action could never succeed regardless of auth.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: Direct `context.auth["credentials"]` reads in all four handlers (no fallback helpers — flat auth is not a shape production ever sends)
:point_right: Unit and live test suites for the four migrated to wrapped auth contexts
:point_right: rss-reader-feedparser-ah-fetch: handler now returns `ActionResult` (was a bare dict, rejected by the SDK before any response reached the caller)

### Test plan :test_tube:
- Against the published pinned SDK (2.0.0): freshdesk 88, ghost 22, supabase 19, rss-reader-feedparser-ah-fetch 1 — all passing
- Against the strict 2.0.1 build (integrations-sdk `release/2.0.1`): identical results — these suites survive the release unchanged
- `validate_integration.py` passes for all four; ruff (incl. E501), ruff format, and bandit clean

### Notes
- These four suites now construct only the wrapped envelope; flat auth is no longer exercised anywhere in them, matching the SDK 2.0.1 contract.
- rss-reader-feedparser-ah-fetch stays pinned to SDK `~=1.0.2`; the wrapped envelope arrives from the platform regardless of SDK version, so the direct read is correct there too.

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

