### PR TITLE
ci(github): validate HiveUp pipeline

### DIFF
--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Validate
         id: validate
-        uses: autohive-ai/autohive-integrations-tooling@test/hiveup-integrations-ci
+        uses: autohive-ai/autohive-integrations-tooling@fix/deduplicate-bandit-output
         with:
           base_ref: origin/${{ github.base_ref }}
           # Don't post directly: pull_request workflows triggered from forks

--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Validate
         id: validate
-        uses: autohive-ai/autohive-integrations-tooling@fix/ci-output-and-behavior
+        uses: autohive-ai/autohive-integrations-tooling@v2
         with:
           base_ref: origin/${{ github.base_ref }}
           # Don't post directly: pull_request workflows triggered from forks

--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Validate
         id: validate
-        uses: autohive-ai/autohive-integrations-tooling@v2
+        uses: autohive-ai/autohive-integrations-tooling@test/hiveup-integrations-ci
         with:
           base_ref: origin/${{ github.base_ref }}
           # Don't post directly: pull_request workflows triggered from forks

--- a/.github/workflows/validate-integration.yml
+++ b/.github/workflows/validate-integration.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Validate
         id: validate
-        uses: autohive-ai/autohive-integrations-tooling@fix/deduplicate-bandit-output
+        uses: autohive-ai/autohive-integrations-tooling@fix/ci-output-and-behavior
         with:
           base_ref: origin/${{ github.base_ref }}
           # Don't post directly: pull_request workflows triggered from forks

--- a/github/README.md
+++ b/github/README.md
@@ -1,5 +1,7 @@
 # GitHub Integration for Autohive
 
+<!-- Temporary HiveUp CI validation trigger. -->
+
 A comprehensive GitHub integration for the Autohive platform that enables full repository management, issue tracking, pull request workflows, commit operations, branch management, webhooks, gists, and file operations.
 
 ## Description


### PR DESCRIPTION
## Purpose

Scratch PR for validating the released HiveUp tooling through the real integrations CI pipeline.

## Test configuration

- Integration under test: `github`
- Tooling ref: `autohive-ai/autohive-integrations-tooling@v2`
- Released tooling version: `2.4.1`
- The temporary README comment ensures HiveUp detects an actual GitHub integration change and runs its full validation profile.

This run validates the production `v2` tag after the reviewed tooling changes were merged and released.

> [!WARNING]
> Scratch CI harness only. **Do not merge this PR.**