### PR TITLE
fix(rss-reader): upgrade rss-reader-ah-fetch to SDK 2.0.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -234,6 +234,14 @@
 # -- Perplexity --
 # PERPLEXITY_API_KEY=
 
+# -- RSS Reader --
+# Optional - override the default public feed URL used by read-only integration tests.
+# RSS_READER_TEST_FEED_URL=
+# Optional - protected feed credentials for Basic Auth integration tests.
+# RSS_READER_BASIC_AUTH_FEED_URL=
+# RSS_READER_BASIC_AUTH_USER_NAME=
+# RSS_READER_BASIC_AUTH_PASSWORD=
+
 # -- Salesforce --
 # SALESFORCE_ACCESS_TOKEN=
 # SALESFORCE_INSTANCE_URL=

--- a/rss-reader-feedparser-ah-fetch/README.md
+++ b/rss-reader-feedparser-ah-fetch/README.md
@@ -77,8 +77,16 @@ Auth:
 
 ## Testing
 
-To run the tests:
+To run the unit tests:
 
-1.  Navigate to the integration's directory: `cd rss-reader-feedparser-ah-fetch`
-2.  Install dependencies: `pip install -r requirements.txt -t dependencies`
-3.  Run the tests: `python tests/test_rss_reader.py` 
+```bash
+pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py -m unit
+```
+
+To run the read-only end-to-end integration tests against a real public RSS feed:
+
+```bash
+pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py -m "integration and not destructive"
+```
+
+The integration tests default to `https://xkcd.com/rss.xml`. Set `RSS_READER_TEST_FEED_URL` in the root `.env` file to test a different public feed. To test a Basic Auth protected feed, also set `RSS_READER_BASIC_AUTH_FEED_URL`, `RSS_READER_BASIC_AUTH_USER_NAME`, and `RSS_READER_BASIC_AUTH_PASSWORD`.

--- a/rss-reader-feedparser-ah-fetch/config.json
+++ b/rss-reader-feedparser-ah-fetch/config.json
@@ -1,6 +1,6 @@
 {
     "name": "RSS Reader using Feedseeker and authoive-integration-sdk's fetch",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "An integration for reading RSS feeds using Feedseeker and authoive-integration-sdk's fetch",
     "entry_point": "rss_reader.py",
     "auth": {

--- a/rss-reader-feedparser-ah-fetch/requirements.txt
+++ b/rss-reader-feedparser-ah-fetch/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.1
 feedparser

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -23,17 +23,29 @@ def build_http_basic_auth_url(url: str, user_name: str, password: str) -> str:
     return f"{protocol}{user_name}:{password}@{domain_part}"
 
 
-def build_api_token_header(api_token: str) -> str:
+def build_api_token_header(api_token: str) -> Dict[str, str]:
     """
     Build a header with API token authentication.
     """
     return {"Authorization": f"Bearer {api_token}"}
 
 
+def redact_secret_values(message: str, *secrets: str | None) -> str:
+    """Remove credential values from user-facing error messages."""
+    redacted = message
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[REDACTED]")
+    return redacted
+
+
 # ---- Action Handlers ----
 @rss_reader.action("get_feed")
 class GetFeedAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
+        user_name = None
+        password = None
+        api_token = None
         try:
             feed_url = inputs["feed_url"]
             limit = inputs.get("limit", 10)
@@ -56,7 +68,7 @@ class GetFeedAction(ActionHandler):
             feed = feedparser.parse(response.data)
 
             if hasattr(feed, "bozo_exception"):
-                raise ValueError(f"Failed to parse feed [{feed_url}] with error: {feed.bozo_exception}")
+                raise ValueError(f"Failed to parse feed with error: {feed.bozo_exception}")
 
             entries = []
             for entry in feed.entries[:limit]:
@@ -78,4 +90,4 @@ class GetFeedAction(ActionHandler):
                 }
             )
         except Exception as e:
-            return ActionError(message=str(e))
+            return ActionError(message=redact_secret_values(str(e), user_name, password, api_token))

--- a/rss-reader-feedparser-ah-fetch/rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/rss_reader.py
@@ -1,7 +1,6 @@
-# rss-reader.py
-from autohive_integrations_sdk import Integration, ExecutionContext, ActionHandler, ActionResult
-from typing import Dict, Any
 import feedparser
+from autohive_integrations_sdk import ActionError, ActionHandler, ActionResult, ExecutionContext, Integration
+from typing import Any, Dict
 
 # Create the integration using the config.json
 rss_reader = Integration.load()
@@ -35,49 +34,48 @@ def build_api_token_header(api_token: str) -> str:
 @rss_reader.action("get_feed")
 class GetFeedAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
-        feed_url = inputs["feed_url"]
-        limit = inputs.get("limit", 10)
+        try:
+            feed_url = inputs["feed_url"]
+            limit = inputs.get("limit", 10)
 
-        creds = context.auth["credentials"]
-        user_name = creds.get("user_name")
-        password = creds.get("password")
-        api_token = creds.get("api_token")
+            creds = context.auth["credentials"]
+            user_name = creds.get("user_name")
+            password = creds.get("password")
+            api_token = creds.get("api_token")
 
-        # Determine authentication method based on available credentials
-        # Variables nned to hold None if keys are missing by using .get() before this block
-        if user_name and password:
-            # Use HTTP Basic Authentication via the 'auth' parameters
-            feed_url = build_http_basic_auth_url(feed_url, user_name, password)
-            response = await context.fetch(feed_url)
-        elif api_token:
-            # Use API Token Authentication via headers
-            headers = build_api_token_header(api_token)
-            response = await context.fetch(feed_url, headers=headers)
-        else:
-            # No authentication provided or required
-            response = await context.fetch(feed_url)
+            # Determine authentication method based on available credentials.
+            if user_name and password:
+                feed_url = build_http_basic_auth_url(feed_url, user_name, password)
+                response = await context.fetch(feed_url)
+            elif api_token:
+                headers = build_api_token_header(api_token)
+                response = await context.fetch(feed_url, headers=headers)
+            else:
+                response = await context.fetch(feed_url)
 
-        # Parse feed; on the pinned SDK 1.x fetch() returns the response body
-        # directly (2.x+ wraps it in FetchResponse.data).
-        feed = feedparser.parse(response)
+            feed = feedparser.parse(response.data)
 
-        # Check for parsing errors
-        if hasattr(feed, "bozo_exception"):
-            raise Exception(f"Failed to parse feed [{feed_url}] with error: {str(feed.bozo_exception)}")
+            if hasattr(feed, "bozo_exception"):
+                raise ValueError(f"Failed to parse feed [{feed_url}] with error: {feed.bozo_exception}")
 
-        # Extract entries
-        entries = []
-        for entry in feed.entries[:limit]:
-            entries.append(
-                {
-                    "title": entry.get("title", ""),
-                    "link": entry.get("link", ""),
-                    "description": entry.get("description", ""),
-                    "published": entry.get("published", ""),
-                    "author": entry.get("author", ""),
+            entries = []
+            for entry in feed.entries[:limit]:
+                entries.append(
+                    {
+                        "title": entry.get("title", ""),
+                        "link": entry.get("link", ""),
+                        "description": entry.get("description", ""),
+                        "published": entry.get("published", ""),
+                        "author": entry.get("author", ""),
+                    }
+                )
+
+            return ActionResult(
+                data={
+                    "feed_title": feed.feed.get("title", ""),
+                    "feed_link": feed.feed.get("link", ""),
+                    "entries": entries,
                 }
             )
-
-        return ActionResult(
-            data={"feed_title": feed.feed.get("title", ""), "feed_link": feed.feed.get("link", ""), "entries": entries}
-        )
+        except Exception as e:
+            return ActionError(message=str(e))

--- a/rss-reader-feedparser-ah-fetch/tests/conftest.py
+++ b/rss-reader-feedparser-ah-fetch/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader.py
@@ -3,7 +3,7 @@
 # framework for authentication.
 import asyncio
 from context import rss_reader
-from autohive_integrations_sdk import ExecutionContext
+from autohive_integrations_sdk import ExecutionContext, ResultType
 
 
 async def test_get_feed():
@@ -29,16 +29,21 @@ async def test_get_feed():
     async with ExecutionContext(auth=auth) as context:
         try:
             result = await rss_reader.execute_action("get_feed", inputs, context)
+            if result.type != ResultType.ACTION:
+                print(f"Error testing get_feed: {result.result.message}")
+                return
+
+            data = result.result.data
             print("\n=== Get Feed Results ===")
-            print(f"Feed Title: {result['feed_title']}")
-            print(f"Feed URL: {result['feed_link']}")
+            print(f"Feed Title: {data['feed_title']}")
+            print(f"Feed URL: {data['feed_link']}")
             print("\nEntries:")
-            for entry in result["entries"]:
+            for entry in data["entries"]:
                 print(f"\nTitle: {entry['title']}")
                 print(f"Link: {entry['link']}")
                 print(f"Published: {entry['published']}")
         except Exception as e:
-            print(f"Error testing get_feed: {e.message}")
+            print(f"Error testing get_feed: {e}")
 
 
 async def main():

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py
@@ -13,13 +13,10 @@ and the file naming (test_*_integration.py) is not matched by python_files.
 """
 
 import os
-import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from autohive_integrations_sdk import FetchResponse, ResultType
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from rss_reader import rss_reader
 

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py
@@ -1,0 +1,106 @@
+"""
+End-to-end integration tests for the RSS Reader integration.
+
+These tests call real RSS feed URLs. The default read-only tests use a public
+feed and require no credentials. Optional environment variables can point the
+tests at a specific public or Basic Auth protected feed.
+
+Run with:
+    pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py -m "integration and not destructive"
+
+Never runs in CI — the default pytest marker filter (-m unit) excludes these,
+and the file naming (test_*_integration.py) is not matched by python_files.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from autohive_integrations_sdk import FetchResponse, ResultType
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from rss_reader import rss_reader
+
+pytestmark = pytest.mark.integration
+
+DEFAULT_PUBLIC_FEED_URL = "https://xkcd.com/rss.xml"
+
+
+@pytest.fixture
+def live_context():
+    """Execution context wired to a real HTTP client via aiohttp."""
+    import aiohttp
+
+    async def real_fetch(url, *, method="GET", json=None, headers=None, params=None, **kwargs):
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, json=json, headers=headers, params=params) as resp:
+                data = await resp.text()
+                if resp.status >= 400:
+                    raise Exception(f"HTTP {resp.status}: {data[:200]}")
+                return FetchResponse(
+                    status=resp.status,
+                    headers=dict(resp.headers),
+                    data=data,
+                )
+
+    ctx = MagicMock(name="ExecutionContext")
+    ctx.fetch = AsyncMock(side_effect=real_fetch)
+    ctx.auth = {"auth_type": "Custom", "credentials": {}}
+    return ctx
+
+
+def public_feed_url() -> str:
+    return os.environ.get("RSS_READER_TEST_FEED_URL", DEFAULT_PUBLIC_FEED_URL)
+
+
+# ---- Read-Only Public Feed Tests ----
+
+
+class TestGetFeedPublic:
+    async def test_fetches_public_feed(self, live_context):
+        result = await rss_reader.execute_action("get_feed", {"feed_url": public_feed_url(), "limit": 3}, live_context)
+
+        assert result.type == ResultType.ACTION
+        data = result.result.data
+        assert "feed_title" in data
+        assert "feed_link" in data
+        assert "entries" in data
+        assert 0 < len(data["entries"]) <= 3
+
+        entry = data["entries"][0]
+        assert "title" in entry
+        assert "link" in entry
+        assert "description" in entry
+        assert "published" in entry
+        assert "author" in entry
+
+    async def test_respects_limit_against_public_feed(self, live_context):
+        result = await rss_reader.execute_action("get_feed", {"feed_url": public_feed_url(), "limit": 1}, live_context)
+
+        assert result.type == ResultType.ACTION
+        assert len(result.result.data["entries"]) <= 1
+
+
+# ---- Optional Basic Auth Feed Test ----
+
+
+class TestGetFeedBasicAuth:
+    async def test_fetches_basic_auth_feed_when_configured(self, live_context, env_credentials):
+        feed_url = env_credentials("RSS_READER_BASIC_AUTH_FEED_URL")
+        user_name = env_credentials("RSS_READER_BASIC_AUTH_USER_NAME")
+        password = env_credentials("RSS_READER_BASIC_AUTH_PASSWORD")
+        if not feed_url or not user_name or not password:
+            pytest.skip("RSS_READER_BASIC_AUTH_* variables not set")
+
+        live_context.auth = {
+            "auth_type": "Custom",
+            "credentials": {"user_name": user_name, "password": password},
+        }
+
+        result = await rss_reader.execute_action("get_feed", {"feed_url": feed_url, "limit": 1}, live_context)
+
+        assert result.type == ResultType.ACTION
+        assert "entries" in result.result.data
+        assert len(result.result.data["entries"]) <= 1

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -6,7 +6,7 @@ from autohive_integrations_sdk import FetchResponse, ResultType
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from rss_reader import build_api_token_header, build_http_basic_auth_url, rss_reader  # noqa: E402
+from rss_reader import build_api_token_header, build_http_basic_auth_url, redact_secret_values, rss_reader  # noqa: E402
 
 pytestmark = pytest.mark.unit
 
@@ -51,6 +51,17 @@ def test_build_http_basic_auth_url_adds_default_http_scheme():
 
 def test_build_api_token_header():
     assert build_api_token_header("test-token") == {"Authorization": "Bearer test-token"}  # nosec B105
+
+
+def test_redact_secret_values():
+    message = "Request failed for https://user:secret@example.com/feed with token test-token"
+
+    redacted = redact_secret_values(message, "user", "secret", "test-token")  # nosec B105
+
+    assert "user" not in redacted
+    assert "secret" not in redacted
+    assert "test-token" not in redacted
+    assert redacted.count("[REDACTED]") == 3
 
 
 @pytest.mark.asyncio
@@ -160,3 +171,16 @@ async def test_get_feed_returns_action_error_for_parse_failure(make_context):
 
     assert result.type == ResultType.ACTION_ERROR
     assert "Failed to parse feed" in result.result.message
+
+
+@pytest.mark.asyncio
+async def test_get_feed_parse_error_does_not_leak_basic_auth_credentials(make_context):
+    ctx = make_context(auth=custom_auth({"user_name": "test_user", "password": "test_password"}))  # nosec B105
+    ctx.fetch.return_value = feed_response("not xml")
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
+    assert result.type == ResultType.ACTION_ERROR
+    assert "Failed to parse feed" in result.result.message
+    assert "test_user" not in result.result.message
+    assert "test_password" not in result.result.message

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -1,10 +1,5 @@
-import os
-import sys
-
 import pytest
 from autohive_integrations_sdk import FetchResponse, ResultType
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from rss_reader import build_api_token_header, build_http_basic_auth_url, redact_secret_values, rss_reader  # noqa: E402
 

--- a/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
+++ b/rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py
@@ -1,19 +1,12 @@
-"""
-Unit tests for the RSS Reader integration using mocked fetch.
-
-Run with:
-    pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py -m unit
-"""
-
 import os
 import sys
 
 import pytest
-from autohive_integrations_sdk import ResultType
+from autohive_integrations_sdk import FetchResponse, ResultType
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from rss_reader import rss_reader  # noqa: E402
+from rss_reader import build_api_token_header, build_http_basic_auth_url, rss_reader  # noqa: E402
 
 pytestmark = pytest.mark.unit
 
@@ -27,29 +20,143 @@ SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
       <link>https://example.com/1</link>
       <description>First entry</description>
       <published>2025-01-01T00:00:00Z</published>
+      <author>Alice</author>
+    </item>
+    <item>
+      <title>Entry Two</title>
+      <link>https://example.com/2</link>
+      <description>Second entry</description>
+      <published>2025-01-02T00:00:00Z</published>
     </item>
   </channel>
 </rss>
 """
 
 
-async def test_get_feed(make_context):
-    """get_feed with HTTP basic auth: parses the feed and bakes the
-    credentials into the fetched URL."""
-    ctx = make_context(
-        auth={
-            "auth_type": "Custom",
-            "credentials": {"user_name": "test_user", "password": "test_password"},  # nosec B105
-        }
-    )
-    # Pinned SDK 1.x fetch() returns the body directly, not a FetchResponse.
-    ctx.fetch.return_value = SAMPLE_FEED
-    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed", "limit": 10}, ctx)
+def custom_auth(credentials: dict[str, str]) -> dict[str, object]:
+    return {"auth_type": "Custom", "credentials": credentials}
+
+
+def feed_response(data: str = SAMPLE_FEED) -> FetchResponse:
+    return FetchResponse(status=200, headers={}, data=data)
+
+
+def test_build_http_basic_auth_url_with_https():
+    assert build_http_basic_auth_url("https://example.com/feed", "user", "pass") == "https://user:pass@example.com/feed"
+
+
+def test_build_http_basic_auth_url_adds_default_http_scheme():
+    assert build_http_basic_auth_url("example.com/feed", "user", "pass") == "http://user:pass@example.com/feed"
+
+
+def test_build_api_token_header():
+    assert build_api_token_header("test-token") == {"Authorization": "Bearer test-token"}  # nosec B105
+
+
+@pytest.mark.asyncio
+async def test_get_feed_without_auth(make_context):
+    ctx = make_context(auth=custom_auth({}))
+    ctx.fetch.return_value = feed_response()
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
     assert result.type == ResultType.ACTION
-    data = result.result.data
-    assert data["feed_title"] == "Test Feed"
-    assert len(data["entries"]) == 1
-    assert data["entries"][0]["title"] == "Entry One"
-    # Basic-auth credentials should have been baked into the fetched URL.
-    fetched_url = ctx.fetch.call_args.args[0]
-    assert "test_user:test_password@" in fetched_url
+    assert result.result.data == {
+        "feed_title": "Test Feed",
+        "feed_link": "https://example.com",
+        "entries": [
+            {
+                "title": "Entry One",
+                "link": "https://example.com/1",
+                "description": "First entry",
+                "published": "2025-01-01T00:00:00Z",
+                "author": "Alice",
+            },
+            {
+                "title": "Entry Two",
+                "link": "https://example.com/2",
+                "description": "Second entry",
+                "published": "2025-01-02T00:00:00Z",
+                "author": "",
+            },
+        ],
+    }
+    ctx.fetch.assert_awaited_once_with("https://example.com/feed")
+
+
+@pytest.mark.asyncio
+async def test_get_feed_respects_limit(make_context):
+    ctx = make_context(auth=custom_auth({}))
+    ctx.fetch.return_value = feed_response()
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed", "limit": 1}, ctx)
+
+    assert result.type == ResultType.ACTION
+    assert len(result.result.data["entries"]) == 1
+    assert result.result.data["entries"][0]["title"] == "Entry One"
+
+
+@pytest.mark.asyncio
+async def test_get_feed_uses_basic_auth_url(make_context):
+    ctx = make_context(auth=custom_auth({"user_name": "test_user", "password": "test_password"}))  # nosec B105
+    ctx.fetch.return_value = feed_response()
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
+    assert result.type == ResultType.ACTION
+    ctx.fetch.assert_awaited_once_with("https://test_user:test_password@example.com/feed")
+
+
+@pytest.mark.asyncio
+async def test_get_feed_uses_bearer_token_header(make_context):
+    ctx = make_context(auth=custom_auth({"api_token": "test_token"}))  # nosec B105
+    ctx.fetch.return_value = feed_response()
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
+    assert result.type == ResultType.ACTION
+    ctx.fetch.assert_awaited_once_with(
+        "https://example.com/feed",
+        headers={"Authorization": "Bearer test_token"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_feed_prefers_basic_auth_over_bearer_token(make_context):
+    ctx = make_context(
+        auth=custom_auth(
+            {
+                "user_name": "test_user",
+                "password": "test_password",  # nosec B105
+                "api_token": "test_token",  # nosec B105
+            }
+        )
+    )
+    ctx.fetch.return_value = feed_response()
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
+    assert result.type == ResultType.ACTION
+    ctx.fetch.assert_awaited_once_with("https://test_user:test_password@example.com/feed")
+
+
+@pytest.mark.asyncio
+async def test_get_feed_returns_action_error_for_fetch_exception(make_context):
+    ctx = make_context(auth=custom_auth({}))
+    ctx.fetch.side_effect = Exception("Network error")
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
+    assert result.type == ResultType.ACTION_ERROR
+    assert "Network error" in result.result.message
+
+
+@pytest.mark.asyncio
+async def test_get_feed_returns_action_error_for_parse_failure(make_context):
+    ctx = make_context(auth=custom_auth({}))
+    ctx.fetch.return_value = feed_response("not xml")
+
+    result = await rss_reader.execute_action("get_feed", {"feed_url": "https://example.com/feed"}, ctx)
+
+    assert result.type == ResultType.ACTION_ERROR
+    assert "Failed to parse feed" in result.result.message


### PR DESCRIPTION
## Summary

Closes #407.

Modernizes the maintained RSS reader integration, `rss-reader-feedparser-ah-fetch`, for SDK 2.0.1.

## Changes

- Upgrades `rss-reader-feedparser-ah-fetch` from `autohive-integrations-sdk~=1.0.2` to `~=2.0.1`
- Bumps the integration version from `1.1.0` to `2.0.0`
- Updates the handler to parse `context.fetch(...).data` under SDK 2.x
- Returns `ActionError` for fetch and feed parsing failures
- Redacts auth credential values from user-facing error messages
- Keeps the production wrapped custom auth shape via `context.auth["credentials"]`
- Expands unit coverage for unauthenticated fetches, basic auth, bearer token auth, limits, helper functions, fetch failures, parse failures, and auth error redaction
- Adds read-only e2e integration tests against a real public RSS feed, plus an optional Basic Auth feed test driven by `.env` variables
- Updates README testing instructions and `.env.example` integration-test variables
- Updates the manual testbed to read `result.result.data`

## Validation

- [x] `validate_integration.py rss-reader-feedparser-ah-fetch`
- [x] `check_code.py rss-reader-feedparser-ah-fetch`
- [x] `run_tests.py rss-reader-feedparser-ah-fetch` — 12/12 passed, 96% coverage
- [x] `check_readme.py origin/master rss-reader-feedparser-ah-fetch`
- [x] `check_version_bump.py origin/master rss-reader-feedparser-ah-fetch`
- [x] `pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py -q` — 12 passed
- [x] `pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py -m "integration and not destructive" -q` — 2 passed, 1 skipped
- [x] `pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_unit.py rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py -m "unit or (integration and not destructive)" -q` — 14 passed, 1 skipped
- [x] `git diff --check`

### E2E test evidence

Command:

```bash
/home/kai/code/autohive/autohive-integrations/.venv/bin/python -m pytest rss-reader-feedparser-ah-fetch/tests/test_rss_reader_integration.py -m "integration and not destructive" -q
```

Output:

```text
..s                                                                      [100%]
2 passed, 1 skipped in 0.83s
```
