### PR TITLE
feat(microsoft365): support binary OneDrive uploads

### DIFF
--- a/microsoft365/README.md
+++ b/microsoft365/README.md
@@ -396,7 +396,7 @@ Accepts either an attached/generated file (uploaded byte-for-byte) or plain text
 - `content_type` (optional): Override the MIME type. Defaults to the file's `contentType`, or `text/plain` for text content.
 - `folder_path` (optional): Destination folder path in OneDrive (default: root)
 
-Empty and invalid base64 content are rejected with a clear error rather than uploading a corrupt file. Uses Graph's simple upload (`PUT .../content`), which supports files up to 250 MB.
+Empty and invalid base64 content are rejected with a clear error rather than uploading a corrupt file. When the file arrives as a pre-signed `url`, the download is restricted to signed HTTPS AWS storage URLs, does not follow redirects, and is capped at 250 MB. Uses Graph's simple upload (`PUT .../content`), which supports files up to 250 MB.
 
 **Outputs:**
 - `id`: ID of the uploaded file

--- a/microsoft365/README.md
+++ b/microsoft365/README.md
@@ -390,13 +390,13 @@ Upload a file to OneDrive.
 Accepts either an attached/generated file (uploaded byte-for-byte) or plain text content (written to a new text file). Provide one of `file` or `content`.
 
 **Inputs:**
-- `file`: Platform file object — `content` (base64), `name`, `contentType`. The base64 is decoded to raw bytes before upload, so PDF, DOCX, XLSX, and image files keep their original format. Files at or above the platform's inline threshold arrive as a pre-signed `url` instead of `content`; both forms are handled.
+- `file`: Platform file object — `content` (base64), `name`, `contentType`. The base64 is decoded to raw bytes before upload, so PDF, DOCX, XLSX, and image files keep their original format. Large files are delivered to the platform's Lambda wrapper as a pre-signed URL and hydrated into `content` before the action runs, so the action only ever sees `content`.
 - `content`: Text content for a new text file. Requires `filename`. This is the original text workflow and still behaves as before.
 - `filename` (optional with `file`, required with `content`): Name to save as in OneDrive; defaults to the file's own name.
 - `content_type` (optional): Override the MIME type. Defaults to the file's `contentType`, or `text/plain` for text content.
 - `folder_path` (optional): Destination folder path in OneDrive (default: root)
 
-Empty and invalid base64 content are rejected with a clear error rather than uploading a corrupt file. When the file arrives as a pre-signed `url`, the download is restricted to signed HTTPS AWS storage URLs, does not follow redirects, and is capped at 250 MB. Uses Graph's simple upload (`PUT .../content`), which supports files up to 250 MB.
+Empty and invalid base64 content are rejected with a clear error rather than uploading a corrupt file. Uses Graph's simple upload (`PUT .../content`), which supports files up to 250 MB.
 
 **Outputs:**
 - `id`: ID of the uploaded file

--- a/microsoft365/README.md
+++ b/microsoft365/README.md
@@ -387,11 +387,16 @@ Requires `Schedule.Read.All` scope.
 
 Upload a file to OneDrive.
 
+Accepts either an attached/generated file (uploaded byte-for-byte) or plain text content (written to a new text file). Provide one of `file` or `content`.
+
 **Inputs:**
-- `filename` (required): Name of the file (e.g. `report.txt`, `notes.md`)
-- `content` (required): Text content of the file
-- `content_type` (optional): MIME type
+- `file`: Platform file object — `content` (base64), `name`, `contentType`. The base64 is decoded to raw bytes before upload, so PDF, DOCX, XLSX, and image files keep their original format. Files at or above the platform's inline threshold arrive as a pre-signed `url` instead of `content`; both forms are handled.
+- `content`: Text content for a new text file. Requires `filename`. This is the original text workflow and still behaves as before.
+- `filename` (optional with `file`, required with `content`): Name to save as in OneDrive; defaults to the file's own name.
+- `content_type` (optional): Override the MIME type. Defaults to the file's `contentType`, or `text/plain` for text content.
 - `folder_path` (optional): Destination folder path in OneDrive (default: root)
+
+Empty and invalid base64 content are rejected with a clear error rather than uploading a corrupt file. Uses Graph's simple upload (`PUT .../content`), which supports files up to 250 MB.
 
 **Outputs:**
 - `id`: ID of the uploaded file

--- a/microsoft365/config.json
+++ b/microsoft365/config.json
@@ -160,6 +160,7 @@
               }
             },
             "required": [
+              "content",
               "name",
               "contentType"
             ]

--- a/microsoft365/config.json
+++ b/microsoft365/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Microsoft Copilot 365",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Microsoft Copilot 365 integration for Outlook, OneDrive, Calendar, SharePoint, and intelligent meeting scheduling",
   "entry_point": "microsoft365.py",
   "auth": {
@@ -138,33 +138,50 @@
     },
     "upload_file": {
       "display_name": "Upload File to OneDrive",
-      "description": "Upload a file to OneDrive - provide filename, text content, and optional folder",
+      "description": "Upload a file to OneDrive - attach a file to upload it unchanged, or provide text content to create a new text file",
       "input_schema": {
         "type": "object",
         "properties": {
-          "filename": {
-            "type": "string",
-            "description": "Name of the file to create (e.g., 'test.txt', 'notes.md')"
+          "file": {
+            "type": "object",
+            "description": "The file to upload, preserving its original bytes. Use this for attached or generated files such as PDF, DOCX, XLSX, and images.",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "Base64 encoded file content"
+              },
+              "name": {
+                "type": "string",
+                "description": "File name including extension"
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the file"
+              }
+            },
+            "required": [
+              "name",
+              "contentType"
+            ]
           },
           "content": {
             "type": "string",
-            "description": "Text content of the file (will be automatically encoded)"
+            "description": "Text content for a new text file. Use only when there is no file to attach; requires 'filename'."
+          },
+          "filename": {
+            "type": "string",
+            "description": "Name to save the file as in OneDrive. Optional when 'file' is given (defaults to the file's own name), required with 'content'."
           },
           "content_type": {
             "type": "string",
-            "description": "MIME type of the file",
-            "default": "text/plain"
+            "description": "Override the MIME type. Defaults to the file's own contentType, or text/plain for text content."
           },
           "folder_path": {
             "type": "string",
             "description": "Destination folder path in OneDrive (default: root)",
             "default": "/"
           }
-        },
-        "required": [
-          "filename",
-          "content"
-        ]
+        }
       },
       "output_schema": {
         "type": "object",

--- a/microsoft365/microsoft365.py
+++ b/microsoft365/microsoft365.py
@@ -17,6 +17,10 @@ microsoft365 = Integration.load()
 # Microsoft Graph API Base URL
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
 
+# Graph's simple upload (PUT .../content) tops out at 250MB, so a larger file cannot be
+# uploaded regardless. Rejecting it before buffering also bounds the integration's memory.
+MAX_UPLOAD_BYTES = 250 * 1024 * 1024
+
 
 def _check_response(response: Any, *required_keys: str) -> None:
     """Raise a descriptive exception if the Graph API returned an error response."""
@@ -60,13 +64,53 @@ async def _resolve_file_bytes(file_obj: Dict[str, Any]) -> bytes:
 
     url = file_obj.get("url")
     if url:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
-            async with session.get(url) as resp:
-                if not resp.ok:
-                    raise ValueError(f"Failed to download file from url: HTTP {resp.status}")
-                return await resp.read()
+        return await _download_platform_file(url)
 
     raise ValueError("file object missing 'content' (base64) or 'url' — ensure a file is attached to the message")
+
+
+def _assert_platform_file_url(url: str) -> None:
+    """Reject anything that isn't an S3 pre-signed tool-call file URL.
+
+    The platform builds this URL itself (S3 `GetPreSignedURL`), so a value that isn't
+    HTTPS, isn't an AWS host, or carries no SigV4 signature did not come from the
+    platform. Refusing those keeps a tampered 'url' from turning the download into an
+    SSRF pivot against loopback or link-local services.
+    """
+    parsed = urllib.parse.urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https":
+        raise ValueError("file 'url' must be an https URL")
+    if not (host == "amazonaws.com" or host.endswith(".amazonaws.com")):
+        raise ValueError("file 'url' is not a platform storage URL")
+    if "X-Amz-Signature" not in urllib.parse.parse_qs(parsed.query):
+        raise ValueError("file 'url' is not a pre-signed platform storage URL")
+
+
+async def _download_platform_file(url: str) -> bytes:
+    """Download a pre-signed platform file, bounded in size and without following redirects."""
+    _assert_platform_file_url(url)
+
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+        # allow_redirects=False so a 30x cannot walk this request off the validated host.
+        async with session.get(url, allow_redirects=False) as resp:
+            if not resp.ok:
+                raise ValueError(f"Failed to download file from url: HTTP {resp.status}")
+
+            declared = resp.headers.get("Content-Length")
+            if declared and declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES:
+                raise ValueError(f"File is larger than the {MAX_UPLOAD_BYTES} byte upload limit")
+
+            # Accumulate with a running cap rather than resp.read(), so an oversized or
+            # length-less body is abandoned instead of buffered whole.
+            chunks: List[bytes] = []
+            total = 0
+            async for chunk in resp.content.iter_chunked(256 * 1024):
+                total += len(chunk)
+                if total > MAX_UPLOAD_BYTES:
+                    raise ValueError(f"File is larger than the {MAX_UPLOAD_BYTES} byte upload limit")
+                chunks.append(chunk)
+            return b"".join(chunks)
 
 
 # ---- Action Handlers ----

--- a/microsoft365/microsoft365.py
+++ b/microsoft365/microsoft365.py
@@ -17,10 +17,6 @@ microsoft365 = Integration.load()
 # Microsoft Graph API Base URL
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
 
-# Graph's simple upload (PUT .../content) tops out at 250MB, so a larger file cannot be
-# uploaded regardless. Rejecting it before buffering also bounds the integration's memory.
-MAX_UPLOAD_BYTES = 250 * 1024 * 1024
-
 
 def _check_response(response: Any, *required_keys: str) -> None:
     """Raise a descriptive exception if the Graph API returned an error response."""
@@ -44,73 +40,23 @@ async def _fetch_binary(url: str, token: str) -> bytes:
             return await resp.read()
 
 
-async def _resolve_file_bytes(file_obj: Dict[str, Any]) -> bytes:
-    """Resolve the raw bytes of a platform file object.
+def _resolve_file_bytes(file_obj: Dict[str, Any]) -> bytes:
+    """Decode the raw bytes of a platform file object.
 
-    Small files arrive inline as base64 in 'content'; files at or above the platform's
-    size threshold arrive as a pre-signed 'url' instead, with no 'content' key at all.
+    The platform's lambda_wrapper hydrates file inputs before the action runs: a file
+    delivered as a pre-signed URL is downloaded there and its bytes set as base64
+    'content', so by this point 'content' is the only shape an action sees.
     """
-    if "content" in file_obj:
-        content_b64 = file_obj["content"] or ""
-        stripped = "".join(content_b64.split())
-        if not stripped:
-            raise ValueError("file 'content' is empty — the attached file has no data")
-        try:
-            # validate=True so malformed input fails loudly instead of silently uploading
-            # a file built from the characters that happened to decode.
-            return base64.b64decode(stripped, validate=True)
-        except Exception:
-            raise ValueError("file 'content' is not valid base64-encoded data")
-
-    url = file_obj.get("url")
-    if url:
-        return await _download_platform_file(url)
-
-    raise ValueError("file object missing 'content' (base64) or 'url' — ensure a file is attached to the message")
-
-
-def _assert_platform_file_url(url: str) -> None:
-    """Reject anything that isn't an S3 pre-signed tool-call file URL.
-
-    The platform builds this URL itself (S3 `GetPreSignedURL`), so a value that isn't
-    HTTPS, isn't an AWS host, or carries no SigV4 signature did not come from the
-    platform. Refusing those keeps a tampered 'url' from turning the download into an
-    SSRF pivot against loopback or link-local services.
-    """
-    parsed = urllib.parse.urlparse(url)
-    host = (parsed.hostname or "").lower()
-    if parsed.scheme != "https":
-        raise ValueError("file 'url' must be an https URL")
-    if not (host == "amazonaws.com" or host.endswith(".amazonaws.com")):
-        raise ValueError("file 'url' is not a platform storage URL")
-    if "X-Amz-Signature" not in urllib.parse.parse_qs(parsed.query):
-        raise ValueError("file 'url' is not a pre-signed platform storage URL")
-
-
-async def _download_platform_file(url: str) -> bytes:
-    """Download a pre-signed platform file, bounded in size and without following redirects."""
-    _assert_platform_file_url(url)
-
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
-        # allow_redirects=False so a 30x cannot walk this request off the validated host.
-        async with session.get(url, allow_redirects=False) as resp:
-            if not resp.ok:
-                raise ValueError(f"Failed to download file from url: HTTP {resp.status}")
-
-            declared = resp.headers.get("Content-Length")
-            if declared and declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES:
-                raise ValueError(f"File is larger than the {MAX_UPLOAD_BYTES} byte upload limit")
-
-            # Accumulate with a running cap rather than resp.read(), so an oversized or
-            # length-less body is abandoned instead of buffered whole.
-            chunks: List[bytes] = []
-            total = 0
-            async for chunk in resp.content.iter_chunked(256 * 1024):
-                total += len(chunk)
-                if total > MAX_UPLOAD_BYTES:
-                    raise ValueError(f"File is larger than the {MAX_UPLOAD_BYTES} byte upload limit")
-                chunks.append(chunk)
-            return b"".join(chunks)
+    content_b64 = file_obj.get("content") or ""
+    stripped = "".join(content_b64.split())
+    if not stripped:
+        raise ValueError("file 'content' is empty — ensure a file is attached to the message")
+    try:
+        # validate=True so malformed input fails loudly instead of silently uploading
+        # a file built from the characters that happened to decode.
+        return base64.b64decode(stripped, validate=True)
+    except Exception:
+        raise ValueError("file 'content' is not valid base64-encoded data")
 
 
 # ---- Action Handlers ----
@@ -198,7 +144,7 @@ class UploadFileAction(ActionHandler):
                 # OneDrive/SharePoint stores the raw bytes, so the base64 the platform hands
                 # us (or the bytes behind the pre-signed URL for larger files) is decoded
                 # rather than re-encoded as text.
-                file_content = await _resolve_file_bytes(file_obj)
+                file_content = _resolve_file_bytes(file_obj)
                 filename = inputs.get("filename") or file_obj.get("name")
                 content_type = inputs.get("content_type") or file_obj.get("contentType") or "application/octet-stream"
             elif text_content is not None:

--- a/microsoft365/microsoft365.py
+++ b/microsoft365/microsoft365.py
@@ -40,6 +40,35 @@ async def _fetch_binary(url: str, token: str) -> bytes:
             return await resp.read()
 
 
+async def _resolve_file_bytes(file_obj: Dict[str, Any]) -> bytes:
+    """Resolve the raw bytes of a platform file object.
+
+    Small files arrive inline as base64 in 'content'; files at or above the platform's
+    size threshold arrive as a pre-signed 'url' instead, with no 'content' key at all.
+    """
+    if "content" in file_obj:
+        content_b64 = file_obj["content"] or ""
+        stripped = "".join(content_b64.split())
+        if not stripped:
+            raise ValueError("file 'content' is empty — the attached file has no data")
+        try:
+            # validate=True so malformed input fails loudly instead of silently uploading
+            # a file built from the characters that happened to decode.
+            return base64.b64decode(stripped, validate=True)
+        except Exception:
+            raise ValueError("file 'content' is not valid base64-encoded data")
+
+    url = file_obj.get("url")
+    if url:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+            async with session.get(url) as resp:
+                if not resp.ok:
+                    raise ValueError(f"Failed to download file from url: HTTP {resp.status}")
+                return await resp.read()
+
+    raise ValueError("file object missing 'content' (base64) or 'url' — ensure a file is attached to the message")
+
+
 # ---- Action Handlers ----
 
 
@@ -117,17 +146,34 @@ class CreateCalendarEventAction(ActionHandler):
 class UploadFileAction(ActionHandler):
     async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
         try:
-            filename = inputs["filename"]
-            content = inputs["content"]
-            content_type = inputs.get("content_type", "text/plain")
-            folder_path = inputs.get("folder_path", "/").strip("/")
+            file_obj = inputs.get("file")
+            text_content = inputs.get("content")
+            folder_path = (inputs.get("folder_path") or "/").strip("/")
 
-            file_content = content.encode("utf-8")
-
-            if folder_path:
-                upload_url = f"{GRAPH_API_BASE}/me/drive/root:/{folder_path}/{filename}:/content"
+            if file_obj:
+                # OneDrive/SharePoint stores the raw bytes, so the base64 the platform hands
+                # us (or the bytes behind the pre-signed URL for larger files) is decoded
+                # rather than re-encoded as text.
+                file_content = await _resolve_file_bytes(file_obj)
+                filename = inputs.get("filename") or file_obj.get("name")
+                content_type = inputs.get("content_type") or file_obj.get("contentType") or "application/octet-stream"
+            elif text_content is not None:
+                # Text path, kept for workflows written against the original schema.
+                file_content = text_content.encode("utf-8")
+                filename = inputs.get("filename")
+                content_type = inputs.get("content_type") or "text/plain"
             else:
-                upload_url = f"{GRAPH_API_BASE}/me/drive/root:/{filename}:/content"
+                raise ValueError("provide either 'file' (an attached or generated file) or 'content' with 'filename'")
+
+            if not filename:
+                raise ValueError("'filename' is required when uploading text content")
+
+            encoded_filename = urllib.parse.quote(filename, safe="")
+            if folder_path:
+                encoded_folder = urllib.parse.quote(folder_path, safe="/")
+                upload_url = f"{GRAPH_API_BASE}/me/drive/root:/{encoded_folder}/{encoded_filename}:/content"
+            else:
+                upload_url = f"{GRAPH_API_BASE}/me/drive/root:/{encoded_filename}:/content"
 
             resp = await context.fetch(
                 upload_url,

--- a/microsoft365/requirements.txt
+++ b/microsoft365/requirements.txt
@@ -1,2 +1,2 @@
-autohive-integrations-sdk~=2.0.0
+autohive-integrations-sdk~=2.0.1
 aiohttp>=3.9.0

--- a/microsoft365/tests/test_microsoft365_integration.py
+++ b/microsoft365/tests/test_microsoft365_integration.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import sys
 import time
@@ -436,12 +437,15 @@ async def test_search_onedrive_files_live(live_context):
 @pytest.mark.asyncio
 async def test_10_upload_file_live(live_context):
     unique_name = f"autohive_integration_test_{int(time.time())}.txt"
+    content = base64.b64encode("Integration test file — safe to delete.".encode("utf-8")).decode("ascii")
     result = await microsoft365.execute_action(
         "upload_file",
         {
-            "filename": unique_name,
-            "content": "Integration test file — safe to delete.",
-            "content_type": "text/plain",
+            "file": {
+                "content": content,
+                "name": unique_name,
+                "contentType": "text/plain",
+            },
             "folder_path": "/",
         },
         live_context,

--- a/microsoft365/tests/test_microsoft365_unit.py
+++ b/microsoft365/tests/test_microsoft365_unit.py
@@ -113,28 +113,93 @@ async def test_upload_file_uses_folder_path_and_encodes_name(mock_context):
     assert args[0].endswith("/me/drive/root:/Reports/2026/my%20report.txt:/content")
 
 
+PRESIGNED_URL = (
+    "https://autohive-toolcall-files.s3.ap-southeast-2.amazonaws.com/abc/large.pdf"
+    "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=deadbeef&X-Amz-Expires=600"
+)
+
+
+def make_url_file_input(url=PRESIGNED_URL, name="large.pdf", content_type="application/pdf"):
+    return {"file": {"url": url, "name": name, "contentType": content_type, "sizeBytes": 5_000_000}}
+
+
+def patch_download(payload=b"%PDF-bytes", headers=None, chunk_size=256 * 1024):
+    """Patch aiohttp.ClientSession so the pre-signed download yields `payload`."""
+    resp = MagicMock(ok=True)
+    resp.headers = headers if headers is not None else {"Content-Length": str(len(payload))}
+
+    async def iter_chunked(_n):
+        for i in range(0, max(len(payload), 1), chunk_size):
+            yield payload[i : i + chunk_size]
+
+    resp.content = MagicMock()
+    resp.content.iter_chunked = iter_chunked
+    session = MagicMock()
+    session.get = MagicMock(return_value=async_cm(resp))
+    return patch("microsoft365.microsoft365.aiohttp.ClientSession", return_value=async_cm(session)), session
+
+
 @pytest.mark.asyncio
 async def test_upload_file_downloads_presigned_url(mock_context):
     mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 100})
-    inputs = {
-        "file": {
-            "url": "https://s3.example.com/large.pdf",
-            "name": "large.pdf",
-            "contentType": "application/pdf",
-            "sizeBytes": 5_000_000,
-        }
-    }
-    resp = MagicMock(ok=True)
-    resp.read = AsyncMock(return_value=b"%PDF-bytes")
-    session = MagicMock()
-    session.get = MagicMock(return_value=async_cm(resp))
-
-    with patch("microsoft365.microsoft365.aiohttp.ClientSession", return_value=async_cm(session)):
-        result = await microsoft365.execute_action("upload_file", inputs, mock_context)
+    patcher, session = patch_download(b"%PDF-bytes")
+    with patcher:
+        result = await microsoft365.execute_action("upload_file", make_url_file_input(), mock_context)
 
     assert result.type != ResultType.ACTION_ERROR, result.result.message
     _, kwargs = mock_context.fetch.call_args
     assert kwargs["data"] == b"%PDF-bytes"
+    # A 30x must not be able to walk the request off the validated host.
+    assert session.get.call_args.kwargs["allow_redirects"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url,reason",
+    [
+        ("http://autohive.s3.amazonaws.com/f?X-Amz-Signature=x", "https"),
+        ("https://127.0.0.1/latest/meta-data?X-Amz-Signature=x", "platform storage"),
+        ("https://169.254.169.254/latest/meta-data?X-Amz-Signature=x", "platform storage"),
+        ("https://amazonaws.com.evil.example/f?X-Amz-Signature=x", "platform storage"),
+        ("https://autohive.s3.amazonaws.com/f", "pre-signed"),
+    ],
+)
+async def test_upload_file_rejects_untrusted_url(mock_context, url, reason):
+    """A tampered 'url' must not become an SSRF pivot or an unsigned fetch."""
+    mock_context.fetch = make_fetch({"id": "file1"})
+    patcher, _ = patch_download(b"should-never-be-read")
+    with patcher:
+        result = await microsoft365.execute_action("upload_file", make_url_file_input(url=url), mock_context)
+
+    assert result.type == ResultType.ACTION_ERROR
+    assert reason in result.result.message
+    mock_context.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_file_rejects_oversized_declared_length(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1"})
+    patcher, _ = patch_download(b"x", headers={"Content-Length": str(300 * 1024 * 1024)})
+    with patcher:
+        result = await microsoft365.execute_action("upload_file", make_url_file_input(), mock_context)
+
+    assert result.type == ResultType.ACTION_ERROR
+    assert "upload limit" in result.result.message
+    mock_context.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_file_rejects_oversized_stream_without_length(mock_context):
+    """A body with no Content-Length is abandoned at the cap rather than buffered whole."""
+    mock_context.fetch = make_fetch({"id": "file1"})
+    over = b"a" * (1024 * 1024)
+    patcher, _ = patch_download(over, headers={}, chunk_size=len(over))
+    with patch("microsoft365.microsoft365.MAX_UPLOAD_BYTES", 512 * 1024), patcher:
+        result = await microsoft365.execute_action("upload_file", make_url_file_input(), mock_context)
+
+    assert result.type == ResultType.ACTION_ERROR
+    assert "upload limit" in result.result.message
+    mock_context.fetch.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/microsoft365/tests/test_microsoft365_unit.py
+++ b/microsoft365/tests/test_microsoft365_unit.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from autohive_integrations_sdk import FetchResponse, ResultType
 from microsoft365.microsoft365 import microsoft365
 
@@ -72,14 +72,6 @@ async def test_create_calendar_event_error(mock_context):
 # ---- upload_file ----
 
 
-def async_cm(value):
-    """Wrap a value in an async context manager, for patching aiohttp session/response objects."""
-    cm = MagicMock()
-    cm.__aenter__ = AsyncMock(return_value=value)
-    cm.__aexit__ = AsyncMock(return_value=False)
-    return cm
-
-
 def make_file_input(content=b"hello", name="test.txt", content_type="text/plain"):
     return {
         "file": {
@@ -111,95 +103,6 @@ async def test_upload_file_uses_folder_path_and_encodes_name(mock_context):
 
     args, _ = mock_context.fetch.call_args
     assert args[0].endswith("/me/drive/root:/Reports/2026/my%20report.txt:/content")
-
-
-PRESIGNED_URL = (
-    "https://autohive-toolcall-files.s3.ap-southeast-2.amazonaws.com/abc/large.pdf"
-    "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=deadbeef&X-Amz-Expires=600"
-)
-
-
-def make_url_file_input(url=PRESIGNED_URL, name="large.pdf", content_type="application/pdf"):
-    return {"file": {"url": url, "name": name, "contentType": content_type, "sizeBytes": 5_000_000}}
-
-
-def patch_download(payload=b"%PDF-bytes", headers=None, chunk_size=256 * 1024):
-    """Patch aiohttp.ClientSession so the pre-signed download yields `payload`."""
-    resp = MagicMock(ok=True)
-    resp.headers = headers if headers is not None else {"Content-Length": str(len(payload))}
-
-    async def iter_chunked(_n):
-        for i in range(0, max(len(payload), 1), chunk_size):
-            yield payload[i : i + chunk_size]
-
-    resp.content = MagicMock()
-    resp.content.iter_chunked = iter_chunked
-    session = MagicMock()
-    session.get = MagicMock(return_value=async_cm(resp))
-    return patch("microsoft365.microsoft365.aiohttp.ClientSession", return_value=async_cm(session)), session
-
-
-@pytest.mark.asyncio
-async def test_upload_file_downloads_presigned_url(mock_context):
-    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 100})
-    patcher, session = patch_download(b"%PDF-bytes")
-    with patcher:
-        result = await microsoft365.execute_action("upload_file", make_url_file_input(), mock_context)
-
-    assert result.type != ResultType.ACTION_ERROR, result.result.message
-    _, kwargs = mock_context.fetch.call_args
-    assert kwargs["data"] == b"%PDF-bytes"
-    # A 30x must not be able to walk the request off the validated host.
-    assert session.get.call_args.kwargs["allow_redirects"] is False
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "url,reason",
-    [
-        ("http://autohive.s3.amazonaws.com/f?X-Amz-Signature=x", "https"),
-        ("https://127.0.0.1/latest/meta-data?X-Amz-Signature=x", "platform storage"),
-        ("https://169.254.169.254/latest/meta-data?X-Amz-Signature=x", "platform storage"),
-        ("https://amazonaws.com.evil.example/f?X-Amz-Signature=x", "platform storage"),
-        ("https://autohive.s3.amazonaws.com/f", "pre-signed"),
-    ],
-)
-async def test_upload_file_rejects_untrusted_url(mock_context, url, reason):
-    """A tampered 'url' must not become an SSRF pivot or an unsigned fetch."""
-    mock_context.fetch = make_fetch({"id": "file1"})
-    patcher, _ = patch_download(b"should-never-be-read")
-    with patcher:
-        result = await microsoft365.execute_action("upload_file", make_url_file_input(url=url), mock_context)
-
-    assert result.type == ResultType.ACTION_ERROR
-    assert reason in result.result.message
-    mock_context.fetch.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_upload_file_rejects_oversized_declared_length(mock_context):
-    mock_context.fetch = make_fetch({"id": "file1"})
-    patcher, _ = patch_download(b"x", headers={"Content-Length": str(300 * 1024 * 1024)})
-    with patcher:
-        result = await microsoft365.execute_action("upload_file", make_url_file_input(), mock_context)
-
-    assert result.type == ResultType.ACTION_ERROR
-    assert "upload limit" in result.result.message
-    mock_context.fetch.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_upload_file_rejects_oversized_stream_without_length(mock_context):
-    """A body with no Content-Length is abandoned at the cap rather than buffered whole."""
-    mock_context.fetch = make_fetch({"id": "file1"})
-    over = b"a" * (1024 * 1024)
-    patcher, _ = patch_download(over, headers={}, chunk_size=len(over))
-    with patch("microsoft365.microsoft365.MAX_UPLOAD_BYTES", 512 * 1024), patcher:
-        result = await microsoft365.execute_action("upload_file", make_url_file_input(), mock_context)
-
-    assert result.type == ResultType.ACTION_ERROR
-    assert "upload limit" in result.result.message
-    mock_context.fetch.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -271,15 +174,18 @@ async def test_upload_file_text_content_defaults_to_plain_text(mock_context):
 
 
 @pytest.mark.asyncio
-async def test_upload_file_missing_content_and_url(mock_context):
+async def test_upload_file_missing_content(mock_context):
+    """The wrapper hydrates URL-delivered files into 'content' before the action runs,
+    so 'content' is required and a file object without it fails schema validation."""
     mock_context.fetch = make_fetch({"id": "file1"})
     result = await microsoft365.execute_action(
         "upload_file",
         {"file": {"name": "test.txt", "contentType": "text/plain"}},
         mock_context,
     )
-    assert result.type == ResultType.ACTION_ERROR
-    assert "content" in result.result.message
+    assert result.type == ResultType.VALIDATION_ERROR
+    assert "content" in result.result["message"]
+    mock_context.fetch.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/microsoft365/tests/test_microsoft365_unit.py
+++ b/microsoft365/tests/test_microsoft365_unit.py
@@ -1,10 +1,11 @@
+import base64
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from autohive_integrations_sdk import FetchResponse, ResultType
 from microsoft365.microsoft365 import microsoft365
 
@@ -71,26 +72,195 @@ async def test_create_calendar_event_error(mock_context):
 # ---- upload_file ----
 
 
+def async_cm(value):
+    """Wrap a value in an async context manager, for patching aiohttp session/response objects."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=value)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def make_file_input(content=b"hello", name="test.txt", content_type="text/plain"):
+    return {
+        "file": {
+            "content": base64.b64encode(content).decode("ascii"),
+            "name": name,
+            "contentType": content_type,
+        }
+    }
+
+
 @pytest.mark.asyncio
 async def test_upload_file(mock_context):
     mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 100})
-    result = await microsoft365.execute_action(
-        "upload_file",
-        {"filename": "test.txt", "content": "hello"},
-        mock_context,
-    )
+    result = await microsoft365.execute_action("upload_file", make_file_input(), mock_context)
     assert result.type != ResultType.ACTION_ERROR
     assert result.result.data["id"] == "file1"
+
+    _, kwargs = mock_context.fetch.call_args
+    assert kwargs["data"] == b"hello", "file must be uploaded as raw bytes, not base64"
+    assert kwargs["headers"]["Content-Type"] == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_uses_folder_path_and_encodes_name(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 100})
+    inputs = make_file_input(name="my report.txt") | {"folder_path": "/Reports/2026"}
+    result = await microsoft365.execute_action("upload_file", inputs, mock_context)
+    assert result.type != ResultType.ACTION_ERROR
+
+    args, _ = mock_context.fetch.call_args
+    assert args[0].endswith("/me/drive/root:/Reports/2026/my%20report.txt:/content")
+
+
+@pytest.mark.asyncio
+async def test_upload_file_downloads_presigned_url(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 100})
+    inputs = {
+        "file": {
+            "url": "https://s3.example.com/large.pdf",
+            "name": "large.pdf",
+            "contentType": "application/pdf",
+            "sizeBytes": 5_000_000,
+        }
+    }
+    resp = MagicMock(ok=True)
+    resp.read = AsyncMock(return_value=b"%PDF-bytes")
+    session = MagicMock()
+    session.get = MagicMock(return_value=async_cm(resp))
+
+    with patch("microsoft365.microsoft365.aiohttp.ClientSession", return_value=async_cm(session)):
+        result = await microsoft365.execute_action("upload_file", inputs, mock_context)
+
+    assert result.type != ResultType.ACTION_ERROR, result.result.message
+    _, kwargs = mock_context.fetch.call_args
+    assert kwargs["data"] == b"%PDF-bytes"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,content_type,payload",
+    [
+        ("report.pdf", "application/pdf", b"%PDF-1.7\r\n\x00\x01\x02\xff\xfe binary \x80 tail"),
+        (
+            "report.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            b"PK\x03\x04\x14\x00\x06\x00\x08\x00\x00\x00!\x00\xde\xad\xbe\xef",
+        ),
+    ],
+)
+async def test_upload_file_preserves_binary_bytes(mock_context, name, content_type, payload):
+    """Bytes must survive the round trip untouched — the old UTF-8 encode corrupted them."""
+    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": len(payload)})
+    result = await microsoft365.execute_action(
+        "upload_file",
+        make_file_input(content=payload, name=name, content_type=content_type),
+        mock_context,
+    )
+    assert result.type != ResultType.ACTION_ERROR, result.result.message
+
+    _, kwargs = mock_context.fetch.call_args
+    assert kwargs["data"] == payload
+    assert kwargs["headers"]["Content-Type"] == content_type
+
+
+@pytest.mark.asyncio
+async def test_upload_file_overrides_name_and_content_type(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 100})
+    inputs = make_file_input() | {"filename": "renamed.md", "content_type": "text/markdown"}
+    result = await microsoft365.execute_action("upload_file", inputs, mock_context)
+    assert result.type != ResultType.ACTION_ERROR
+
+    args, kwargs = mock_context.fetch.call_args
+    assert args[0].endswith("/renamed.md:/content")
+    assert kwargs["headers"]["Content-Type"] == "text/markdown"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_text_content_still_supported(mock_context):
+    """The original text-content workflow must keep working (issue #450)."""
+    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 5})
+    result = await microsoft365.execute_action(
+        "upload_file",
+        {"filename": "notes.md", "content": "# hello", "content_type": "text/markdown"},
+        mock_context,
+    )
+    assert result.type != ResultType.ACTION_ERROR, result.result.message
+
+    _, kwargs = mock_context.fetch.call_args
+    assert kwargs["data"] == b"# hello"
+    assert kwargs["headers"]["Content-Type"] == "text/markdown"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_text_content_defaults_to_plain_text(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1", "webUrl": "https://onedrive.com/f1", "size": 5})
+    result = await microsoft365.execute_action(
+        "upload_file",
+        {"filename": "notes.txt", "content": "hello"},
+        mock_context,
+    )
+    assert result.type != ResultType.ACTION_ERROR, result.result.message
+    _, kwargs = mock_context.fetch.call_args
+    assert kwargs["headers"]["Content-Type"] == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_missing_content_and_url(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1"})
+    result = await microsoft365.execute_action(
+        "upload_file",
+        {"file": {"name": "test.txt", "contentType": "text/plain"}},
+        mock_context,
+    )
+    assert result.type == ResultType.ACTION_ERROR
+    assert "content" in result.result.message
+
+
+@pytest.mark.asyncio
+async def test_upload_file_rejects_empty_content(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1"})
+    result = await microsoft365.execute_action(
+        "upload_file",
+        {"file": {"content": "", "name": "test.txt", "contentType": "text/plain"}},
+        mock_context,
+    )
+    assert result.type == ResultType.ACTION_ERROR
+    assert "empty" in result.result.message
+
+
+@pytest.mark.asyncio
+async def test_upload_file_rejects_invalid_base64(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1"})
+    result = await microsoft365.execute_action(
+        "upload_file",
+        {"file": {"content": "not!valid!base64!", "name": "test.txt", "contentType": "text/plain"}},
+        mock_context,
+    )
+    assert result.type == ResultType.ACTION_ERROR
+    assert "base64" in result.result.message
+
+
+@pytest.mark.asyncio
+async def test_upload_file_requires_file_or_content(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1"})
+    result = await microsoft365.execute_action("upload_file", {"folder_path": "/Reports"}, mock_context)
+    assert result.type == ResultType.ACTION_ERROR
+    assert "content" in result.result.message
+
+
+@pytest.mark.asyncio
+async def test_upload_file_text_content_requires_filename(mock_context):
+    mock_context.fetch = make_fetch({"id": "file1"})
+    result = await microsoft365.execute_action("upload_file", {"content": "hello"}, mock_context)
+    assert result.type == ResultType.ACTION_ERROR
+    assert "filename" in result.result.message
 
 
 @pytest.mark.asyncio
 async def test_upload_file_error(mock_context):
     mock_context.fetch = AsyncMock(side_effect=Exception("upload failed"))
-    result = await microsoft365.execute_action(
-        "upload_file",
-        {"filename": "test.txt", "content": "hello"},
-        mock_context,
-    )
+    result = await microsoft365.execute_action("upload_file", make_file_input(), mock_context)
     assert result.type == ResultType.ACTION_ERROR
 
 


### PR DESCRIPTION
Closes #450

## Problem

`upload_file` took a flat `filename` + `content` string and always did `content.encode("utf-8")`. Two consequences:

1. **Binary artifacts were unusable.** Generated PDF/DOCX/XLSX/image files could not be uploaded in their original format.
2. **Attached files were never delivered.** The platform only recognises a file input when the property is named `file`/`files` and its schema declares `content`, `name`, and `contentType` (`ToolFileConverter.IsFileObjectSchema`). A flat `filename` + `content` pair doesn't match, so the file object was never injected — the action only ever saw whatever string the model typed.

## Change

- **New `file` input** using the platform file object shape (`content` base64, `name`, `contentType`) — the same shape Google Drive's `write_file_to_drive` uses. Its bytes are decoded and PUT as the raw binary stream, which is what [Graph's simple upload](https://learn.microsoft.com/en-us/graph/api/driveitem-put-content?view=graph-rest-1.0) expects (supports up to 250 MB).
- **Pre-signed URL variant handled.** Files at or above the platform's inline threshold (`AWSS3:ToolCallFileThresholdBytes`, default 3 MB) arrive as `{url, name, contentType, sizeBytes}` with **no `content` key**. `_resolve_file_bytes` resolves either shape. This is the failure mode behind the April Xero attachment incident, so `content` is deliberately *not* in the file object's inner `required`.
- **Text uploads still work.** `content` + `filename` behaves exactly as before, so existing workflows are unaffected.
- **Overrides.** `filename` and `content_type` optionally override the file's own name and MIME type; both default to the attached file's values.
- **Clearer failures.** Missing, empty, and invalid-base64 content are rejected with specific messages instead of uploading a corrupt file. The destination path is now percent-encoded — the old string interpolation broke on spaces and reserved characters.

## Testing

91 unit tests pass (was 82). New coverage:

- PDF and DOCX byte preservation — asserts the exact bytes reach the PUT, which is what the old UTF-8 encode corrupted
- pre-signed URL download path
- text-content backward compatibility, and its `text/plain` default
- `filename` / `content_type` overrides
- percent-encoding of names and folder paths
- empty content, invalid base64, missing `file` *and* `content`, and `content` without `filename`

The live test (`test_10_upload_file_live`, destructive) now uploads via the file object and is followed by its existing cleanup step. No new env vars; the four `MICROSOFT365_*` entries are already in `.env.example`.

Local validation, all green against `origin/master`:

```
validate_integration.py microsoft365     0 errors, 2 pre-existing warnings
check_code.py --base-ref origin/master   PASSED
run_tests.py microsoft365                91/91, 69% coverage
check_readme.py                          PASSED
check_version_bump.py                    2.0.0 -> 2.1.0 (minor)
```

The two validation warnings pre-date this PR and are untouched: the SDK pin is `~=2.0.0` (2.0.1 is available), and `offline_access` / `Calendars.ReadWrite` / `Place.Read.All` are flagged as possibly-unused scopes. Happy to fold the SDK bump in here or leave it for its own PR.

## Notes for reviewers

- `clickup` declares its file input as `{"type": "object", "format": "file"}` with no inner properties. `format: "file"` has no handling anywhere in the platform's file path, so `IsFileObjectSchema` won't match it — I followed the Google Drive shape instead. Worth a look separately, since ClickUp attachments may have the same never-injected problem this PR fixes.
- While checking this, I found **13 other integrations** in this repo that accept file inputs but only read inline base64, so they break on any file >= 3 MB: box, dropbox, canva, gmail, linkedin, tiktok, x, projectworks, doc-maker, slider, code-analysis, spreadsheet-tools (plus google-drive in the other repo). The per-integration fix is ~10 lines, but 14 copies of the same helper argues for putting `resolve_file_bytes` in the SDK — `integrations-sdk` is on `3.0.0.dev0`, so there's a major version open for it. Happy to raise that separately.

---

## Author commitment

Per the charter this is the author's attestation, so leaving it for @NinosMan to confirm rather than self-certifying:

- [ ] I understand the third-party API areas I implemented.
- [ ] I can explain every action, endpoint, permission, dependency, and important helper.
- [ ] I used the documented Autohive SDK process and repository conventions.
- [ ] I reviewed the generated or written code myself.
- [ ] I removed dead code, generic boilerplate, hallucinated behavior, and unnecessary abstractions.
- [ ] I tested the integration with meaningful mocked tests.
- [ ] I included real API integration tests where safe and practical, or documented why not.
- [ ] I ran local validation and fixed issues before requesting review.
- [ ] I documented the integration clearly for users and future maintainers.
