### PR TITLE
docs(float): document FLOAT_APP_NAME and FLOAT_CONTACT_EMAIL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,9 @@
 
 # -- Float --
 # FLOAT_API_KEY=
+# Optional — defaults to "Autohive Float Integration" and "" respectively if unset.
+# FLOAT_APP_NAME=
+# FLOAT_CONTACT_EMAIL=
 
 # -- Freshdesk --
 # FRESHDESK_API_KEY=


### PR DESCRIPTION
## Summary
- Follow-up to #350 per TheRealAgentK's review comment: `.env.example` was missing env vars used in the Float e2e integration tests.
- `float/tests/test_float_integration.py` reads `FLOAT_APP_NAME` and `FLOAT_CONTACT_EMAIL` via `os.environ.get()` (both optional, with defaults), but only `FLOAT_API_KEY` was documented in the root `.env.example`.

## Changes
- `.env.example` — added `FLOAT_APP_NAME` and `FLOAT_CONTACT_EMAIL` under the Float section with a note on their defaults.

## Test plan
- [x] Confirmed these are the only Float env vars referenced anywhere in `float/` (`grep -rn "FLOAT_" --include="*.py"`)
- [x] Diff against `origin/master` is a clean 3-line addition, no conflicts