### PR TITLE
test: migrate custom auth test contexts to the platform auth envelope

### DIFF
--- a/active-campaign/tests/test_active_campaign_integration.py
+++ b/active-campaign/tests/test_active_campaign_integration.py
@@ -49,7 +49,7 @@ def live_context(env_credentials, make_context):
                     data = await resp.text()
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"api_key": api_key, "api_url": api_url})
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": api_key, "api_url": api_url}})
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/active-campaign/tests/test_active_campaign_unit.py
+++ b/active-campaign/tests/test_active_campaign_unit.py
@@ -44,7 +44,12 @@ def err(status, data=None):
 
 
 async def test_list_campaigns_returns_list(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaigns": [CAMPAIGN], "meta": {"total": "1"}})
     result = await active_campaign.execute_action("list_campaigns", {}, ctx)
     assert result.type == ResultType.ACTION
@@ -55,7 +60,12 @@ async def test_list_campaigns_returns_list(make_context):
 
 
 async def test_list_campaigns_derives_rates(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaigns": [CAMPAIGN], "meta": {"total": "1"}})
     result = await active_campaign.execute_action("list_campaigns", {}, ctx)
     c = result.result.data["campaigns"][0]
@@ -67,7 +77,12 @@ async def test_list_campaigns_derives_rates(make_context):
 
 async def test_list_campaigns_zero_sends_no_division_error(make_context):
     campaign = {**CAMPAIGN, "send_amt": "0", "uniqueopens": "0", "uniquelinkclicks": "0"}
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaigns": [campaign], "meta": {"total": "1"}})
     result = await active_campaign.execute_action("list_campaigns", {}, ctx)
     c = result.result.data["campaigns"][0]
@@ -77,7 +92,12 @@ async def test_list_campaigns_zero_sends_no_division_error(make_context):
 
 
 async def test_list_campaigns_uses_correct_url(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaigns": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_campaigns", {}, ctx)
     url = ctx.fetch.call_args.args[0]
@@ -86,7 +106,12 @@ async def test_list_campaigns_uses_correct_url(make_context):
 
 async def test_list_campaigns_params_baked_into_url_not_passed_as_kwarg(make_context):
     """Params must be baked into the URL so the SDK retry loop cannot duplicate them."""
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaigns": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_campaigns", {"limit": 2, "offset": 10}, ctx)
     call = ctx.fetch.call_args
@@ -98,7 +123,12 @@ async def test_list_campaigns_params_baked_into_url_not_passed_as_kwarg(make_con
 
 async def test_list_contacts_params_baked_into_url_not_passed_as_kwarg(make_context):
     """Params must be baked into the URL so the SDK retry loop cannot duplicate them."""
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"contacts": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_contacts", {"email": "test@example.com", "limit": 5}, ctx)
     call = ctx.fetch.call_args
@@ -110,7 +140,12 @@ async def test_list_contacts_params_baked_into_url_not_passed_as_kwarg(make_cont
 
 async def test_list_contact_activities_params_baked_into_url_not_passed_as_kwarg(make_context):
     """Params must be baked into the URL so the SDK retry loop cannot duplicate them."""
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"activities": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_contact_activities", {"contact_id": 42}, ctx)
     call = ctx.fetch.call_args
@@ -121,7 +156,12 @@ async def test_list_contact_activities_params_baked_into_url_not_passed_as_kwarg
 
 async def test_list_lists_params_baked_into_url_not_passed_as_kwarg(make_context):
     """Params must be baked into the URL so the SDK retry loop cannot duplicate them."""
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"lists": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_lists", {"limit": 5, "offset": 10}, ctx)
     call = ctx.fetch.call_args
@@ -135,7 +175,12 @@ async def test_list_lists_params_baked_into_url_not_passed_as_kwarg(make_context
 
 
 async def test_get_campaign_returns_campaign(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaign": CAMPAIGN})
     result = await active_campaign.execute_action("get_campaign", {"campaign_id": 1}, ctx)
     data = result.result.data
@@ -144,7 +189,12 @@ async def test_get_campaign_returns_campaign(make_context):
 
 
 async def test_get_campaign_derives_rates(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaign": CAMPAIGN})
     result = await active_campaign.execute_action("get_campaign", {"campaign_id": 1}, ctx)
     c = result.result.data["campaign"]
@@ -153,7 +203,12 @@ async def test_get_campaign_derives_rates(make_context):
 
 
 async def test_get_campaign_uses_correct_url(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaign": CAMPAIGN})
     await active_campaign.execute_action("get_campaign", {"campaign_id": 99}, ctx)
     url = ctx.fetch.call_args.args[0]
@@ -164,7 +219,12 @@ async def test_get_campaign_uses_correct_url(make_context):
 
 
 async def test_get_campaign_links_returns_links(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"links": [{"id": "1", "link": "https://example.com", "uniqueclicks": "5"}]})
     result = await active_campaign.execute_action("get_campaign_links", {"campaign_id": 1}, ctx)
     data = result.result.data
@@ -173,7 +233,12 @@ async def test_get_campaign_links_returns_links(make_context):
 
 
 async def test_get_campaign_links_uses_correct_url(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"links": []})
     await active_campaign.execute_action("get_campaign_links", {"campaign_id": 5}, ctx)
     url = ctx.fetch.call_args.args[0]
@@ -184,7 +249,12 @@ async def test_get_campaign_links_uses_correct_url(make_context):
 
 
 async def test_list_contacts_returns_list(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok(
         {"contacts": [{"id": "1", "email": "test@example.com", "firstName": "Jane"}], "meta": {"total": "1"}}
     )
@@ -196,7 +266,12 @@ async def test_list_contacts_returns_list(make_context):
 
 
 async def test_list_contacts_passes_email_filter(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"contacts": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_contacts", {"email": "jane@example.com"}, ctx)
     url = ctx.fetch.call_args.args[0]
@@ -207,7 +282,12 @@ async def test_list_contacts_passes_email_filter(make_context):
 
 
 async def test_get_contact_returns_contact(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"contact": {"id": "5", "email": "bob@example.com"}})
     result = await active_campaign.execute_action("get_contact", {"contact_id": 5}, ctx)
     data = result.result.data
@@ -217,7 +297,12 @@ async def test_get_contact_returns_contact(make_context):
 
 
 async def test_get_contact_uses_correct_url(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"contact": {"id": "5"}})
     await active_campaign.execute_action("get_contact", {"contact_id": 5}, ctx)
     url = ctx.fetch.call_args.args[0]
@@ -228,7 +313,12 @@ async def test_get_contact_uses_correct_url(make_context):
 
 
 async def test_list_contact_activities_returns_activities(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok(
         {"activities": [{"tstamp": "2025-01-01", "reference_action": "open"}], "meta": {"total": "1"}}
     )
@@ -240,7 +330,12 @@ async def test_list_contact_activities_returns_activities(make_context):
 
 
 async def test_list_contact_activities_passes_contact_id(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"activities": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_contact_activities", {"contact_id": 42}, ctx)
     url = ctx.fetch.call_args.args[0]
@@ -251,7 +346,12 @@ async def test_list_contact_activities_passes_contact_id(make_context):
 
 
 async def test_list_lists_returns_lists(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"lists": [{"id": "1", "name": "Newsletter"}], "meta": {"total": "1"}})
     result = await active_campaign.execute_action("list_lists", {}, ctx)
     data = result.result.data
@@ -264,7 +364,12 @@ async def test_list_lists_returns_lists(make_context):
 
 
 async def test_error_response_returns_action_error(make_context):
-    ctx = make_context(auth={"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "testkey", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = err(401, {"message": "Unauthorized"})
     result = await active_campaign.execute_action("list_campaigns", {}, ctx)
     assert result.type == ResultType.ACTION_ERROR
@@ -272,7 +377,12 @@ async def test_error_response_returns_action_error(make_context):
 
 
 async def test_auth_header_is_set(make_context):
-    ctx = make_context(auth={"api_key": "my-secret-key", "api_url": "https://testaccount.api-us1.com"})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_key": "my-secret-key", "api_url": "https://testaccount.api-us1.com"},
+        }
+    )
     ctx.fetch.return_value = ok({"campaigns": [], "meta": {"total": "0"}})
     await active_campaign.execute_action("list_campaigns", {}, ctx)
     headers = ctx.fetch.call_args.kwargs["headers"]

--- a/app-business-reviews/tests/test_app_business_reviews_integration.py
+++ b/app-business-reviews/tests/test_app_business_reviews_integration.py
@@ -39,7 +39,7 @@ def live_context():
 
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
-    ctx.auth = {"credentials": {"api_key": API_KEY}}
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_key": API_KEY}}
     return ctx
 
 

--- a/app-business-reviews/tests/test_app_business_reviews_unit.py
+++ b/app-business-reviews/tests/test_app_business_reviews_unit.py
@@ -82,6 +82,7 @@ def mock_context():
     ctx.fetch = AsyncMock(name="fetch")
     # Source reads context.auth.get("credentials", {}).get("api_key", "")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {"api_key": "test_serpapi_key"},  # nosec B105
     }
     return ctx

--- a/aws/tests/conftest.py
+++ b/aws/tests/conftest.py
@@ -7,8 +7,11 @@ from autohive_integrations_sdk import ExecutionContext
 def mock_context():
     ctx = MagicMock(spec=ExecutionContext)
     ctx.auth = {
-        "aws_access_key_id": "test_access_key",
-        "aws_secret_access_key": "test_secret_key",  # nosec B105
-        "aws_region": "us-east-1",
+        "auth_type": "Custom",
+        "credentials": {
+            "aws_access_key_id": "test_access_key",
+            "aws_secret_access_key": "test_secret_key",  # nosec B105
+            "aws_region": "us-east-1",
+        },
     }
     return ctx

--- a/aws/tests/test_aws_integration.py
+++ b/aws/tests/test_aws_integration.py
@@ -55,19 +55,19 @@ pytestmark = [
 
 @pytest.fixture
 def live_context():
-    auth = {
+    credentials = {
         "aws_access_key_id": AWS_ACCESS_KEY_ID,
         "aws_secret_access_key": AWS_SECRET_ACCESS_KEY,
         "aws_region": AWS_REGION,
     }
     if AWS_SESSION_TOKEN:
-        auth["aws_session_token"] = AWS_SESSION_TOKEN
+        credentials["aws_session_token"] = AWS_SESSION_TOKEN
 
     class _Ctx:
         pass
 
     ctx = _Ctx()
-    ctx.auth = auth
+    ctx.auth = {"auth_type": "Custom", "credentials": credentials}
     return ctx
 
 

--- a/circle/tests/conftest.py
+++ b/circle/tests/conftest.py
@@ -6,5 +6,5 @@ import pytest
 def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"api_token": "test_token"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": "test_token"}}  # nosec B105
     return ctx

--- a/circle/tests/test_circle_integration.py
+++ b/circle/tests/test_circle_integration.py
@@ -69,7 +69,7 @@ def live_context(make_context):
 
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"api_token": CIRCLE_API_TOKEN})
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_token": CIRCLE_API_TOKEN}})
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/circle/tests/test_circle_unit.py
+++ b/circle/tests/test_circle_unit.py
@@ -281,6 +281,7 @@ async def test_api_error_in_response(mock_context):
 
 @pytest.mark.asyncio
 async def test_missing_api_token(mock_context):
-    mock_context.auth = {}
+    mock_context.auth = {"auth_type": "Custom", "credentials": {}}
     result = await circle.execute_action("list_tags", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
+    assert "Circle API token is required" in result.result.message

--- a/coda/tests/test_coda_integration.py
+++ b/coda/tests/test_coda_integration.py
@@ -45,7 +45,7 @@ def live_context():
 
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
-    ctx.auth = {"credentials": {"api_token": API_KEY}}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": API_KEY}}  # nosec B105
     return ctx
 
 

--- a/coda/tests/test_coda_unit.py
+++ b/coda/tests/test_coda_unit.py
@@ -13,7 +13,7 @@ API_BASE = "https://coda.io/apis/v1"
 def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"credentials": {"api_token": "test_token"}}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": "test_token"}}  # nosec B105
     return ctx
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,8 +4,6 @@ Root conftest.py — shared fixtures for all integration test suites.
 Provides:
 - mock_context: A pre-configured MagicMock ExecutionContext with AsyncMock fetch
 - make_context: Factory for building mock contexts with custom auth shapes
-- make_custom_auth_context: Factory for mock contexts with the wrapped Custom
-  auth envelope (auth_type + credentials) that production actually sends
 - env_credentials: Helper to load credentials from env/.env files
 
 Also patches Integration.load() so it resolves config.json from the calling
@@ -113,27 +111,6 @@ def make_context():
         ctx.fetch = AsyncMock(name="fetch")
         ctx.auth = auth or {}
         return ctx
-
-    return _factory
-
-
-@pytest.fixture
-def make_custom_auth_context(make_context):
-    """Factory fixture — build a mock context with the wrapped Custom auth envelope.
-
-    This builds the platform-shaped auth envelope that production sends to
-    integrations; custom-auth integration tests should use this instead of
-    passing flat auth dicts.
-
-    Example::
-
-        def test_foo(make_custom_auth_context):
-            ctx = make_custom_auth_context({"api_key": "k"})
-            ctx.fetch.return_value = {...}
-    """
-
-    def _factory(credentials: Dict[str, str]) -> MagicMock:
-        return make_context(auth={"auth_type": "Custom", "credentials": credentials})
 
     return _factory
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,8 @@ Root conftest.py — shared fixtures for all integration test suites.
 Provides:
 - mock_context: A pre-configured MagicMock ExecutionContext with AsyncMock fetch
 - make_context: Factory for building mock contexts with custom auth shapes
+- make_custom_auth_context: Factory for mock contexts with the wrapped Custom
+  auth envelope (auth_type + credentials) that production actually sends
 - env_credentials: Helper to load credentials from env/.env files
 
 Also patches Integration.load() so it resolves config.json from the calling
@@ -97,7 +99,9 @@ def make_context():
     Example::
 
         def test_foo(make_context):
-            ctx = make_context(auth={"credentials": {"api_key": "k"}})
+            ctx = make_context(
+                auth={"auth_type": "Custom", "credentials": {"api_key": "k"}}
+            )
             ctx.fetch.return_value = {...}
     """
 
@@ -109,6 +113,27 @@ def make_context():
         ctx.fetch = AsyncMock(name="fetch")
         ctx.auth = auth or {}
         return ctx
+
+    return _factory
+
+
+@pytest.fixture
+def make_custom_auth_context(make_context):
+    """Factory fixture — build a mock context with the wrapped Custom auth envelope.
+
+    This builds the platform-shaped auth envelope that production sends to
+    integrations; custom-auth integration tests should use this instead of
+    passing flat auth dicts.
+
+    Example::
+
+        def test_foo(make_custom_auth_context):
+            ctx = make_custom_auth_context({"api_key": "k"})
+            ctx.fetch.return_value = {...}
+    """
+
+    def _factory(credentials: Dict[str, str]) -> MagicMock:
+        return make_context(auth={"auth_type": "Custom", "credentials": credentials})
 
     return _factory
 

--- a/elevenlabs/tests/test_elevenlabs_integration.py
+++ b/elevenlabs/tests/test_elevenlabs_integration.py
@@ -44,7 +44,7 @@ def live_context():
 
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
-    ctx.auth = {"credentials": {"api_key": API_KEY}}
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_key": API_KEY}}
     return ctx
 
 

--- a/elevenlabs/tests/test_elevenlabs_unit.py
+++ b/elevenlabs/tests/test_elevenlabs_unit.py
@@ -28,7 +28,7 @@ API_BASE = "https://api.elevenlabs.io/v1"
 def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"api_key": "test_key"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_key": "test_key"}}  # nosec B105
     return ctx
 
 

--- a/fergus/tests/conftest.py
+++ b/fergus/tests/conftest.py
@@ -6,5 +6,5 @@ import pytest
 def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"credentials": {"api_token": "test_token"}}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": "test_token"}}  # nosec B105
     return ctx

--- a/fergus/tests/test_fergus_integration.py
+++ b/fergus/tests/test_fergus_integration.py
@@ -36,7 +36,7 @@ def live_context(make_context):
                     data = await resp.text()
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"credentials": {"api_token": FERGUS_API_TOKEN}})
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_token": FERGUS_API_TOKEN}})
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/fergus/tests/test_fergus_unit.py
+++ b/fergus/tests/test_fergus_unit.py
@@ -174,6 +174,7 @@ async def test_list_users_with_search(mock_context):
 
 @pytest.mark.asyncio
 async def test_auth_token_missing(mock_context):
-    mock_context.auth = {}
+    mock_context.auth = {"auth_type": "Custom", "credentials": {}}
     result = await fergus.execute_action("list_jobs", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
+    assert "Fergus Personal Access Token is required" in result.result.message

--- a/float/tests/test_float_integration.py
+++ b/float/tests/test_float_integration.py
@@ -55,11 +55,12 @@ def live_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_key": API_KEY,
             "application_name": os.environ.get("FLOAT_APP_NAME", "Autohive Float Integration"),
             "contact_email": os.environ.get("FLOAT_CONTACT_EMAIL", ""),
-        }
+        },
     }
     return ctx
 

--- a/float/tests/test_float_misc_unit.py
+++ b/float/tests/test_float_misc_unit.py
@@ -26,11 +26,12 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_key": "test_api_key",  # nosec B105
             "application_name": "Test App",
             "contact_email": "test@example.com",
-        }
+        },
     }
     return ctx
 

--- a/float/tests/test_float_people_unit.py
+++ b/float/tests/test_float_people_unit.py
@@ -34,11 +34,12 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_key": "test_api_key",  # nosec B105
             "application_name": "Test App",
             "contact_email": "test@example.com",
-        }
+        },
     }
     return ctx
 

--- a/float/tests/test_float_projects_unit.py
+++ b/float/tests/test_float_projects_unit.py
@@ -33,11 +33,12 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_key": "test_api_key",  # nosec B105
             "application_name": "Test App",
             "contact_email": "test@example.com",
-        }
+        },
     }
     return ctx
 

--- a/float/tests/test_float_tasks_unit.py
+++ b/float/tests/test_float_tasks_unit.py
@@ -35,11 +35,12 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_key": "test_api_key",  # nosec B105
             "application_name": "Test App",
             "contact_email": "test@example.com",
-        }
+        },
     }
     return ctx
 

--- a/float/tests/test_float_timeoff_unit.py
+++ b/float/tests/test_float_timeoff_unit.py
@@ -35,11 +35,12 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_key": "test_api_key",  # nosec B105
             "application_name": "Test App",
             "contact_email": "test@example.com",
-        }
+        },
     }
     return ctx
 

--- a/float/tests/test_float_unit.py
+++ b/float/tests/test_float_unit.py
@@ -22,7 +22,7 @@ float_integration = _mod.float
 
 pytestmark = pytest.mark.unit
 
-TEST_AUTH = {"credentials": {"api_key": "test_key"}}
+TEST_AUTH = {"auth_type": "Custom", "credentials": {"api_key": "test_key"}}
 
 
 def ok(data):

--- a/freshdesk/config.json
+++ b/freshdesk/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Freshdesk",
     "display_name": "Freshdesk",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Freshdesk integration for managing tickets, contacts, companies, and customer support operations",
     "entry_point": "freshdesk.py",
     "auth": {

--- a/freshdesk/freshdesk.py
+++ b/freshdesk/freshdesk.py
@@ -12,6 +12,11 @@ FRESHDESK_API_VERSION = "v2"
 # ---- Helper Functions ----
 
 
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
+
+
 def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     """
     Build authentication headers for Freshdesk API requests.
@@ -23,7 +28,7 @@ def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     Returns:
         Dictionary with Authorization and Content-Type headers
     """
-    api_key = context.auth.get("api_key", "")
+    api_key = _credentials(context).get("api_key", "")
 
     # Freshdesk requires Basic Auth with format: api_key:X
     auth_string = f"{api_key}:X"
@@ -43,7 +48,7 @@ def get_base_url(context: ExecutionContext) -> str:
     Returns:
         Base URL string (e.g., https://yourcompany.freshdesk.com/api/v2)
     """
-    domain = context.auth.get("domain", "")
+    domain = _credentials(context).get("domain", "")
 
     return f"https://{domain}.freshdesk.com/api/{FRESHDESK_API_VERSION}"
 

--- a/freshdesk/freshdesk.py
+++ b/freshdesk/freshdesk.py
@@ -12,11 +12,6 @@ FRESHDESK_API_VERSION = "v2"
 # ---- Helper Functions ----
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     """
     Build authentication headers for Freshdesk API requests.
@@ -28,7 +23,7 @@ def get_auth_headers(context: ExecutionContext) -> Dict[str, str]:
     Returns:
         Dictionary with Authorization and Content-Type headers
     """
-    api_key = _credentials(context).get("api_key", "")
+    api_key = context.auth["credentials"].get("api_key", "")
 
     # Freshdesk requires Basic Auth with format: api_key:X
     auth_string = f"{api_key}:X"
@@ -48,7 +43,7 @@ def get_base_url(context: ExecutionContext) -> str:
     Returns:
         Base URL string (e.g., https://yourcompany.freshdesk.com/api/v2)
     """
-    domain = _credentials(context).get("domain", "")
+    domain = context.auth["credentials"].get("domain", "")
 
     return f"https://{domain}.freshdesk.com/api/{FRESHDESK_API_VERSION}"
 

--- a/freshdesk/tests/conftest.py
+++ b/freshdesk/tests/conftest.py
@@ -10,8 +10,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.fixture
 def mock_context():
-    """Mock execution context with the custom auth shape Freshdesk expects."""
+    """Mock execution context with the wrapped Custom auth envelope Freshdesk expects.
+
+    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
+    not make the real ``credentials`` property available; set it explicitly to
+    the unwrapped credentials dict.
+    """
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    credentials = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": credentials}
     return ctx

--- a/freshdesk/tests/conftest.py
+++ b/freshdesk/tests/conftest.py
@@ -10,12 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.fixture
 def mock_context():
-    """Mock execution context with the wrapped Custom auth envelope Freshdesk expects.
-
-    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
-    not make the real ``credentials`` property available; set it explicitly to
-    the unwrapped credentials dict.
-    """
+    """Mock execution context with the wrapped Custom auth envelope Freshdesk expects."""
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     credentials = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105

--- a/freshdesk/tests/test_freshdesk_integration.py
+++ b/freshdesk/tests/test_freshdesk_integration.py
@@ -36,7 +36,8 @@ def live_context(env_credentials, make_context):
                     data = await resp.text()
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"api_key": api_key, "domain": domain})
+    credentials = {"api_key": api_key, "domain": domain}
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": credentials})
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/freshdesk/tests/test_freshdesk_unit.py
+++ b/freshdesk/tests/test_freshdesk_unit.py
@@ -28,9 +28,16 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def mock_context():
+    """Mock execution context with the wrapped Custom auth envelope.
+
+    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
+    not make the real ``credentials`` property available; set it explicitly to
+    the unwrapped credentials dict.
+    """
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    credentials = {"api_key": "test_api_key", "domain": "testcompany"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": credentials}
     return ctx
 
 
@@ -102,24 +109,6 @@ class TestGetBaseUrl:
     def test_freshdesk_subdomain_format(self, mock_context):
         url = get_base_url(mock_context)
         assert url == "https://testcompany.freshdesk.com/api/v2"
-
-
-class TestWrappedAuthEnvelope:
-    @pytest.mark.asyncio
-    async def test_list_companies_succeeds_with_wrapped_credentials(self, mock_context):
-        mock_context.auth = {
-            "auth_type": "Custom",
-            "credentials": {"api_key": "test_api_key", "domain": "testcompany"},
-        }
-        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_COMPANY])
-
-        result = await freshdesk.execute_action("list_companies", {}, mock_context)
-
-        assert result.type == ResultType.ACTION
-        assert result.result.data["companies"] == [SAMPLE_COMPANY]
-
-        call_args = mock_context.fetch.call_args
-        assert "testcompany.freshdesk.com/api/v2/companies" in call_args.args[0]
 
 
 # ---- Company Tests ----

--- a/freshdesk/tests/test_freshdesk_unit.py
+++ b/freshdesk/tests/test_freshdesk_unit.py
@@ -104,6 +104,24 @@ class TestGetBaseUrl:
         assert url == "https://testcompany.freshdesk.com/api/v2"
 
 
+class TestWrappedAuthEnvelope:
+    @pytest.mark.asyncio
+    async def test_list_companies_succeeds_with_wrapped_credentials(self, mock_context):
+        mock_context.auth = {
+            "auth_type": "Custom",
+            "credentials": {"api_key": "test_api_key", "domain": "testcompany"},
+        }
+        mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=[SAMPLE_COMPANY])
+
+        result = await freshdesk.execute_action("list_companies", {}, mock_context)
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data["companies"] == [SAMPLE_COMPANY]
+
+        call_args = mock_context.fetch.call_args
+        assert "testcompany.freshdesk.com/api/v2/companies" in call_args.args[0]
+
+
 # ---- Company Tests ----
 
 

--- a/ghost/config.json
+++ b/ghost/config.json
@@ -1,7 +1,7 @@
 {
     "name": "ghost",
     "display_name": "Ghost",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Ghost CMS integration for reading and managing posts, pages, members, and newsletters",
     "entry_point": "ghost.py",
     "auth": {

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -15,8 +15,13 @@ from autohive_integrations_sdk import (
 ghost = Integration.load()
 
 
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
+
+
 def _get_base_url(context: ExecutionContext) -> str:
-    url = context.auth.get("api_url", "")
+    url = _credentials(context).get("api_url", "")
     if not url:
         raise ValueError("api_url is required in auth")
     return url.rstrip("/")
@@ -24,7 +29,7 @@ def _get_base_url(context: ExecutionContext) -> str:
 
 def _content_headers(context: ExecutionContext) -> tuple:
     """Returns (base_url, params_with_key)."""
-    content_key = context.auth.get("content_api_key", "")
+    content_key = _credentials(context).get("content_api_key", "")
     if not content_key:
         raise ValueError("content_api_key is required in auth")
     base = _get_base_url(context)
@@ -32,7 +37,7 @@ def _content_headers(context: ExecutionContext) -> tuple:
 
 
 def _make_admin_jwt(context: ExecutionContext) -> str:
-    admin_key = context.auth.get("admin_api_key", "")
+    admin_key = _credentials(context).get("admin_api_key", "")
     if not admin_key:
         raise ValueError("admin_api_key is required in auth")
     if ":" not in admin_key:

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -15,13 +15,8 @@ from autohive_integrations_sdk import (
 ghost = Integration.load()
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def _get_base_url(context: ExecutionContext) -> str:
-    url = _credentials(context).get("api_url", "")
+    url = context.auth["credentials"].get("api_url", "")
     if not url:
         raise ValueError("api_url is required in auth")
     return url.rstrip("/")
@@ -29,7 +24,7 @@ def _get_base_url(context: ExecutionContext) -> str:
 
 def _content_headers(context: ExecutionContext) -> tuple:
     """Returns (base_url, params_with_key)."""
-    content_key = _credentials(context).get("content_api_key", "")
+    content_key = context.auth["credentials"].get("content_api_key", "")
     if not content_key:
         raise ValueError("content_api_key is required in auth")
     base = _get_base_url(context)
@@ -37,7 +32,7 @@ def _content_headers(context: ExecutionContext) -> tuple:
 
 
 def _make_admin_jwt(context: ExecutionContext) -> str:
-    admin_key = _credentials(context).get("admin_api_key", "")
+    admin_key = context.auth["credentials"].get("admin_api_key", "")
     if not admin_key:
         raise ValueError("admin_api_key is required in auth")
     if ":" not in admin_key:

--- a/ghost/tests/conftest.py
+++ b/ghost/tests/conftest.py
@@ -1,14 +1,12 @@
-from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
 @pytest.fixture
-def mock_context():
-    ctx = MagicMock(name="ExecutionContext")
-    ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {
+def mock_context(make_custom_auth_context):
+    credentials = {
         "api_url": "https://demo.ghost.io",
         "content_api_key": "test_content_key",  # nosec B105
         "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",  # nosec B105
     }
+    ctx = make_custom_auth_context(credentials)
     return ctx

--- a/ghost/tests/conftest.py
+++ b/ghost/tests/conftest.py
@@ -1,12 +1,19 @@
 import pytest
 
+# 32-byte hex secret keeps PyJWT's HS256 key-length warning quiet.
+_ADMIN_API_KEY = "testid00000000000000000a:" + "aabbccddeeff0011" * 4  # nosec B105
+
 
 @pytest.fixture
-def mock_context(make_custom_auth_context):
-    credentials = {
-        "api_url": "https://demo.ghost.io",
-        "content_api_key": "test_content_key",  # nosec B105
-        "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",  # nosec B105
-    }
-    ctx = make_custom_auth_context(credentials)
-    return ctx
+def mock_context(make_context):
+    """Mock execution context with the wrapped Custom auth envelope Ghost expects."""
+    return make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {
+                "api_url": "https://demo.ghost.io",
+                "content_api_key": "test_content_key",  # nosec B105
+                "admin_api_key": _ADMIN_API_KEY,
+            },
+        }
+    )

--- a/ghost/tests/conftest.py
+++ b/ghost/tests/conftest.py
@@ -1,19 +1,20 @@
+from unittest.mock import AsyncMock, MagicMock
 import pytest
 
-# 32-byte hex secret keeps PyJWT's HS256 key-length warning quiet.
+# 32-byte hex secret keeps the line length and PyJWT's HS256 key-length warning in check.
 _ADMIN_API_KEY = "testid00000000000000000a:" + "aabbccddeeff0011" * 4  # nosec B105
 
 
 @pytest.fixture
-def mock_context(make_context):
-    """Mock execution context with the wrapped Custom auth envelope Ghost expects."""
-    return make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {
-                "api_url": "https://demo.ghost.io",
-                "content_api_key": "test_content_key",  # nosec B105
-                "admin_api_key": _ADMIN_API_KEY,
-            },
-        }
-    )
+def mock_context():
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(name="fetch")
+    ctx.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "api_url": "https://demo.ghost.io",
+            "content_api_key": "test_content_key",  # nosec B105
+            "admin_api_key": _ADMIN_API_KEY,
+        },
+    }
+    return ctx

--- a/ghost/tests/test_ghost_integration.py
+++ b/ghost/tests/test_ghost_integration.py
@@ -39,9 +39,12 @@ def live_context(make_context):
 
     ctx = make_context(
         auth={
-            "api_url": GHOST_API_URL,
-            "content_api_key": GHOST_CONTENT_API_KEY,
-            "admin_api_key": GHOST_ADMIN_API_KEY,
+            "auth_type": "Custom",
+            "credentials": {
+                "api_url": GHOST_API_URL,
+                "content_api_key": GHOST_CONTENT_API_KEY,
+                "admin_api_key": GHOST_ADMIN_API_KEY,
+            },
         }
     )
     ctx.fetch.side_effect = real_fetch

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -204,16 +204,24 @@ async def test_send_newsletter(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_missing_content_api_key(make_custom_auth_context):
-    credentials = {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"}
-    mock_context = make_custom_auth_context(credentials)
+async def test_missing_content_api_key(make_context):
+    mock_context = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"},
+        }
+    )
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 
 @pytest.mark.asyncio
-async def test_missing_api_url(make_custom_auth_context):
-    credentials = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
-    mock_context = make_custom_auth_context(credentials)
+async def test_missing_api_url(make_context):
+    mock_context = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"content_api_key": "key", "admin_api_key": "id:aabbcc"},
+        }
+    )
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -215,3 +215,21 @@ async def test_missing_api_url(mock_context):
     mock_context.auth = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
+
+
+@pytest.mark.asyncio
+async def test_get_posts_with_wrapped_auth_envelope(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "api_url": "https://demo.ghost.io",
+            "content_api_key": "test_content_key",
+            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+        },
+    }
+    mock_context.fetch = AsyncMock(return_value=_fetch_result({"posts": [{"id": "1", "title": "Hello"}], "meta": {}}))
+    result = await ghost.execute_action("get_posts", {}, mock_context)
+    assert result.type == ResultType.ACTION
+    assert len(result.result.data["posts"]) == 1
+    params = mock_context.fetch.call_args[1]["params"]
+    assert params["key"] == "test_content_key"

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -204,24 +204,20 @@ async def test_send_newsletter(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_missing_content_api_key(make_context):
-    mock_context = make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"},
-        }
-    )
+async def test_missing_content_api_key(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"},
+    }
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 
 @pytest.mark.asyncio
-async def test_missing_api_url(make_context):
-    mock_context = make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {"content_api_key": "key", "admin_api_key": "id:aabbcc"},
-        }
-    )
+async def test_missing_api_url(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {"content_api_key": "key", "admin_api_key": "id:aabbcc"},
+    }
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -204,32 +204,16 @@ async def test_send_newsletter(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_missing_content_api_key(mock_context):
-    mock_context.auth = {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"}
+async def test_missing_content_api_key(make_custom_auth_context):
+    credentials = {"api_url": "https://demo.ghost.io", "admin_api_key": "id:aabbcc"}
+    mock_context = make_custom_auth_context(credentials)
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 
 @pytest.mark.asyncio
-async def test_missing_api_url(mock_context):
-    mock_context.auth = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
+async def test_missing_api_url(make_custom_auth_context):
+    credentials = {"content_api_key": "key", "admin_api_key": "id:aabbcc"}
+    mock_context = make_custom_auth_context(credentials)
     result = await ghost.execute_action("get_posts", {}, mock_context)
     assert result.type == ResultType.ACTION_ERROR
-
-
-@pytest.mark.asyncio
-async def test_get_posts_with_wrapped_auth_envelope(mock_context):
-    mock_context.auth = {
-        "auth_type": "Custom",
-        "credentials": {
-            "api_url": "https://demo.ghost.io",
-            "content_api_key": "test_content_key",
-            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899",
-        },
-    }
-    mock_context.fetch = AsyncMock(return_value=_fetch_result({"posts": [{"id": "1", "title": "Hello"}], "meta": {}}))
-    result = await ghost.execute_action("get_posts", {}, mock_context)
-    assert result.type == ResultType.ACTION
-    assert len(result.result.data["posts"]) == 1
-    params = mock_context.fetch.call_args[1]["params"]
-    assert params["key"] == "test_content_key"

--- a/ghost/tests/test_ghost_unit.py
+++ b/ghost/tests/test_ghost_unit.py
@@ -224,7 +224,7 @@ async def test_get_posts_with_wrapped_auth_envelope(mock_context):
         "credentials": {
             "api_url": "https://demo.ghost.io",
             "content_api_key": "test_content_key",
-            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+            "admin_api_key": "testid00000000000000000a:aabbccddeeff00112233445566778899",
         },
     }
     mock_context.fetch = AsyncMock(return_value=_fetch_result({"posts": [{"id": "1", "title": "Hello"}], "meta": {}}))

--- a/google-looker/tests/test_google_looker_integration.py
+++ b/google-looker/tests/test_google_looker_integration.py
@@ -68,11 +68,12 @@ def live_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "base_url": LOOKER_BASE_URL,
             "client_id": LOOKER_CLIENT_ID,
             "client_secret": LOOKER_CLIENT_SECRET,
-        }
+        },
     }
     return ctx
 

--- a/google-looker/tests/test_google_looker_unit.py
+++ b/google-looker/tests/test_google_looker_unit.py
@@ -33,11 +33,12 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "base_url": "https://test-looker.looker.com",
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",  # nosec B105
-        }
+        },
     }
     return ctx
 
@@ -112,12 +113,12 @@ class TestListDashboards:
 
     @pytest.mark.asyncio
     async def test_missing_credentials_returns_action_error(self, mock_context):
-        mock_context.auth = {}
+        mock_context.auth = {"auth_type": "Custom", "credentials": {}}
 
         result = await google_looker.execute_action("list_dashboards", {}, mock_context)
 
         assert result.type == ResultType.ACTION_ERROR
-        assert "authentication credentials" in result.result.message.lower()
+        assert "missing required configuration" in result.result.message.lower()
 
 
 # ---- Get Dashboard ----

--- a/humanitix/actions/__init__.py
+++ b/humanitix/actions/__init__.py
@@ -9,3 +9,12 @@ from actions.orders import GetOrdersAction
 from actions.tickets import GetTicketsAction
 from actions.tags import GetTagsAction
 from actions.checkin import CheckInAction, CheckOutAction
+
+__all__ = [
+    "GetEventsAction",
+    "GetOrdersAction",
+    "GetTicketsAction",
+    "GetTagsAction",
+    "CheckInAction",
+    "CheckOutAction",
+]

--- a/humanitix/config.json
+++ b/humanitix/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Humanitix",
   "display_name": "Humanitix",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Humanitix integration for managing events, orders, tickets, and tags",
   "entry_point": "humanitix.py",
   "auth": {

--- a/humanitix/tests/test_humanitix_integration.py
+++ b/humanitix/tests/test_humanitix_integration.py
@@ -44,7 +44,7 @@ def live_context():
 
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
-    ctx.auth = {"credentials": {"api_key": API_KEY}}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_key": API_KEY}}  # nosec B105
     return ctx
 
 

--- a/humanitix/tests/test_humanitix_unit.py
+++ b/humanitix/tests/test_humanitix_unit.py
@@ -28,7 +28,7 @@ def err(status: int, message: str) -> FetchResponse:
 def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"credentials": {"api_key": "test_api_key_123"}}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_key": "test_api_key_123"}}  # nosec B105
     return ctx
 
 

--- a/lumin-pdf/tests/test_lumin_pdf_integration.py
+++ b/lumin-pdf/tests/test_lumin_pdf_integration.py
@@ -76,7 +76,7 @@ def live_context(env_credentials, make_context):
                     body = {}
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=body)
 
-    ctx = make_context(auth={"api_key": api_key})
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": api_key}})
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/lumin-pdf/tests/test_lumin_pdf_unit.py
+++ b/lumin-pdf/tests/test_lumin_pdf_unit.py
@@ -28,7 +28,7 @@ API_KEY = "test_api_key"  # nosec B105
 
 class TestGetCurrentUser:
     async def test_returns_user(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "u1", "email": "test@example.com"})
 
         result = await lumin_pdf.execute_action("get_current_user", {}, ctx)
@@ -38,7 +38,7 @@ class TestGetCurrentUser:
         ctx.fetch.assert_called_once_with(f"{BASE_URL}/user/info", method="GET", headers={"X-API-KEY": API_KEY})
 
     async def test_error_returns_action_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Unauthorized")
 
         result = await lumin_pdf.execute_action("get_current_user", {}, ctx)
@@ -49,7 +49,7 @@ class TestGetCurrentUser:
 
 class TestGetWorkspace:
     async def test_returns_workspace(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "ws1", "name": "My Workspace"})
 
         result = await lumin_pdf.execute_action("get_workspace", {}, ctx)
@@ -59,7 +59,7 @@ class TestGetWorkspace:
         ctx.fetch.assert_called_once_with(f"{BASE_URL}/workspaces/info", method="GET", headers={"X-API-KEY": API_KEY})
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Not found")
 
         result = await lumin_pdf.execute_action("get_workspace", {}, ctx)
@@ -70,7 +70,7 @@ class TestGetWorkspace:
 class TestListWorkspaceMembers:
     async def test_returns_members_list(self, make_context):
         members = [{"id": "m1"}, {"id": "m2"}]
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=members)
 
         result = await lumin_pdf.execute_action("list_workspace_members", {"page": 1, "limit": 10}, ctx)
@@ -81,7 +81,7 @@ class TestListWorkspaceMembers:
 
     async def test_returns_members_from_data_key(self, make_context):
         members = [{"id": "m1"}]
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"data": members, "total": 1})
 
         result = await lumin_pdf.execute_action("list_workspace_members", {}, ctx)
@@ -89,7 +89,7 @@ class TestListWorkspaceMembers:
         assert result.result.data["members"] == members
 
     async def test_defaults_page_and_limit_when_not_provided(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_workspace_members", {}, ctx)
@@ -99,7 +99,7 @@ class TestListWorkspaceMembers:
         assert params["limit"] == 10
 
     async def test_page_only_defaults_limit_to_10(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_workspace_members", {"page": 3}, ctx)
@@ -107,7 +107,7 @@ class TestListWorkspaceMembers:
         assert ctx.fetch.call_args.kwargs["params"] == {"page": 3, "limit": 10}
 
     async def test_limit_only_defaults_page_to_1(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_workspace_members", {"limit": 10}, ctx)
@@ -121,7 +121,7 @@ class TestListWorkspaceMembers:
 class TestListTemplates:
     async def test_returns_templates_list(self, make_context):
         templates = [{"id": "t1", "name": "NDA"}]
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=templates)
 
         result = await lumin_pdf.execute_action("list_templates", {"limit": 5}, ctx)
@@ -131,7 +131,7 @@ class TestListTemplates:
 
     async def test_returns_templates_from_data_key(self, make_context):
         templates = [{"id": "t1"}]
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"templates": templates})
 
         result = await lumin_pdf.execute_action("list_templates", {}, ctx)
@@ -139,7 +139,7 @@ class TestListTemplates:
         assert result.result.data["templates"] == templates
 
     async def test_defaults_page_and_limit_when_not_provided(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_templates", {}, ctx)
@@ -149,7 +149,7 @@ class TestListTemplates:
         assert params["limit"] == 10
 
     async def test_page_only_defaults_limit_to_10(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_templates", {"page": 3}, ctx)
@@ -157,7 +157,7 @@ class TestListTemplates:
         assert ctx.fetch.call_args.kwargs["params"] == {"page": 3, "limit": 10}
 
     async def test_limit_only_defaults_page_to_1(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         await lumin_pdf.execute_action("list_templates", {"limit": 25}, ctx)
@@ -165,7 +165,7 @@ class TestListTemplates:
         assert ctx.fetch.call_args.kwargs["params"] == {"page": 1, "limit": 25}
 
     async def test_limit_clamped_to_nearest_valid_value(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
         # 5 → nearest valid is 10, 20 → nearest valid is 25, 40 → nearest valid is 50
@@ -174,7 +174,7 @@ class TestListTemplates:
             assert ctx.fetch.call_args.kwargs["params"]["limit"] == expected
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Server error")
 
         result = await lumin_pdf.execute_action("list_templates", {}, ctx)
@@ -196,7 +196,7 @@ class TestListTemplates:
     ],
 )
 async def test_list_actions_send_pagination_params(make_context, action_name, expected_path, inputs, expected_params):
-    ctx = make_context(auth={"api_key": API_KEY})
+    ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
     ctx.fetch.return_value = FetchResponse(status=200, headers={}, data=[])
 
     await lumin_pdf.execute_action(action_name, inputs, ctx)
@@ -209,7 +209,7 @@ async def test_list_actions_send_pagination_params(make_context, action_name, ex
 
 class TestGetTemplate:
     async def test_returns_template(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "t1", "name": "NDA"})
 
         result = await lumin_pdf.execute_action("get_template", {"template_id": "t1"}, ctx)
@@ -221,7 +221,7 @@ class TestGetTemplate:
         )
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Not found")
 
         result = await lumin_pdf.execute_action("get_template", {"template_id": "bad"}, ctx)
@@ -234,7 +234,7 @@ class TestGetTemplate:
 
 class TestSendSignatureRequest:
     async def test_send_with_file_url(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr1", "status": "pending"})
         inputs = {
             "title": "Test Doc",
@@ -253,7 +253,7 @@ class TestSendSignatureRequest:
         assert "expires_at" in body
 
     async def test_send_normalizes_email_field(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr2"})
         inputs = {
             "title": "Test",
@@ -267,7 +267,7 @@ class TestSendSignatureRequest:
         assert body["signers"][0]["email_address"] == "bob@example.com"
 
     async def test_send_with_file_urls(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr3"})
         inputs = {
             "title": "Multi",
@@ -282,7 +282,7 @@ class TestSendSignatureRequest:
         assert "file_url" not in body
 
     async def test_missing_email_returns_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         inputs = {
             "title": "Test",
             "file_url": "https://example.com/doc.pdf",
@@ -296,7 +296,7 @@ class TestSendSignatureRequest:
         ctx.fetch.assert_not_called()
 
     async def test_missing_name_returns_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         inputs = {
             "title": "Test",
             "file_url": "https://example.com/doc.pdf",
@@ -309,7 +309,7 @@ class TestSendSignatureRequest:
         ctx.fetch.assert_not_called()
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Bad request")
 
         result = await lumin_pdf.execute_action(
@@ -323,7 +323,7 @@ class TestSendSignatureRequest:
 
 class TestGetSignatureRequest:
     async def test_returns_signature_request(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr1", "status": "pending"})
 
         result = await lumin_pdf.execute_action("get_signature_request", {"signature_request_id": "sr1"}, ctx)
@@ -337,7 +337,7 @@ class TestGetSignatureRequest:
         )
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Not found")
 
         result = await lumin_pdf.execute_action("get_signature_request", {"signature_request_id": "bad"}, ctx)
@@ -347,7 +347,7 @@ class TestGetSignatureRequest:
 
 class TestCancelSignatureRequest:
     async def test_cancels_request(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={})
 
         result = await lumin_pdf.execute_action("cancel_signature_request", {"signature_request_id": "sr1"}, ctx)
@@ -362,7 +362,7 @@ class TestCancelSignatureRequest:
         )
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Already canceled")
 
         result = await lumin_pdf.execute_action("cancel_signature_request", {"signature_request_id": "sr1"}, ctx)
@@ -372,7 +372,7 @@ class TestCancelSignatureRequest:
 
 class TestGenerateSigningLink:
     async def test_returns_view_url(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(
             status=200, headers={}, data={"view_url": "https://sign.luminpdf.com/abc"}
         )
@@ -384,7 +384,7 @@ class TestGenerateSigningLink:
         assert result.result.data["signing_link"] == "https://sign.luminpdf.com/abc"
 
     async def test_falls_back_to_url_key(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"url": "https://sign.luminpdf.com/xyz"})
         inputs = {"signature_request_id": "sr1", "signer_email": "bob@example.com"}
 
@@ -393,7 +393,7 @@ class TestGenerateSigningLink:
         assert result.result.data["signing_link"] == "https://sign.luminpdf.com/xyz"
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Forbidden")
 
         result = await lumin_pdf.execute_action(
@@ -407,7 +407,7 @@ class TestGenerateSigningLink:
 
 class TestSendReminder:
     async def test_sends_reminder_with_emails(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={})
         inputs = {"signature_request_id": "sr1", "emails": ["alice@example.com"]}
 
@@ -421,7 +421,7 @@ class TestSendReminder:
     async def test_sends_without_emails_fetches_signers(self, make_context):
         from unittest.mock import AsyncMock
 
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         # First call: fetch SR to get signers. Second call: send reminder.
         ctx.fetch = AsyncMock(
             side_effect=[
@@ -443,7 +443,7 @@ class TestSendReminder:
     async def test_no_pending_signers_raises_error(self, make_context):
         from unittest.mock import AsyncMock
 
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch = AsyncMock(
             side_effect=[
                 FetchResponse(
@@ -460,7 +460,7 @@ class TestSendReminder:
         assert "No pending signers" in result.result.message
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Timeout")
 
         result = await lumin_pdf.execute_action("send_reminder", {"signature_request_id": "sr1"}, ctx)
@@ -473,7 +473,7 @@ class TestSendReminder:
 
 class TestSendFromTemplate:
     async def test_send_with_required_fields(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr1", "status": "pending"})
         inputs = {
             "template_id": "tpl1",
@@ -491,7 +491,7 @@ class TestSendFromTemplate:
         assert "expires_at" in body
 
     async def test_send_with_optional_fields(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr2"})
         inputs = {
             "template_id": "tpl1",
@@ -510,7 +510,7 @@ class TestSendFromTemplate:
         assert body["fields"] == {"date": "2026-01-01"}
 
     async def test_normalizes_email_to_email_address(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr5"})
         inputs = {
             "template_id": "tpl1",
@@ -526,7 +526,7 @@ class TestSendFromTemplate:
         assert body["signers"][0]["signer_role"] == "Employee"
 
     async def test_role_alias_mapped_to_signer_role(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr6"})
         inputs = {
             "template_id": "tpl1",
@@ -541,7 +541,7 @@ class TestSendFromTemplate:
         assert "role" not in body["signers"][0]
 
     async def test_preserves_verification_payload(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr7"})
         verification = {"type": "SMS", "phone": "+15550001234"}
         inputs = {
@@ -563,7 +563,7 @@ class TestSendFromTemplate:
         assert body["signers"][0]["verification"] == verification
 
     async def test_missing_email_returns_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         inputs = {
             "template_id": "tpl1",
             "title": "Contract",
@@ -577,7 +577,7 @@ class TestSendFromTemplate:
         ctx.fetch.assert_not_called()
 
     async def test_missing_name_returns_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         inputs = {
             "template_id": "tpl1",
             "title": "Contract",
@@ -590,7 +590,7 @@ class TestSendFromTemplate:
         ctx.fetch.assert_not_called()
 
     async def test_due_date_naive_treated_as_utc(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr3"})
         inputs = {
             "template_id": "tpl1",
@@ -606,7 +606,7 @@ class TestSendFromTemplate:
         assert body["expires_at"] == 1798675200000
 
     async def test_due_date_offset_aware_converted_correctly(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr4"})
         inputs = {
             "template_id": "tpl1",
@@ -622,7 +622,7 @@ class TestSendFromTemplate:
         assert body["expires_at"] == 1798646400000
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Bad template")
 
         result = await lumin_pdf.execute_action(
@@ -636,7 +636,7 @@ class TestSendFromTemplate:
 
 class TestUpdateSignatureRequest:
     async def test_updates_expiry(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "sr1", "expires_at": 9999999999000})
         inputs = {"signature_request_id": "sr1", "due_date": "2026-12-31T00:00:00"}
 
@@ -650,7 +650,7 @@ class TestUpdateSignatureRequest:
         assert isinstance(call.kwargs["json"]["expires_at"], int)
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Not found")
 
         result = await lumin_pdf.execute_action(
@@ -664,7 +664,7 @@ class TestUpdateSignatureRequest:
 
 class TestDownloadSignedDocument:
     async def test_returns_file_url(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(
             status=200, headers={}, data={"signed_url": "https://cdn.lumin.com/signed.pdf"}
         )
@@ -677,7 +677,7 @@ class TestDownloadSignedDocument:
         assert ctx.fetch.call_args.kwargs["headers"].get("Accept") == "application/json"
 
     async def test_custom_type(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(
             status=200, headers={}, data={"signed_url": "https://cdn.lumin.com/coc.pdf"}
         )
@@ -691,7 +691,7 @@ class TestDownloadSignedDocument:
         assert ctx.fetch.call_args.kwargs["params"] == {"type": "coc"}
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Not signed yet")
 
         result = await lumin_pdf.execute_action("download_signed_document", {"signature_request_id": "sr1"}, ctx)
@@ -701,7 +701,7 @@ class TestDownloadSignedDocument:
 
 class TestUploadDocument:
     async def test_upload_from_url(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "doc1", "name": "My Doc"})
         inputs = {"document_name": "My Doc", "file_url": "https://example.com/doc.pdf"}
 
@@ -715,7 +715,7 @@ class TestUploadDocument:
         assert body["location"] == {"type": "personal"}
 
     async def test_upload_from_template(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "doc2"})
         inputs = {"document_name": "From Template", "template_id": "tpl1", "location": "workspace"}
 
@@ -727,7 +727,7 @@ class TestUploadDocument:
         assert body["location"] == {"type": "workspace"}
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("File too large")
 
         result = await lumin_pdf.execute_action("upload_document", {"document_name": "Big File"}, ctx)
@@ -737,7 +737,7 @@ class TestUploadDocument:
 
 class TestGenerateDocumentFromTemplate:
     async def test_generates_document(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "doc1", "name": "Generated"})
         inputs = {
             "template_id": "tpl1",
@@ -756,7 +756,7 @@ class TestGenerateDocumentFromTemplate:
         assert ctx.fetch.call_args.kwargs["headers"].get("Accept") == "application/json"
 
     async def test_without_optional_fields(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "doc2"})
         inputs = {"template_id": "tpl1", "document_name": "Plain Doc"}
 
@@ -768,7 +768,7 @@ class TestGenerateDocumentFromTemplate:
         assert "variables" not in body
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Template not found")
 
         result = await lumin_pdf.execute_action(
@@ -782,7 +782,7 @@ class TestGenerateDocumentFromTemplate:
 
 class TestCreateAgreement:
     async def test_creates_agreement(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "agr1", "name": "NDA"})
         inputs = {"agreement_name": "NDA", "template_id": "tpl1"}
 
@@ -792,7 +792,7 @@ class TestCreateAgreement:
         assert result.result.data["agreement"]["id"] == "agr1"
 
     async def test_unwraps_nested_agreement_response(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         # API returns {"agreement": {"id": "agr1", ...}} — should be unwrapped
         ctx.fetch.return_value = FetchResponse(
             status=200, headers={}, data={"agreement": {"id": "agr1", "name": "NDA"}}
@@ -809,7 +809,7 @@ class TestCreateAgreement:
         assert body["agreement_data"]["template_id"] == "tpl1"
 
     async def test_with_optional_data(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(status=200, headers={}, data={"id": "agr2"})
         inputs = {
             "agreement_name": "MSA",
@@ -825,7 +825,7 @@ class TestCreateAgreement:
         assert body["agreement_data"]["fields"] == {"date": "2026-01-01"}
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Forbidden")
 
         result = await lumin_pdf.execute_action(
@@ -837,7 +837,7 @@ class TestCreateAgreement:
 
 class TestDownloadAgreement:
     async def test_returns_file_url(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.return_value = FetchResponse(
             status=200, headers={}, data={"signed_url": "https://cdn.lumin.com/agreement.pdf"}
         )
@@ -850,7 +850,7 @@ class TestDownloadAgreement:
         assert ctx.fetch.call_args.kwargs["headers"].get("Accept") == "application/json"
 
     async def test_error(self, make_context):
-        ctx = make_context(auth={"api_key": API_KEY})
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {"api_key": API_KEY}})
         ctx.fetch.side_effect = Exception("Not found")
 
         result = await lumin_pdf.execute_action("download_agreement", {"agreement_id": "bad"}, ctx)

--- a/missive/tests/test_missive_integration.py
+++ b/missive/tests/test_missive_integration.py
@@ -55,7 +55,7 @@ def live_context():
 
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
-    ctx.auth = {"api_token": API_TOKEN}
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": API_TOKEN}}
     return ctx
 
 
@@ -326,7 +326,7 @@ class TestPosts:
                     f"https://public.missiveapp.com/v1/posts/{post_id}",
                     method="DELETE",
                     headers={
-                        "Authorization": f"Bearer {live_context.auth.get('api_token', '')}",
+                        "Authorization": f"Bearer {live_context.auth['credentials'].get('api_token', '')}",
                         "Content-Type": "application/json",
                     },
                 )
@@ -415,7 +415,7 @@ class TestContacts:
                 f"https://public.missiveapp.com/v1/contacts/{contact_id}",
                 method="DELETE",
                 headers={
-                    "Authorization": f"Bearer {live_context.auth.get('api_token', '')}",
+                    "Authorization": f"Bearer {live_context.auth['credentials'].get('api_token', '')}",
                     "Content-Type": "application/json",
                 },
             )

--- a/missive/tests/test_missive_unit.py
+++ b/missive/tests/test_missive_unit.py
@@ -29,14 +29,14 @@ def err(status=401, message="Unauthorized"):
 def make_ctx(response_data):
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(return_value=ok(response_data))
-    ctx.auth = {"api_token": "test_token"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": "test_token"}}  # nosec B105
     return ctx
 
 
 def make_err_ctx(status, message):
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(return_value=err(status, message))
-    ctx.auth = {"api_token": "test_token"}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_token": "test_token"}}  # nosec B105
     return ctx
 
 

--- a/nzbn/tests/context.py
+++ b/nzbn/tests/context.py
@@ -5,4 +5,4 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))
 
-from nzbn import nzbn
+from nzbn import nzbn  # noqa: F401 — re-exported for test modules

--- a/nzbn/tests/test_nzbn.py
+++ b/nzbn/tests/test_nzbn.py
@@ -20,7 +20,7 @@ from context import nzbn
 from autohive_integrations_sdk import ExecutionContext
 
 
-TEST_AUTH = {"credentials": {}}
+TEST_AUTH = {"auth_type": "Custom", "credentials": {}}
 
 TEST_NZBN = "9429041525746"
 

--- a/nzbn/tests/test_nzbn_unit.py
+++ b/nzbn/tests/test_nzbn_unit.py
@@ -33,7 +33,7 @@ TEST_NZBN = "9429041525746"
 def mock_context():
     """Create a mock ExecutionContext."""
     context = MagicMock()
-    context.auth = {"credentials": {}}
+    context.auth = {"auth_type": "Custom", "credentials": {}}
     context.fetch = AsyncMock()
     return context
 

--- a/projectworks/tests/conftest.py
+++ b/projectworks/tests/conftest.py
@@ -11,11 +11,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.fixture
 def mock_context():
-    """Mock ExecutionContext pre-loaded with ProjectWorks custom-auth credentials."""
+    """Mock ExecutionContext pre-loaded with Projectworks custom-auth credentials."""
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
-        "consumer_key": "test_consumer_key",  # nosec B105
-        "consumer_secret": "test_consumer_secret",  # nosec B105
+        "auth_type": "Custom",
+        "credentials": {
+            "consumer_key": "test_consumer_key",  # nosec B105
+            "consumer_secret": "test_consumer_secret",  # nosec B105
+        },
     }
     return ctx

--- a/projectworks/tests/test_projectworks_integration.py
+++ b/projectworks/tests/test_projectworks_integration.py
@@ -60,7 +60,10 @@ def live_context(env_credentials):
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(side_effect=real_fetch)
     # Custom auth — the action handler builds the Basic auth header from this.
-    ctx.auth = {"consumer_key": consumer_key, "consumer_secret": consumer_secret}
+    ctx.auth = {
+        "auth_type": "Custom",
+        "credentials": {"consumer_key": consumer_key, "consumer_secret": consumer_secret},
+    }
     return ctx
 
 

--- a/projectworks/tests/test_projectworks_unit.py
+++ b/projectworks/tests/test_projectworks_unit.py
@@ -21,20 +21,13 @@ def ok(data):
 
 
 class TestGetHeaders:
-    def test_basic_auth_header_from_flat_auth(self):
+    def test_basic_auth_header_from_credentials(self):
         ctx = type("Ctx", (), {})()
-        ctx.auth = {"consumer_key": "key123", "consumer_secret": "secret456"}  # nosec B105
+        ctx.auth = {"auth_type": "Custom", "credentials": {"consumer_key": "key123", "consumer_secret": "secret456"}}  # nosec B105
         headers = _get_headers(ctx)
         expected = base64.b64encode(b"key123:secret456").decode()
         assert headers["Authorization"] == f"Basic {expected}"
         assert headers["Accept"] == "application/json"
-
-    def test_basic_auth_header_from_nested_credentials(self):
-        ctx = type("Ctx", (), {})()
-        ctx.auth = {"credentials": {"consumer_key": "k", "consumer_secret": "s"}}  # nosec B105
-        headers = _get_headers(ctx)
-        expected = base64.b64encode(b"k:s").decode()
-        assert headers["Authorization"] == f"Basic {expected}"
 
     def test_missing_credentials_raise(self):
         ctx = type("Ctx", (), {})()
@@ -44,15 +37,25 @@ class TestGetHeaders:
 
     def test_blank_credentials_raise(self):
         ctx = type("Ctx", (), {})()
-        ctx.auth = {"consumer_key": "key123", "consumer_secret": ""}  # nosec B105
+        ctx.auth = {"auth_type": "Custom", "credentials": {"consumer_key": "key123", "consumer_secret": ""}}  # nosec B105
         with pytest.raises(ValueError, match="Consumer Key and Consumer Secret are required"):
             _get_headers(ctx)
 
     @pytest.mark.asyncio
-    async def test_action_surfaces_missing_credential_error(self, mock_context):
+    async def test_action_surfaces_blank_credential_error(self, mock_context):
         # The runtime guard should reach the caller as a clear ActionError,
         # not an unauthenticated request.
-        mock_context.auth = {}
+        mock_context.auth = {"auth_type": "Custom", "credentials": {"consumer_key": "key123", "consumer_secret": ""}}  # nosec B105
+        result = await projectworks.execute_action("list_users", {}, mock_context)
+        assert result.type == ResultType.ACTION_ERROR
+        assert "Consumer Key and Consumer Secret are required" in result.result.message
+        mock_context.fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_action_surfaces_missing_credential_error(self, mock_context):
+        # Missing credential keys are caught by the handler's runtime guard
+        # (the config declares no auth.fields.required).
+        mock_context.auth = {"auth_type": "Custom", "credentials": {}}
         result = await projectworks.execute_action("list_users", {}, mock_context)
         assert result.type == ResultType.ACTION_ERROR
         assert "Consumer Key and Consumer Secret are required" in result.result.message

--- a/rss-reader-feedparser-ah-fetch/config.json
+++ b/rss-reader-feedparser-ah-fetch/config.json
@@ -1,6 +1,6 @@
 {
     "name": "RSS Reader using Feedseeker and authoive-integration-sdk's fetch",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "An integration for reading RSS feeds using Feedseeker and authoive-integration-sdk's fetch",
     "entry_point": "rss_reader.py",
     "auth": {

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -7,11 +7,6 @@ import feedparser
 rss_reader = Integration.load()
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def build_http_basic_auth_url(url: str, user_name: str, password: str) -> str:
     """
     Build a URL with HTTP basic authentication.
@@ -43,7 +38,7 @@ class GetFeedAction(ActionHandler):
         feed_url = inputs["feed_url"]
         limit = inputs.get("limit", 10)
 
-        creds = _credentials(context)
+        creds = context.auth["credentials"]
         user_name = creds.get("user_name")
         password = creds.get("password")
         api_token = creds.get("api_token")

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -1,10 +1,15 @@
 # rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler
+from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
 from typing import Dict, Any
 import feedparser
 
 # Create the integration using the config.json
 rss_reader = Integration.load()
+
+
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
 
 
 def build_http_basic_auth_url(url: str, user_name: str, password: str) -> str:
@@ -38,9 +43,10 @@ class GetFeedAction(ActionHandler):
         feed_url = inputs["feed_url"]
         limit = inputs.get("limit", 10)
 
-        user_name = context.auth.get("user_name")
-        password = context.auth.get("password")
-        api_token = context.auth.get("api_token")
+        creds = _credentials(context)
+        user_name = creds.get("user_name")
+        password = creds.get("password")
+        api_token = creds.get("api_token")
 
         # Determine authentication method based on available credentials
         # Variables nned to hold None if keys are missing by using .get() before this block
@@ -76,4 +82,6 @@ class GetFeedAction(ActionHandler):
                 }
             )
 
-        return {"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        return ActionResult(
+            data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
+        )

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -62,7 +62,8 @@ class GetFeedAction(ActionHandler):
             # No authentication provided or required
             response = await context.fetch(feed_url)
 
-        # Parse feed
+        # Parse feed; on the pinned SDK 1.x fetch() returns the response body
+        # directly (2.x+ wraps it in FetchResponse.data).
         feed = feedparser.parse(response)
 
         # Check for parsing errors

--- a/rss-reader-feedparser-ah-fetch/tests/context.py
+++ b/rss-reader-feedparser-ah-fetch/tests/context.py
@@ -6,4 +6,4 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../dependencies")))
 
-from rss_reader import rss_reader
+from rss_reader import rss_reader  # noqa: F401 — re-exported for test modules

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader.py
@@ -10,13 +10,17 @@ async def test_get_feed():
 
     # Uncomment this to use HTTP Basic Authentication
     auth = {
-        "user_name": "test_user",
-        "password": "test_password",  # nosec B105
+        "auth_type": "Custom",
+        "credentials": {
+            "user_name": "test_user",
+            "password": "test_password",  # nosec B105
+        },
     }
 
     # Uncomment this to use API token authentication
     # auth = {
-    #    "api_token": "test_api_token"
+    #    "auth_type": "Custom",
+    #    "credentials": {"api_token": "test_api_token"},
     # }
 
     # Define test configuration

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -33,11 +33,9 @@ SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-async def test_get_feed_reads_wrapped_credentials(make_context):
-    """Production sends the wrapped Custom auth envelope; the handler must
-    read basic-auth credentials from context.auth["credentials"], not from
-    the top-level auth dict.
-    """
+async def test_get_feed(make_context):
+    """get_feed with HTTP basic auth: parses the feed and bakes the
+    credentials into the fetched URL."""
     ctx = make_context(
         auth={
             "auth_type": "Custom",

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for the RSS Reader integration using mocked fetch.
+
+Run with:
+    pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py -m unit
+"""
+
+import os
+import sys
+
+import pytest
+from autohive_integrations_sdk import ResultType
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from rss_reader import rss_reader  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Entry One</title>
+      <link>https://example.com/1</link>
+      <description>First entry</description>
+      <published>2025-01-01T00:00:00Z</published>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+async def test_get_feed_reads_wrapped_credentials(make_context):
+    """Production sends the wrapped Custom auth envelope; the handler must
+    read basic-auth credentials from context.auth["credentials"], not from
+    the top-level auth dict.
+    """
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"user_name": "test_user", "password": "test_password"},
+        }
+    )
+    ctx.fetch.return_value = SAMPLE_FEED
+    result = await rss_reader.execute_action(
+        "get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx
+    )
+    assert result.type == ResultType.ACTION
+    data = result.result.data
+    assert data["feed_title"] == "Test Feed"
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["title"] == "Entry One"
+    # Basic-auth credentials should have been baked into the fetched URL.
+    fetched_url = ctx.fetch.call_args.args[0]
+    assert "test_user:test_password@" in fetched_url

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -41,14 +41,12 @@ async def test_get_feed_reads_wrapped_credentials(make_context):
     ctx = make_context(
         auth={
             "auth_type": "Custom",
-            "credentials": {"user_name": "test_user", "password": "test_password"},
+            "credentials": {"user_name": "test_user", "password": "test_password"},  # nosec B105
         }
     )
     # Pinned SDK 1.x fetch() returns the body directly, not a FetchResponse.
     ctx.fetch.return_value = SAMPLE_FEED
-    result = await rss_reader.execute_action(
-        "get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx
-    )
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx)
     assert result.type == ResultType.ACTION
     data = result.result.data
     assert data["feed_title"] == "Test Feed"

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -44,6 +44,7 @@ async def test_get_feed_reads_wrapped_credentials(make_context):
             "credentials": {"user_name": "test_user", "password": "test_password"},
         }
     )
+    # Pinned SDK 1.x fetch() returns the body directly, not a FetchResponse.
     ctx.fetch.return_value = SAMPLE_FEED
     result = await rss_reader.execute_action(
         "get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx

--- a/supabase/config.json
+++ b/supabase/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Supabase",
   "display_name": "Supabase",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Integration with Supabase for database operations, storage, and authentication management",
   "entry_point": "supabase.py",
   "auth": {

--- a/supabase/supabase.py
+++ b/supabase/supabase.py
@@ -10,13 +10,8 @@ from typing import Dict, Any
 supabase = Integration.load()
 
 
-def _credentials(context: ExecutionContext) -> Dict[str, Any]:
-    auth = context.auth or {}
-    return auth.get("credentials", auth)
-
-
 def get_headers(context: ExecutionContext) -> Dict[str, str]:
-    service_role_secret = _credentials(context).get("service_role_secret", "")
+    service_role_secret = context.auth["credentials"].get("service_role_secret", "")
     return {
         "apikey": service_role_secret,
         "Authorization": f"Bearer {service_role_secret}",
@@ -26,7 +21,7 @@ def get_headers(context: ExecutionContext) -> Dict[str, str]:
 
 
 def get_base_url(context: ExecutionContext) -> str:
-    return _credentials(context).get("host", "").rstrip("/")
+    return context.auth["credentials"].get("host", "").rstrip("/")
 
 
 # ---- Database (PostgREST) Handlers ----

--- a/supabase/supabase.py
+++ b/supabase/supabase.py
@@ -10,8 +10,13 @@ from typing import Dict, Any
 supabase = Integration.load()
 
 
+def _credentials(context: ExecutionContext) -> Dict[str, Any]:
+    auth = context.auth or {}
+    return auth.get("credentials", auth)
+
+
 def get_headers(context: ExecutionContext) -> Dict[str, str]:
-    service_role_secret = context.auth.get("service_role_secret", "")
+    service_role_secret = _credentials(context).get("service_role_secret", "")
     return {
         "apikey": service_role_secret,
         "Authorization": f"Bearer {service_role_secret}",
@@ -21,7 +26,7 @@ def get_headers(context: ExecutionContext) -> Dict[str, str]:
 
 
 def get_base_url(context: ExecutionContext) -> str:
-    return context.auth.get("host", "").rstrip("/")
+    return _credentials(context).get("host", "").rstrip("/")
 
 
 # ---- Database (PostgREST) Handlers ----

--- a/supabase/tests/conftest.py
+++ b/supabase/tests/conftest.py
@@ -1,15 +1,17 @@
 import pytest
+from unittest.mock import MagicMock, AsyncMock
+from autohive_integrations_sdk import ExecutionContext
 
 
 @pytest.fixture
-def mock_context(make_context):
-    """Mock execution context with the wrapped Custom auth envelope Supabase expects."""
-    return make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {
-                "host": "https://test.supabase.co",
-                "service_role_secret": "test-service-role-secret",  # nosec B105
-            },
-        }
-    )
+def mock_context():
+    ctx = MagicMock(spec=ExecutionContext)
+    ctx.fetch = AsyncMock()
+    ctx.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "host": "https://test.supabase.co",
+            "service_role_secret": "test-service-role-secret",  # nosec B105
+        },
+    }
+    return ctx

--- a/supabase/tests/conftest.py
+++ b/supabase/tests/conftest.py
@@ -2,16 +2,14 @@ import pytest
 
 
 @pytest.fixture
-def mock_context(make_custom_auth_context):
-    """Mock execution context with the wrapped Custom auth envelope Supabase expects.
-
-    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
-    not make the real ``credentials`` property available; set it explicitly to
-    the unwrapped credentials dict.
-    """
-    credentials = {
-        "host": "https://test.supabase.co",
-        "service_role_secret": "test-service-role-secret",  # nosec B105
-    }
-    ctx = make_custom_auth_context(credentials)
-    return ctx
+def mock_context(make_context):
+    """Mock execution context with the wrapped Custom auth envelope Supabase expects."""
+    return make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {
+                "host": "https://test.supabase.co",
+                "service_role_secret": "test-service-role-secret",  # nosec B105
+            },
+        }
+    )

--- a/supabase/tests/conftest.py
+++ b/supabase/tests/conftest.py
@@ -1,14 +1,17 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
-from autohive_integrations_sdk import ExecutionContext
 
 
 @pytest.fixture
-def mock_context():
-    ctx = MagicMock(spec=ExecutionContext)
-    ctx.fetch = AsyncMock()
-    ctx.auth = {
+def mock_context(make_custom_auth_context):
+    """Mock execution context with the wrapped Custom auth envelope Supabase expects.
+
+    MagicMock attributes don't share state, so setting ``ctx.auth`` alone does
+    not make the real ``credentials`` property available; set it explicitly to
+    the unwrapped credentials dict.
+    """
+    credentials = {
         "host": "https://test.supabase.co",
         "service_role_secret": "test-service-role-secret",  # nosec B105
     }
+    ctx = make_custom_auth_context(credentials)
     return ctx

--- a/supabase/tests/test_supabase_integration.py
+++ b/supabase/tests/test_supabase_integration.py
@@ -74,7 +74,12 @@ def live_context(make_context):
 
                 return FetchResponse(status=resp.status, headers=dict(resp.headers), data=data)
 
-    ctx = make_context(auth={"host": SUPABASE_URL, "service_role_secret": service_role_key})
+    ctx = make_context(
+        auth={
+            "auth_type": "Custom",
+            "credentials": {"host": SUPABASE_URL, "service_role_secret": service_role_key},
+        }
+    )
     ctx.fetch.side_effect = real_fetch
     return ctx
 

--- a/supabase/tests/test_supabase_unit.py
+++ b/supabase/tests/test_supabase_unit.py
@@ -202,22 +202,3 @@ async def test_delete_user(mock_context):
     result = await supabase.execute_action("delete_user", {"user_id": "user-uuid"}, mock_context)
     assert result.type == ResultType.ACTION
     assert result.result.data["deleted"] is True
-
-
-# ---- Wrapped Auth Envelope ----
-
-
-@pytest.mark.asyncio
-async def test_select_records_wrapped_auth(mock_context):
-    mock_context.auth = {
-        "auth_type": "Custom",
-        "credentials": {
-            "host": "https://test.supabase.co",
-            "service_role_secret": "test-service-role-secret",  # nosec B105
-        },
-    }
-    mock_context.fetch = AsyncMock(return_value=MagicMock(data=[{"id": 1, "name": "Alice"}]))
-    result = await supabase.execute_action("select_records", {"table": "users"}, mock_context)
-    assert result.type == ResultType.ACTION
-    assert result.result.data["records"] == [{"id": 1, "name": "Alice"}]
-    assert result.result.data["count"] == 1

--- a/supabase/tests/test_supabase_unit.py
+++ b/supabase/tests/test_supabase_unit.py
@@ -202,3 +202,22 @@ async def test_delete_user(mock_context):
     result = await supabase.execute_action("delete_user", {"user_id": "user-uuid"}, mock_context)
     assert result.type == ResultType.ACTION
     assert result.result.data["deleted"] is True
+
+
+# ---- Wrapped Auth Envelope ----
+
+
+@pytest.mark.asyncio
+async def test_select_records_wrapped_auth(mock_context):
+    mock_context.auth = {
+        "auth_type": "Custom",
+        "credentials": {
+            "host": "https://test.supabase.co",
+            "service_role_secret": "test-service-role-secret",  # nosec B105
+        },
+    }
+    mock_context.fetch = AsyncMock(return_value=MagicMock(data=[{"id": 1, "name": "Alice"}]))
+    result = await supabase.execute_action("select_records", {"table": "users"}, mock_context)
+    assert result.type == ResultType.ACTION
+    assert result.result.data["records"] == [{"id": 1, "name": "Alice"}]
+    assert result.result.data["count"] == 1

--- a/supadata/tests/conftest.py
+++ b/supadata/tests/conftest.py
@@ -28,5 +28,5 @@ def mock_context() -> MagicMock:
     """Mock ExecutionContext pre-loaded with a Supadata API key."""
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
-    ctx.auth = {"credentials": {"api_key": "test_api_key"}}  # nosec B105
+    ctx.auth = {"auth_type": "Custom", "credentials": {"api_key": "test_api_key"}}  # nosec B105
     return ctx

--- a/supadata/tests/test_supadata_integration.py
+++ b/supadata/tests/test_supadata_integration.py
@@ -26,7 +26,7 @@ def live_context(env_credentials, make_context):
     api_key = env_credentials("SUPADATA_API_KEY")
     if not api_key:
         pytest.skip("SUPADATA_API_KEY not set — skipping live integration tests")
-    return make_context(auth={"credentials": {"api_key": api_key}})
+    return make_context(auth={"auth_type": "Custom", "credentials": {"api_key": api_key}})
 
 
 @pytest.mark.asyncio

--- a/supadata/tests/test_supadata_unit.py
+++ b/supadata/tests/test_supadata_unit.py
@@ -220,7 +220,7 @@ class TestGetTranscript:
         empty string so the upstream 401 is caught cleanly and converted to
         ``ActionError`` like any other auth failure.
         """
-        ctx = make_context(auth={})  # No credentials at all.
+        ctx = make_context(auth={"auth_type": "Custom", "credentials": {}})  # No credential fields at all.
 
         with patch("supadata_transcribe.Supadata") as MockSupadata:
             MockSupadata.return_value.transcript.side_effect = SupadataError(

--- a/toggl/tests/conftest.py
+++ b/toggl/tests/conftest.py
@@ -22,7 +22,7 @@ def toggl_context():
     api_token = _get_env("TOGGL_API_TOKEN")
     if not api_token:
         pytest.skip("TOGGL_API_TOKEN not set — skipping integration tests")
-    return ExecutionContext(auth={"credentials": {"api_token": api_token}})
+    return ExecutionContext(auth={"auth_type": "Custom", "credentials": {"api_token": api_token}})
 
 
 @pytest.fixture

--- a/toggl/tests/test_toggl_unit.py
+++ b/toggl/tests/test_toggl_unit.py
@@ -25,6 +25,7 @@ def mock_context():
     ctx = MagicMock(name="ExecutionContext")
     ctx.fetch = AsyncMock(name="fetch")
     ctx.auth = {
+        "auth_type": "Custom",
         "credentials": {
             "api_token": "test_api_token_123",  # nosec B105
         },
@@ -102,7 +103,7 @@ class TestCreateTimeEntry:
         assert "Connection refused" in result.result.message
 
     async def test_missing_api_token_returns_action_error(self, mock_context):
-        mock_context.auth = {"credentials": {"api_token": ""}}  # nosec B105
+        mock_context.auth = {"auth_type": "Custom", "credentials": {"api_token": ""}}  # nosec B105
 
         result = await toggl.execute_action(
             "create_time_entry",
@@ -114,7 +115,7 @@ class TestCreateTimeEntry:
         assert "api_token" in result.result.message
 
     async def test_missing_credentials_returns_action_error(self, mock_context):
-        mock_context.auth = {}
+        mock_context.auth = {"auth_type": "Custom", "credentials": {}}
 
         result = await toggl.execute_action(
             "create_time_entry",

--- a/trello/tests/test_trello_unit.py
+++ b/trello/tests/test_trello_unit.py
@@ -52,7 +52,7 @@ from trello.trello import (  # noqa: E402
 pytestmark = pytest.mark.unit
 
 
-AUTH = {"auth_type": "custom", "credentials": {"api_key": "k", "token": "t"}}  # nosec B105
+AUTH = {"auth_type": "Custom", "credentials": {"api_key": "k", "token": "t"}}  # nosec B105
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "config.json")
 


### PR DESCRIPTION
### Description :memo:
- **Purpose**: Prepares the remaining custom-auth integrations' test suites for SDK 2.0.1 (integrations-sdk #51). Their handlers already read wrapped credentials correctly, but their unit tests construct flat auth dicts — under 2.0.1's strict envelope validation those tests fail the moment an integration is rebuilt. Migrating the tests now, while the wrapped shape also passes on the current SDK 2.0.0, means the 2.0.1 release needs no coordinated test scramble.
- **Approach**: Test files only, held to a minimal-diff standard: each file keeps its construction style from master, with the auth dict changed to the wrapped `{"auth_type": "Custom", "credentials": {...}}` envelope written literally at each site. No shared fixtures, no helper indirection, no handler/config/pin changes.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: 17 integrations' test suites migrated: active-campaign, app-business-reviews, aws, circle, coda, elevenlabs, fergus, float, google-looker, humanitix, lumin-pdf, missive, nzbn, projectworks, supadata, toggl, trello
:point_right: Missing-credential tests assert the handler-guard `ACTION_ERROR` behavior, identical on SDK 2.0.0 and 2.0.1 (configs declare no `auth.fields.required`)
:point_right: trello: fixes `"auth_type": "custom"` casing to the `AuthType` enum's `"Custom"` (the lowercase value fails 2.0.1's enum check)
:point_right: `humanitix/actions/__init__.py` gains an `__all__` declaring its re-exports (pre-existing lint failure surfaced by directory-wide CI linting)

**Scope notes**

- The five SDK 1.x-pinned integrations (grammarly, heartbeat, retail-express, both rss-readers) are excluded: `~=1.0.2` never resolves to 2.0.1, and their tests target 1.x fetch semantics.
- Stacked on #405 (whose four suites are already envelope-shaped); after both merge, those are the only flat suites left anywhere.

### Test plan :test_tube:
- All 21 custom-auth suites on this branch (17 here + 4 from #405) pass against the published SDK 2.0.0: 921 passed, 0 failed
- Identical results against the strict 2.0.1 build (integrations-sdk `release/2.0.1`): 921 passed, 0 failed
- CI-parity checks run locally: ruff (incl. E501), ruff format, bandit — clean

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)