### PR TITLE
fix(hubspot): return recent ticket owner IDs

### DIFF
--- a/hubspot/README.md
+++ b/hubspot/README.md
@@ -556,7 +556,7 @@ This integration provides comprehensive actions covering complete CRUD operation
   - `status` (optional): Filter by pipeline stage/status (1, 2, 3, 4)
   - `sort_property` (optional): Property to sort by (default: hs_lastmodifieddate)
   - `sort_direction` (optional): Sort direction ASC/DESC (default: DESC)
-- **Outputs:** Array of ticket records with subject, content, priority, and status information
+- **Outputs:** Array of ticket records with subject, content, priority, status, and assigned owner ID information
 
 #### Action: `get_ticket_conversation`
 - **Description:** Retrieve the complete conversation thread associated with a support ticket

--- a/hubspot/config.json
+++ b/hubspot/config.json
@@ -1,7 +1,7 @@
 {
   "name": "HubSpot",
   "display_name": "HubSpot CRM",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "HubSpot CRM integration for managing contacts, companies, deals, and support tickets with advanced pipeline analytics and UTC date handling",
   "entry_point": "hubspot.py",
   "auth": {
@@ -1442,6 +1442,13 @@
                             "null"
                           ],
                           "description": "Ticket priority level"
+                        },
+                        "hubspot_owner_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "HubSpot owner ID assigned to the ticket"
                         },
                         "hs_ticket_category": {
                           "type": [

--- a/hubspot/hubspot.py
+++ b/hubspot/hubspot.py
@@ -1121,6 +1121,7 @@ class GetRecentTicketsActionHandler(ActionHandler):
             "content",
             "hs_pipeline_stage",
             "hs_ticket_priority",
+            "hubspot_owner_id",
             "createdate",
             "hs_lastmodifieddate",
             "hs_ticket_category",

--- a/hubspot/requirements.txt
+++ b/hubspot/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=2.0.0
+autohive-integrations-sdk~=2.0.1

--- a/hubspot/tests/test_hubspot_tickets_unit.py
+++ b/hubspot/tests/test_hubspot_tickets_unit.py
@@ -25,7 +25,14 @@ class TestGetRecentTickets:
         mock_context.fetch.return_value = FetchResponse(
             status=200,
             headers={},
-            data={"results": [{"id": "t-1", "properties": {"subject": "Issue A"}}]},
+            data={
+                "results": [
+                    {
+                        "id": "t-1",
+                        "properties": {"subject": "Issue A", "hubspot_owner_id": "owner-123"},
+                    }
+                ]
+            },
         )
 
         result = await hubspot.execute_action("get_recent_tickets", {}, mock_context)
@@ -33,6 +40,7 @@ class TestGetRecentTickets:
         data = result.result.data
         assert "tickets" in data
         assert data["tickets"]["results"][0]["id"] == "t-1"
+        assert data["tickets"]["results"][0]["properties"]["hubspot_owner_id"] == "owner-123"
 
         call_kwargs = mock_context.fetch.call_args
         assert call_kwargs.args[0] == "https://api.hubapi.com/crm/v3/objects/tickets/search"
@@ -103,6 +111,7 @@ class TestGetRecentTickets:
             "content",
             "hs_pipeline_stage",
             "hs_ticket_priority",
+            "hubspot_owner_id",
             "createdate",
         ]:
             assert expected in props


### PR DESCRIPTION
## Summary
- request `hubspot_owner_id` when retrieving recent HubSpot tickets
- declare the property in the action output schema and document it
- cover the property request and response passthrough with unit tests
- explicitly require Autohive Integrations SDK 2.0.1

Closes #436

## Verification
- `uv run --project ../autohive-integrations-tooling --python 3.14 hiveup validate --base-ref origin/master hubspot`
- `uv run --project ../autohive-integrations-tooling --python 3.14 hiveup package hubspot`

HiveUp passed with existing warnings for potentially unused scopes, historical config-input drift, and the version-bump heuristic.