### PR TITLE
fix(hubspot): allow partial list membership responses

### DIFF
--- a/hubspot/README.md
+++ b/hubspot/README.md
@@ -97,7 +97,7 @@ This integration provides comprehensive actions covering complete CRUD operation
 - **Inputs:**
   - `list_id` (required): HubSpot list ID
   - `contact_id` (required): Contact ID to add to the list
-- **Outputs:** Record IDs added to the list, missing from the account, or removed by the membership update
+- **Outputs:** Record IDs added to the list, missing from the account, or removed by the membership update. HubSpot omits result arrays that have no values.
 - **Required scope:** `crm.lists.write`
 - **Limitation:** Dynamic lists calculate membership from filters and cannot be updated directly
 

--- a/hubspot/config.json
+++ b/hubspot/config.json
@@ -1,7 +1,7 @@
 {
   "name": "HubSpot",
   "display_name": "HubSpot CRM",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "HubSpot CRM integration for managing contacts, companies, deals, and support tickets with advanced pipeline analytics and UTC date handling",
   "entry_point": "hubspot.py",
   "auth": {
@@ -1321,12 +1321,7 @@
                 },
                 "description": "Record IDs removed as part of the membership update"
               }
-            },
-            "required": [
-              "recordsIdsAdded",
-              "recordIdsMissing",
-              "recordIdsRemoved"
-            ]
+            }
           }
         },
         "required": [

--- a/hubspot/tests/test_hubspot_contacts_unit.py
+++ b/hubspot/tests/test_hubspot_contacts_unit.py
@@ -582,13 +582,16 @@ class TestAddContactToList:
 
         assert "crm.lists.write" in config["auth"]["scopes"]
 
+    def test_config_allows_hubspot_to_omit_empty_result_arrays(self):
+        config_path = Path(__file__).parents[1] / "config.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        result_schema = config["actions"]["add_contact_to_list"]["output_schema"]["properties"]["result"]
+
+        assert "required" not in result_schema
+
     @pytest.mark.asyncio
-    async def test_happy_path(self, mock_context):
-        api_result = {
-            "recordsIdsAdded": ["456"],
-            "recordIdsMissing": [],
-            "recordIdsRemoved": [],
-        }
+    async def test_accepts_success_response_with_omitted_empty_arrays(self, mock_context):
+        api_result = {"recordsIdsAdded": ["456"]}
         mock_context.fetch.return_value = FetchResponse(status=200, headers={}, data=api_result)
 
         result = await hubspot.execute_action(


### PR DESCRIPTION
## Summary

- Makes HubSpot list-membership result arrays optional because HubSpot omits arrays with no values.
- Keeps the top-level `result` object required.
- Adds regression coverage for the observed success response containing only `recordsIdsAdded`.
- Documents the conditional response fields and bumps HubSpot from `3.0.0` to `3.0.1`.

Closes #447.

## Why

HubSpot successfully adds a contact to a manual list but may omit `recordIdsMissing` and `recordIdsRemoved` when both arrays would be empty. Requiring all three arrays caused Autohive to raise an output `ValidationError` after the write had already succeeded.

## Flow

```mermaid
flowchart LR
    A["Add contact to manual list"] --> B["HubSpot completes membership write"]
    B --> C["Response includes only populated result arrays"]
    C --> D["Optional array fields pass output validation"]
    D --> E["Automation reports success and continues"]
```

## Verification

- `python -m pytest hubspot -q` — 282 passed.
- HubSpot structure validation passed with only the existing `oauth` and `content` scope heuristic warning.
- Syntax, imports, JSON, lint, formatting, security, dependency audit, config sync, and fetch-pattern checks passed.
- Version and README checks passed.

## Author commitment

- [x] Reproduced the failure from the observed HubSpot response shape.
- [x] Added focused regression coverage.
- [x] Ran the complete HubSpot test and validation suite.
- [x] Updated the integration documentation and version.
