### PR TITLE
docs(rss-reader-feedparser): mark legacy integration unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository hosts Autohive integrations made and maintained by the Autohive 
 
 ### RSS Reader 
 
-[rss-reader-feedparser](rss-reader-feedparser): Reads RSS feeds using the `feedparser` library. Includes 1 action.
+[rss-reader-feedparser](rss-reader-feedparser): **[UNSUPPORTED]** Legacy RSS reader that reads RSS feeds using the `feedparser` library directly. Kept for reference only; use `rss-reader-feedparser-ah-fetch` for maintained RSS feed workflows. Includes 1 action.
 
 [rss-reader-feedparser-ah-fetch](rss-reader-feedparser-ah-fetch): Reads RSS feeds using `feedparser` and the `autohive-integration-sdk`'s `fetch()` method for HTTP requests. 
 

--- a/rss-reader-feedparser/README.md
+++ b/rss-reader-feedparser/README.md
@@ -1,5 +1,9 @@
 # RSS Reader Integration for Autohive using feedparser
 
+> ⚠️ **Status: Unsupported**
+>
+> This integration is **no longer supported or maintained** by the Autohive team. It is kept in the repository for reference only and is not covered by validation, CI checks, or bug-fix updates. Use [`rss-reader-feedparser-ah-fetch`](../rss-reader-feedparser-ah-fetch) for maintained RSS feed workflows that route HTTP requests through the Autohive SDK `context.fetch` layer.
+
 This integration allows Autohive to connect with RSS feeds, enabling users to fetch and process feed entries from any RSS-compatible source.
 
 ## Description
@@ -80,4 +84,4 @@ To run the tests:
 
 1.  Navigate to the integration's directory: `cd rss-reader-feedparser`
 2.  Install dependencies: `pip install -r requirements.txt -t dependencies`
-3.  Run the tests: `python tests/test_rss_reader.py` 
+3.  Run the tests: `python tests/test_rss_reader.py`


### PR DESCRIPTION
## Summary

Marks the legacy `rss-reader-feedparser` integration as unsupported while keeping the directory in place for reference.

`rss-reader-feedparser-ah-fetch` is now the recommended RSS reader integration because it routes HTTP requests through the Autohive SDK `context.fetch` layer and supports basic/Bearer auth.

## Changes

- Added a Heartbeat-style unsupported notice to `rss-reader-feedparser/README.md`
- Updated the root integration catalog to label `rss-reader-feedparser` as unsupported
- Pointed users to `rss-reader-feedparser-ah-fetch` as the maintained replacement

## Validation

- [x] `check_readme.py origin/master rss-reader-feedparser`
- [x] `git diff --check`
