### PR TITLE
chore(asana): verify current integration CI behavior

### DIFF
--- a/asana/README.md
+++ b/asana/README.md
@@ -1,5 +1,7 @@
 # Asana Integration for Autohive
 
+<!-- Temporary CI smoke test for #425; no integration behavior is changed. -->
+
 Connects Autohive to the Asana API to enable task management, project organization, workspace collaboration, and team productivity automation.
 
 ## Description

--- a/asana/config.json
+++ b/asana/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Asana",
     "display_name": "Asana",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Asana integration for managing tasks, projects, workspaces, and team collaboration",
     "entry_point": "asana.py",
     "auth": {


### PR DESCRIPTION
## Purpose

Temporary, runtime-no-op PR to observe the real CI result for Asana using the public repository workflow and its floating `autohive-integrations-tooling@v2` reference.

Relates to #425. **This PR is not intended to be merged.** It will be closed after the CI result is recorded.

## Changes

- Adds an invisible README comment so Asana is selected as a changed integration.
- Bumps the patch version from `2.0.0` to `2.0.1` only to satisfy/isolate the existing version-bump check.
- Makes no runtime, dependency, action, authentication, or test behavior changes.

## What this tests

The local fixed-snapshot comparison predicts that released `v2` CI will reject Asana because the legacy structure validator requires `tests/context.py`, while Asana follows the current SDK-aligned model with `tests/conftest.py`. The rewritten Python HiveUp validation passes Asana and does not require the obsolete helper.

## Local validation

- `validate_integration.py asana`: passed with existing warnings for SDK 2.0.0 and potentially unused `users:read` scope.
- `check_code.py asana`: passed.
- `git diff --check`: passed.

## Author commitment applicability

This is a temporary CI smoke test rather than an integration implementation. No API behavior or production integration code has changed.