### PR TITLE
fix(github): handle directory paths in get_file_content

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -14,7 +14,7 @@ This integration provides complete access to GitHub's REST API (v2022-11-28), al
 - **Commit Operations**: Access commit history and details
 - **Branch Management**: Create, delete, and manage branches
 - **Webhook Integration**: Set up automated workflows with webhooks
-- **File Operations**: Read, create, update, and delete files directly in repositories
+- **File Operations**: Read, create, update, and delete files directly in repositories, and browse directory listings
 - **Gist Management**: Create and manage code snippets
 - **Rate Limiting**: Built-in rate limit monitoring and handling
 
@@ -501,18 +501,25 @@ Deletes a webhook from a repository.
 
 #### `get_file_content`
 
-Retrieves the content of a file from a repository.
+Retrieves the content of a file from a repository, or lists the entries of a directory when `path` points to a folder. GitHub's contents endpoint returns a single object for a file and an array for a directory, and this action handles both shapes.
 
 **Inputs:**
 - `owner` (string, required): Repository owner
 - `repo` (string, required): Repository name
-- `path` (string, required): File path in repository (e.g., 'src/main.py')
+- `path` (string, required): File path (e.g., 'src/main.py') or directory path (e.g., 'src') to list its entries
 - `ref` (string, optional): Branch, tag, or commit SHA (defaults to default branch)
 
 **Outputs:**
-- `content` (string): Decoded file content
-- `sha` (string): File SHA for updates
+- `type` (string): `file` for a single file, `dir` for a directory listing
+- `content` (string): Decoded file content. Empty string when `path` is a directory
+- `sha` (string): File SHA for updates. Empty string when `path` is a directory
+- `size` (integer): File size in bytes. `0` when `path` is a directory
+- `name` (string): File or directory name
+- `path` (string): Full path of the file or directory
+- `entries` (array): Directory entries when `path` is a directory, empty for a single file. Each entry has `name`, `path`, `type` (`file` or `dir`), `sha`, `size`, and `download_url`
 - `result` (boolean): Operation success status
+
+**Browsing a repository tree:** point `path` at a directory to get its immediate children, then call the action again with a child's `path` to walk deeper. Use `''` or the repo root path to list the top level.
 
 #### `create_file`
 
@@ -731,6 +738,14 @@ Common error scenarios:
     "inputs": {
       "owner": "myorg",
       "repo": "config-repo",
+      "path": "config"
+    }
+  },
+  {
+    "action": "get_file_content",
+    "inputs": {
+      "owner": "myorg",
+      "repo": "config-repo",
       "path": "config/production.json"
     }
   },
@@ -795,6 +810,10 @@ For integration issues or questions:
 - Contact Autohive support for platform-related issues
 
 ## Version History
+
+- **2.6.0**
+  - `get_file_content` now handles directory paths, returning a `type` field and an `entries` array instead of failing on GitHub's array response shape
+  - Added `type` and `entries` to the `get_file_content` output schema
 
 - **1.0.0** (Initial Release)
   - Complete GitHub REST API integration

--- a/github/config.json
+++ b/github/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GitHub",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GitHub API integration for complete repository management including CRUD operations for repos, branches, issues, PRs, files, and more.",
   "display_name": "GitHub",
   "supports_connected_account": true,
@@ -2398,7 +2398,7 @@
     },
     "get_file_content": {
       "display_name": "Get File Content",
-      "description": "Get file content from repository",
+      "description": "Get the content of a file in a repository, or list the entries of a directory when path points to a folder. When path is a directory, 'type' is 'dir', 'content' is empty, and 'entries' holds the files and subfolders.",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -2412,7 +2412,7 @@
           },
           "path": {
             "type": "string",
-            "description": "File path"
+            "description": "File path, or directory path to list its entries"
           },
           "ref": {
             "type": "string",
@@ -2428,8 +2428,13 @@
       "output_schema": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "description": "'file' for a single file, 'dir' for a directory listing"
+          },
           "content": {
-            "type": "string"
+            "type": "string",
+            "description": "Decoded file content. Empty when path is a directory."
           },
           "sha": {
             "type": "string"
@@ -2442,6 +2447,34 @@
           },
           "path": {
             "type": "string"
+          },
+          "entries": {
+            "type": "array",
+            "description": "Directory entries when path is a directory. Empty for a single file.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "'file' or 'dir'"
+                },
+                "sha": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "download_url": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/github/github.py
+++ b/github/github.py
@@ -789,7 +789,7 @@ class GitHubAPI:
     async def get_file_content(
         context: ExecutionContext, owner: str, repo: str, path: str, ref: str = None
     ) -> Dict[str, Any]:
-        """Get file content from repository"""
+        """Get file content from repository, or a directory listing when path is a directory"""
         url = f"{GitHubAPI.BASE_URL}/repos/{owner}/{repo}/contents/{path}"
         params = {}
 
@@ -803,15 +803,39 @@ class GitHubAPI:
         )
         response = fetch_result.data
 
+        # GitHub returns a list of entries when the path is a directory
+        if isinstance(response, list):
+            return {
+                "type": "dir",
+                "content": "",
+                "sha": "",
+                "size": 0,
+                "name": path.rstrip("/").split("/")[-1],
+                "path": path,
+                "entries": [
+                    {
+                        "name": entry.get("name", ""),
+                        "path": entry.get("path", ""),
+                        "type": entry.get("type", ""),
+                        "sha": entry.get("sha", ""),
+                        "size": entry.get("size", 0),
+                        "download_url": entry.get("download_url") or "",
+                    }
+                    for entry in response
+                ],
+            }
+
         # Decode base64 content
         content = base64.b64decode(response.get("content", "").replace("\n", "")).decode("utf-8")
 
         return {
+            "type": response.get("type", "file"),
             "content": content,
             "sha": response.get("sha", ""),
             "size": response.get("size", 0),
             "name": response.get("name", ""),
             "path": response.get("path", ""),
+            "entries": [],
         }
 
     @staticmethod
@@ -2153,11 +2177,13 @@ class GetFileContent(ActionHandler):
 
         return ActionResult(
             data={
+                "type": file_data["type"],
                 "content": file_data["content"],
                 "sha": file_data["sha"],
                 "size": file_data["size"],
                 "name": file_data["name"],
                 "path": file_data["path"],
+                "entries": file_data["entries"],
             },
             cost_usd=0.0,
         )

--- a/github/tests/test_github_integration.py
+++ b/github/tests/test_github_integration.py
@@ -24,6 +24,12 @@ pytestmark = pytest.mark.integration
 PUBLIC_OWNER = "octocat"
 PUBLIC_REPO = "Hello-World"
 
+# octocat/Hello-World is flat, so directory-listing coverage uses a public repo
+# with a stable tree.
+DIR_OWNER = "github"
+DIR_REPO = "gitignore"
+DIR_PATH = "Global"
+
 
 @pytest.fixture
 def live_context(env_credentials):
@@ -102,3 +108,41 @@ class TestGitHubReadOnlyActions:
         assert result.result.data["status"] == "identical"
         assert result.result.data["ahead_by"] == 0
         assert result.result.data["behind_by"] == 0
+
+    async def test_get_file_content_returns_decoded_file(self, live_context):
+        result = await github.execute_action(
+            "get_file_content",
+            {"owner": PUBLIC_OWNER, "repo": PUBLIC_REPO, "path": "README"},
+            live_context,
+        )
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data["type"] == "file"
+        assert result.result.data["name"] == "README"
+        assert result.result.data["content"]
+        assert result.result.data["sha"]
+        assert result.result.data["entries"] == []
+
+    async def test_get_file_content_lists_directory_entries(self, live_context):
+        result = await github.execute_action(
+            "get_file_content",
+            {"owner": DIR_OWNER, "repo": DIR_REPO, "path": DIR_PATH},
+            live_context,
+        )
+
+        assert result.type == ResultType.ACTION
+        assert result.result.data["type"] == "dir"
+        assert result.result.data["content"] == ""
+        assert result.result.data["name"] == DIR_PATH
+        assert result.result.data["path"] == DIR_PATH
+
+        entries = result.result.data["entries"]
+        assert entries
+        assert {"name", "path", "type", "sha", "size", "download_url"} <= set(entries[0])
+        assert all(entry["type"] in ("file", "dir") for entry in entries)
+
+        by_name = {entry["name"]: entry for entry in entries}
+        assert "macOS.gitignore" in by_name
+        assert by_name["macOS.gitignore"]["type"] == "file"
+        assert by_name["macOS.gitignore"]["path"] == "Global/macOS.gitignore"
+        assert by_name["macOS.gitignore"]["size"] > 0

--- a/github/tests/test_github_misc_unit.py
+++ b/github/tests/test_github_misc_unit.py
@@ -148,6 +148,47 @@ class TestGetFileContent:
         assert "contents/test.txt" in url
 
     @pytest.mark.asyncio
+    async def test_directory_path_returns_entries(self, mock_context):
+        mock_context.fetch.return_value = FetchResponse(
+            status=200,
+            headers={},
+            data=[
+                {
+                    "name": "README.md",
+                    "path": "reference/hnz-contracts/README.md",
+                    "type": "file",
+                    "sha": "a1",
+                    "size": 42,
+                    "download_url": "https://raw.example/README.md",
+                },
+                {
+                    "name": "specs",
+                    "path": "reference/hnz-contracts/specs",
+                    "type": "dir",
+                    "sha": "b2",
+                    "size": 0,
+                    "download_url": None,
+                },
+            ],
+        )
+
+        result = await github.execute_action(
+            "get_file_content",
+            {"owner": "octocat", "repo": "Hello-World", "path": "reference/hnz-contracts"},
+            mock_context,
+        )
+
+        assert result.result.data["type"] == "dir"
+        assert result.result.data["content"] == ""
+        assert result.result.data["name"] == "hnz-contracts"
+        entries = result.result.data["entries"]
+        assert len(entries) == 2
+        assert entries[0]["name"] == "README.md"
+        assert entries[0]["type"] == "file"
+        assert entries[1]["type"] == "dir"
+        assert entries[1]["download_url"] == ""
+
+    @pytest.mark.asyncio
     async def test_exception_returns_action_error(self, mock_context):
         mock_context.fetch.side_effect = Exception("File not found")
 


### PR DESCRIPTION
## Problem

An agent using the GitHub integration had no working way to browse a repository's tree. GitHub's contents endpoint (`GET /repos/{owner}/{repo}/contents/{path}`) returns a single object for a file but an **array of entries** for a directory. `get_file_content` only handled the object shape and called `.get()` on the response unconditionally, so any directory path failed with:

```
'list' object has no attribute 'get'
```

Since `get_file_content` is the only action that touches repository contents, that error left directory listing entirely unavailable — the agent could fetch a file only if it already knew the exact path.

## Fix

`get_file_content` now detects the array response and returns a directory listing instead of crashing. The output shape is stable across both cases, so a workflow can branch on `type` rather than guess:

| Field | File response | Directory response |
|---|---|---|
| `type` | `"file"` | `"dir"` |
| `content` | decoded file content | `""` |
| `sha` | file SHA | `""` |
| `size` | bytes | `0` |
| `name` / `path` | file name and path | directory name and path |
| `entries` | `[]` | one object per child |

Each entry carries `name`, `path`, `type` (`file` or `dir`), `sha`, `size`, and `download_url`, so an agent can walk deeper by feeding a child's `path` back into the same action.

The action description in `config.json` now states that a directory path returns a listing, which is what stops the model from treating a folder request as a broken file fetch.

## Changes

- `github/github.py` — `GitHubAPI.get_file_content` branches on the response type and normalises both shapes; handler passes `type` and `entries` through
- `github/config.json` — output schema gains `type` and `entries` (with a typed item schema); action and `path` descriptions document directory behaviour; version `2.5.0` → `2.6.0`
- `github/tests/test_github_misc_unit.py` — unit test covering the directory response, including `download_url: null` normalising to `""`
- `github/tests/test_github_integration.py` — live tests for both shapes against public repos (`octocat/Hello-World` for a file, `github/gitignore` at `Global` for a directory)
- `github/README.md` — `get_file_content` docs rewritten with the full output contract and a note on walking a tree; usage example lists a directory before fetching a file; version history entry added

No new environment variables. The live tests reuse the existing `GITHUB_ACCESS_TOKEN` from the root `.env.example` and hit public repos only, so no extra repo access is needed.

## Validation

- [x] `pytest github/tests` — 104 passed
- [x] `ruff check github/` — clean
- [x] `ruff format --check github/` — clean
- [x] `config.json` parses; `get_file_content` output schema matches the handler's returned keys
- [ ] Live integration tests — collected (7 tests) but skipped locally, no `GITHUB_ACCESS_TOKEN` set in this environment

## Deploying

The agent runs the deployed bundle, so this needs a repackage and upload as 2.6.0 before the directory listing works in production.