### PR TITLE
fix(rss-reader): make auth config hiveup compatible

### DIFF
--- a/rss-reader-atoma-ah-fetch/config.json
+++ b/rss-reader-atoma-ah-fetch/config.json
@@ -4,8 +4,9 @@
     "description": "An integration for reading RSS and Atom feeds using Atoma and the Autohive SDK fetch method.",
     "entry_point": "rss_reader.py",
     "auth": {
-        "identifier": "rss_authentication",
         "type": "custom",
+        "title": "RSS Feed Authentication",
+        "identifier": "rss_authentication",
         "fields": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary

Closes #418.

- Move the maintained RSS Atoma integration custom auth `type` discriminator before other auth fields.
- Add the required custom auth `title` field expected by the `hiveup` CLI `CustomAuthConfig` model.
- Leave the deprecated direct `rss-reader-feedparser` integration untouched.

## What was different

`rss-reader-atoma-ah-fetch/config.json` inherited the older RSS auth shape:

```json
"auth": {
  "identifier": "rss_authentication",
  "type": "custom",
  "fields": { ... }
}
```

Most working custom-auth integrations use the modern shape expected by `hiveup`:

```json
"auth": {
  "type": "custom",
  "title": "...",
  "fields": { ... }
}
```

The CLI model uses `type` as the polymorphic discriminator and `CustomAuthConfig` requires `title`, so the old shape failed while parsing `config.json` before dependency bundling started.

## Validation

```bash
./.venv/bin/python ../autohive-integrations-tooling/scripts/validate_integration.py rss-reader-atoma-ah-fetch
# passed

./.venv/bin/python ../autohive-integrations-tooling/scripts/check_code.py rss-reader-atoma-ah-fetch
# passed
```

Full package check via the sibling CLI source:

```bash
PATH="$PWD/.venv/bin:$PATH" DOTNET_ROLL_FORWARD=Major dotnet run --project ../autohive-integrations-cli/Autohive.Integrations.Cli/Autohive.Integrations.Cli.csproj -- package rss-reader-atoma-ah-fetch
# passed; created package and bundled 556 dependency files
```

Note: this workspace only has .NET 10 installed while the CLI targets .NET 9, so `DOTNET_ROLL_FORWARD=Major` was needed locally to run the sibling CLI source.